### PR TITLE
Add CI docs-site build and publish to stochadex.github.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,52 @@ jobs:
       # -race keeps the goroutine-per-partition concurrency invariants honest;
       # -count=1 disables test caching so CI always re-runs the full suite.
       - run: go test ./... -race -count=1
+
+  # Rebuild the docs site and publish it to the stochadex.github.io repo. Runs ONLY
+  # on merge to main and ONLY after the test job passes (needs: [test]) — the site is
+  # never republished from a commit whose tests failed. The test job also guards that
+  # every model card's wiring diagram matches its BuildStub (the cmd/model-graphs CI
+  # guard), so build.sh can trust the committed cards are current.
+  deploy-site:
+    needs: [test]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Install pandoc
+        run: sudo apt-get update && sudo apt-get install -y pandoc
+      - name: Install gomarkdoc
+        run: |
+          go install github.com/princjef/gomarkdoc/cmd/gomarkdoc@latest
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+      - name: Build site
+        run: bash build.sh
+        working-directory: docs
+      - name: Publish to stochadex.github.io
+        env:
+          # Fine-grained PAT (or deploy key) with Contents:write on
+          # stochadex/stochadex.github.io. Stored as a repo secret in
+          # umbralcalc/stochadex — the built-in GITHUB_TOKEN cannot push cross-repo.
+          DEPLOY_TOKEN: ${{ secrets.SITE_DEPLOY_TOKEN }}
+        run: |
+          set -euo pipefail
+          git clone --depth 1 \
+            "https://x-access-token:${DEPLOY_TOKEN}@github.com/stochadex/stochadex.github.io.git" \
+            site-pub
+          # Pages serves main:/docs, so only the docs/ tree needs updating.
+          rm -rf site-pub/docs
+          cp -R docs site-pub/docs
+          cd site-pub
+          git config user.name "stochadex-ci"
+          git config user.email "ci@users.noreply.github.com"
+          git add -A docs
+          if git diff --cached --quiet; then
+            echo "No docs changes to publish."
+          else
+            git commit -m "Rebuild docs site from umbralcalc/stochadex@${GITHUB_SHA}"
+            git push origin main
+          fi

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -239,9 +239,9 @@ generate_package_docs() {
         # Generate markdown with better formatting
         gomarkdoc "$pkg" --output "$TEMP_DIR/${pkg_name}.md" --format github --verbose
         
-        # Fix headings and add metadata
-        sed -i '' 's#</a>#</a>\
-#g' "$TEMP_DIR/${pkg_name}.md"
+        # Fix headings and add metadata. Use perl (portable across BSD/GNU) to add a
+        # newline after each </a> — GNU sed rejects the BSD `sed -i ''` in-place form.
+        perl -0777 -i -pe 's#</a>#</a>\n#g' "$TEMP_DIR/${pkg_name}.md"
         
         # Post-process to fix Example code blocks in docstrings
         # Only convert opening ``` that are not already followed by a language tag


### PR DESCRIPTION
Adds a deploy-site job to ci.yml that rebuilds the docs site and pushes it
to the stochadex/stochadex.github.io repo on merge to main. Gated on the
test job (needs: [test]) so the site is never republished from a commit
whose tests failed, and guarded to run only on push to main (skipped on PRs).

Also fixes a macOS-only `sed -i ''` in docs/build.sh (broken on GNU sed) by
switching to an equivalent perl in-place edit, so build.sh runs on Ubuntu CI.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
