### PR TITLE
Generate anglersim card numbers from its behaviour suite (1.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,19 @@ an exact version rather than assume stability across minors.
 
 ## [Unreleased]
 
-_Nothing yet. New behaviour/API-changing PRs add their entries here._
+### Added
+- **Generated card numbers (flagship: anglersim).** A model's card now shows an
+  "Observed behaviour" table whose numbers are emitted by the model's own
+  expected-behaviour suite and rendered into `card.md` by `cmd/model-graphs`, never
+  hand-typed. `models/cardgen` holds the shared `Claim`/`Observation` types;
+  `anglersim.ObservedBehaviour()` is the single source of both the test assertions
+  and the card numbers, so the card cannot show a value the test did not observe.
+  `TestCardsUpToDate` fails CI if the committed numbers drift from the code.
+
+### Changed
+- `cmd/model-graphs` now regenerates both the partition-wiring diagram and the
+  observed-behaviour block; `anglersim`'s behaviour helpers moved from `_test.go`
+  into `behaviour.go` so they are shared by the tests and the card generator.
 
 ## [0.1.0] — 2026-07-13
 

--- a/cmd/model-graphs/main.go
+++ b/cmd/model-graphs/main.go
@@ -1,15 +1,21 @@
-// Command model-graphs regenerates the "Partition wiring" Mermaid diagram in
-// every models/<domain>/card.md from the domain's BuildStub wiring.
+// Command model-graphs regenerates the machine-derived blocks in every
+// models/<domain>/card.md:
 //
-// The diagram is derived statically by pkg/graph, so it always matches the
-// stub's actual partition wiring. Re-run after changing any stub's wiring:
+//   - the "Partition wiring" Mermaid diagram, from the domain's BuildStub wiring
+//     (via pkg/graph, so it always matches the stub's actual partition wiring); and
+//   - the "Observed behaviour" table, for models whose behaviour suite exposes an
+//     ObservedBehaviour() — the ensemble numbers emitted by the model's own tests,
+//     so a card's numbers are generated from the code, never hand-typed.
+//
+// Re-run after changing any stub's wiring or generative behaviour:
 //
 //	go run ./cmd/model-graphs
 //
-// It rewrites only the region between the generated-block markers (inserting it
-// just above the "## Ingests" heading on first run), so hand-written card prose
-// is never touched. TestCardsUpToDate guards that the committed cards match, so
-// CI fails if a stub's wiring changes without the diagrams being regenerated.
+// It rewrites only the regions between the generated-block markers (inserting the
+// wiring block above "## Ingests" and the observed-behaviour block above
+// "## Bespoke extensions" on first run), so hand-written card prose is never
+// touched. TestCardsUpToDate guards that the committed cards match, so CI fails if
+// a stub's wiring or numbers change without the cards being regenerated.
 package main
 
 //go:generate go run .
@@ -24,6 +30,8 @@ import (
 	"github.com/umbralcalc/stochadex/pkg/graph"
 	"github.com/umbralcalc/stochadex/pkg/simulator"
 
+	"github.com/umbralcalc/stochadex/models/cardgen"
+
 	anglersim "github.com/umbralcalc/stochadex/models/anglersim"
 	amr "github.com/umbralcalc/stochadex/models/antimicrobial-resistance"
 	bathingwater "github.com/umbralcalc/stochadex/models/bathing-water-forecaster"
@@ -37,23 +45,27 @@ import (
 
 // model pairs a catalogue directory with its stub, built at a representative
 // driver value. The wiring graph is independent of the numeric driver, so any
-// in-range value yields the same diagram.
+// in-range value yields the same diagram. obs, when non-nil, is the model's
+// verified response claims with their observed numbers — rendered into the card's
+// "Observed behaviour" block. Only models whose behaviour suite exposes an
+// ObservedBehaviour() supply it (anglersim leads; others follow as generalised).
 type model struct {
 	dir string
 	gen *simulator.ConfigGenerator
+	obs []cardgen.Claim
 }
 
 func models() []model {
 	return []model{
-		{"anglersim", anglersim.BuildStub(anglersim.DefaultWarmingTrend, 60, 42)},
-		{"antimicrobial-resistance", amr.BuildStub(amr.BaselinePrescribingRate, 20)},
-		{"bathing-water-forecaster", bathingwater.BuildStub(bathingwater.DefaultAnomalyVolatility, 60, 42)},
-		{"business-survival", bizsurvival.BuildStub(bizsurvival.DefaultPolicyHazardScale, 24, 7001)},
-		{"energy-balancer", energybalancer.BuildStub(0.5, 60, 42)},
-		{"floodrisk", floodrisk.BuildStub(1.0, 60, 42)},
-		{"homark", homark.BuildStub(homark.DefaultApprovalRate, 48, 42)},
-		{"measles-risk-forecaster", measles.BuildStub(measles.DefaultMMR2Coverage, measles.DefaultMaxGenerations, 42)},
-		{"trywizard", rugby.BuildStub(rugby.DefaultHomeSubMinute, rugby.DefaultNumSteps, 7001)},
+		{dir: "anglersim", gen: anglersim.BuildStub(anglersim.DefaultWarmingTrend, 60, 42), obs: anglersim.ObservedBehaviour()},
+		{dir: "antimicrobial-resistance", gen: amr.BuildStub(amr.BaselinePrescribingRate, 20)},
+		{dir: "bathing-water-forecaster", gen: bathingwater.BuildStub(bathingwater.DefaultAnomalyVolatility, 60, 42)},
+		{dir: "business-survival", gen: bizsurvival.BuildStub(bizsurvival.DefaultPolicyHazardScale, 24, 7001)},
+		{dir: "energy-balancer", gen: energybalancer.BuildStub(0.5, 60, 42)},
+		{dir: "floodrisk", gen: floodrisk.BuildStub(1.0, 60, 42)},
+		{dir: "homark", gen: homark.BuildStub(homark.DefaultApprovalRate, 48, 42)},
+		{dir: "measles-risk-forecaster", gen: measles.BuildStub(measles.DefaultMMR2Coverage, measles.DefaultMaxGenerations, 42)},
+		{dir: "trywizard", gen: rugby.BuildStub(rugby.DefaultHomeSubMinute, rugby.DefaultNumSteps, 7001)},
 	}
 }
 
@@ -61,6 +73,12 @@ const (
 	beginMarker  = "<!-- BEGIN generated: partition-wiring (regenerate with `go run ./cmd/model-graphs`) -->"
 	endMarker    = "<!-- END generated: partition-wiring -->"
 	insertBefore = "\n## Ingests"
+
+	obsBeginMarker  = "<!-- BEGIN generated: observed-behaviour (regenerate with `go run ./cmd/model-graphs`) -->"
+	obsEndMarker    = "<!-- END generated: observed-behaviour -->"
+	obsInsertBefore = "\n## Bespoke extensions"
+
+	regenCmd = "go run ./cmd/model-graphs"
 )
 
 const intro = `## Partition wiring
@@ -83,19 +101,36 @@ func block(mermaid string) string {
 	return b.String()
 }
 
-// splice inserts or replaces the generated block in a card's content.
-func splice(content, generated string) (string, error) {
-	if b := strings.Index(content, beginMarker); b >= 0 {
-		e := strings.Index(content, endMarker)
+// obsBlock renders the marker-wrapped "Observed behaviour" block from a model's
+// claims. Returns "" when the model has no claims (so no block is spliced).
+func obsBlock(claims []cardgen.Claim) string {
+	body := cardgen.ObservedBehaviourMarkdown(claims, regenCmd)
+	if body == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(obsBeginMarker)
+	b.WriteString("\n\n")
+	b.WriteString(body)
+	b.WriteString("\n\n")
+	b.WriteString(obsEndMarker)
+	return b.String()
+}
+
+// splice inserts or replaces a marker-delimited generated block in a card's
+// content. If the begin/end markers are present it replaces between them; else it
+// inserts before the insertBefore heading; else it appends at the end.
+func splice(content, generated, begin, end, insertBefore string) (string, error) {
+	if b := strings.Index(content, begin); b >= 0 {
+		e := strings.Index(content, end)
 		if e < 0 {
-			return "", fmt.Errorf("found begin marker without end marker")
+			return "", fmt.Errorf("found begin marker %q without its end marker", begin)
 		}
-		return content[:b] + generated + content[e+len(endMarker):], nil
+		return content[:b] + generated + content[e+len(end):], nil
 	}
 	if i := strings.Index(content, insertBefore); i >= 0 {
 		return content[:i] + "\n\n" + generated + "\n" + content[i:], nil
 	}
-	// No "## Ingests" heading: append to the end as a fallback.
 	return strings.TrimRight(content, "\n") + "\n\n" + generated + "\n", nil
 }
 
@@ -105,17 +140,25 @@ func cardPath(root, dir string) string {
 }
 
 // desiredCard returns the card content a model should have: the on-disk content
-// with its generated wiring block inserted or refreshed.
+// with its generated wiring block — and, if the model exposes response claims, its
+// "Observed behaviour" block — inserted or refreshed.
 func desiredCard(root string, m model) (current, desired string, err error) {
 	content, err := os.ReadFile(cardPath(root, m.dir))
 	if err != nil {
 		return "", "", err
 	}
-	desired, err = splice(string(content), block(graph.Build(m.gen).Mermaid()))
+	out, err := splice(string(content), block(graph.Build(m.gen).Mermaid()),
+		beginMarker, endMarker, insertBefore)
 	if err != nil {
 		return "", "", err
 	}
-	return string(content), desired, nil
+	if ob := obsBlock(m.obs); ob != "" {
+		out, err = splice(out, ob, obsBeginMarker, obsEndMarker, obsInsertBefore)
+		if err != nil {
+			return "", "", err
+		}
+	}
+	return string(content), out, nil
 }
 
 // run regenerates every card's wiring block under root. When write is false it

--- a/cmd/model-graphs/main_test.go
+++ b/cmd/model-graphs/main_test.go
@@ -5,9 +5,11 @@ import (
 	"testing"
 )
 
-// TestCardsUpToDate fails if any models/<domain>/card.md wiring diagram is out
-// of sync with its stub's BuildStub wiring. This is the CI guard: changing a
-// stub's partition wiring without regenerating the cards breaks the build.
+// TestCardsUpToDate fails if any models/<domain>/card.md generated block is out
+// of sync with the code — either the partition-wiring diagram (from BuildStub) or
+// the observed-behaviour numbers (from the model's ObservedBehaviour). This is the
+// CI guard: changing a stub's wiring or its generative behaviour without
+// regenerating the cards breaks the build, so a card can never show a stale number.
 //
 // To fix a failure, run:
 //
@@ -23,7 +25,8 @@ func TestCardsUpToDate(t *testing.T) {
 	}
 	if len(changed) > 0 {
 		t.Errorf(
-			"stale partition-wiring diagrams in: %s\nrun `go generate ./cmd/model-graphs` to regenerate",
+			"stale generated card sections (wiring diagram or observed-behaviour numbers) in: %s\n"+
+				"run `go generate ./cmd/model-graphs` to regenerate",
 			strings.Join(changed, ", "),
 		)
 	}

--- a/models/anglersim/behaviour.go
+++ b/models/anglersim/behaviour.go
@@ -1,0 +1,275 @@
+package anglersim
+
+import (
+	"math"
+	"sync"
+
+	"github.com/umbralcalc/stochadex/models/cardgen"
+	"github.com/umbralcalc/stochadex/pkg/simulator"
+)
+
+// This file holds the model's runnable expected-behaviour definitions, shared by
+// two consumers: the behaviour test (which asserts each claim's direction) and
+// cmd/model-graphs (which renders the observed numbers into card.md). Keeping the
+// computation here — not in a _test.go file — is what lets the card show exactly
+// the numbers the test asserts on, so the two can never disagree.
+
+// runStub runs the stub to completion and returns the recorded state history for
+// every partition, keyed by partition name.
+func runStub(warmingTrend float64, numSteps int, seed uint64) *simulator.StateTimeStorage {
+	settings, implementations := BuildStub(warmingTrend, numSteps, seed).GenerateConfigs()
+	store := simulator.NewStateTimeStorage()
+	implementations.OutputFunction = &simulator.StateTimeStorageOutputFunction{Store: store}
+	coordinator := simulator.NewPartitionCoordinator(settings, implementations)
+	var wg sync.WaitGroup
+	for !coordinator.ReadyToTerminate() {
+		coordinator.Step(&wg)
+	}
+	return store
+}
+
+// runStubOverride runs the stub with an override hook applied to the generated
+// config before the run, so a behaviour can vary any partition's params without
+// bloating BuildStub's signature — BuildStub still exposes only the one headline
+// driver (the warming trend).
+func runStubOverride(
+	numSteps int,
+	seed uint64,
+	override func(*simulator.ConfigGenerator),
+) *simulator.StateTimeStorage {
+	gen := BuildStub(DefaultWarmingTrend, numSteps, seed)
+	if override != nil {
+		override(gen)
+	}
+	settings, implementations := gen.GenerateConfigs()
+	store := simulator.NewStateTimeStorage()
+	implementations.OutputFunction = &simulator.StateTimeStorageOutputFunction{Store: store}
+	coordinator := simulator.NewPartitionCoordinator(settings, implementations)
+	var wg sync.WaitGroup
+	for !coordinator.ReadyToTerminate() {
+		coordinator.Step(&wg)
+	}
+	return store
+}
+
+// meanFinalLogDensity averages the population log-density over the final window of
+// a run, damping the per-step process noise so the level is about the trajectory,
+// not one noisy year.
+func meanFinalLogDensity(rows [][]float64, window int) float64 {
+	if window > len(rows) {
+		window = len(rows)
+	}
+	sum := 0.0
+	for i := len(rows) - window; i < len(rows); i++ {
+		sum += rows[i][0]
+	}
+	return sum / float64(window)
+}
+
+// meanFinalLogDensityEnsemble averages meanFinalLogDensity across an ensemble of
+// independent realisations (varying the seed) to make each claim about the
+// distribution rather than a single trajectory.
+func meanFinalLogDensityEnsemble(warmingTrend float64, numSteps, window, nMembers int) float64 {
+	sum := 0.0
+	for m := 0; m < nMembers; m++ {
+		store := runStub(warmingTrend, numSteps, uint64(1000+m))
+		sum += meanFinalLogDensity(store.GetValues("population"), window)
+	}
+	return sum / float64(nMembers)
+}
+
+// meanFinalDensityOverride returns the ensemble-mean final log-density under an
+// override, averaging over both the final-window and an ensemble of seeds.
+func meanFinalDensityOverride(
+	numSteps, window, nMembers int,
+	override func(*simulator.ConfigGenerator),
+) float64 {
+	sum := 0.0
+	for m := 0; m < nMembers; m++ {
+		store := runStubOverride(numSteps, uint64(4000+m), override)
+		sum += meanFinalLogDensity(store.GetValues("population"), window)
+	}
+	return sum / float64(nMembers)
+}
+
+// stdFinalDensityOverride returns the across-ensemble standard deviation of the
+// final log-density under an override — the spread of outcomes, used for the
+// process-noise claim.
+func stdFinalDensityOverride(
+	numSteps, nMembers int,
+	override func(*simulator.ConfigGenerator),
+) float64 {
+	finals := make([]float64, nMembers)
+	mean := 0.0
+	for m := 0; m < nMembers; m++ {
+		store := runStubOverride(numSteps, uint64(7000+m), override)
+		rows := store.GetValues("population")
+		finals[m] = rows[len(rows)-1][0]
+		mean += finals[m]
+	}
+	mean /= float64(nMembers)
+	varSum := 0.0
+	for _, v := range finals {
+		d := v - mean
+		varSum += d * d
+	}
+	return math.Sqrt(varSum / float64(nMembers))
+}
+
+// setCovariateBaseline overwrites one entry of the covariate baseline vector.
+func setCovariateBaseline(gen *simulator.ConfigGenerator, index int, value float64) {
+	b := gen.GetPartition("covariates").Params.Map["baseline_levels"]
+	c := make([]float64, len(b))
+	copy(c, b)
+	c[index] = value
+	gen.GetPartition("covariates").Params.Map["baseline_levels"] = c
+}
+
+// setPopulationParam overwrites a scalar param on the population partition.
+func setPopulationParam(gen *simulator.ConfigGenerator, key string, value float64) {
+	gen.GetPartition("population").Params.Map[key] = []float64{value}
+}
+
+// setWarmingTrend overwrites the covariate warming-trend driver.
+func setWarmingTrend(gen *simulator.ConfigGenerator, value float64) {
+	gen.GetPartition("covariates").Params.Map["warming_trend"] = []float64{value}
+}
+
+// ObservedBehaviour returns the model's named response claims, each with the
+// ensemble numbers it produces. It is the single source of the card's "Observed
+// behaviour" numbers AND the values the behaviour test asserts on, so the two can
+// never disagree. Each claim's Monotone direction is what its binding test checks.
+//
+// The claim IDs match the subtest names under TestAnglersimExpectedBehaviour.
+func ObservedBehaviour() []cardgen.Claim {
+	const logDensity = "ensemble-mean final log-density"
+
+	// Shared 60-year baseline, reused across the actionable/structural claims that
+	// perturb one input against it (avoids recomputing the same base each time).
+	base60 := meanFinalDensityOverride(60, 20, 12, nil)
+
+	// Headline climate sweep at the horizon/ensemble the warming claim uses.
+	warm0 := meanFinalDensityOverride(80, 20, 16, nil)
+	warm4 := meanFinalDensityOverride(80, 20, 16, func(g *simulator.ConfigGenerator) { setWarmingTrend(g, 0.04) })
+	warm8 := meanFinalDensityOverride(80, 20, 16, func(g *simulator.ConfigGenerator) { setWarmingTrend(g, 0.08) })
+
+	higherFlow := meanFinalDensityOverride(60, 20, 12, func(g *simulator.ConfigGenerator) {
+		setCovariateBaseline(g, 0, 2.0*DefaultBaselineFlow)
+	})
+	drought := meanFinalDensityOverride(60, 20, 12, func(g *simulator.ConfigGenerator) {
+		setCovariateBaseline(g, 0, 0.25*DefaultBaselineFlow)
+	})
+	cleaner := meanFinalDensityOverride(60, 20, 12, func(g *simulator.ConfigGenerator) {
+		setCovariateBaseline(g, 2, DefaultBaselineDO+3.0)
+	})
+	faster := meanFinalDensityOverride(60, 20, 12, func(g *simulator.ConfigGenerator) {
+		setPopulationParam(g, "growth_rate", 1.0)
+	})
+	crowded := meanFinalDensityOverride(60, 20, 12, func(g *simulator.ConfigGenerator) {
+		setPopulationParam(g, "density_dependence", 2.0)
+	})
+
+	lowNoise := stdFinalDensityOverride(60, 40, func(g *simulator.ConfigGenerator) {
+		setPopulationParam(g, "process_noise_sd", 0.05)
+	})
+	highNoise := stdFinalDensityOverride(60, 40, func(g *simulator.ConfigGenerator) {
+		setPopulationParam(g, "process_noise_sd", 0.6)
+	})
+
+	lowStart := func(g *simulator.ConfigGenerator) {
+		setPopulationParam(g, "process_noise_sd", 0.001)
+		g.GetPartition("population").InitStateValues = []float64{-8.0}
+	}
+	noAllee := meanFinalDensityOverride(8, 1, 8, func(g *simulator.ConfigGenerator) {
+		lowStart(g)
+		setPopulationParam(g, "allee_effect", 0.0)
+	})
+	withAllee := meanFinalDensityOverride(8, 1, 8, func(g *simulator.ConfigGenerator) {
+		lowStart(g)
+		setPopulationParam(g, "allee_effect", 30.0)
+	})
+
+	return []cardgen.Claim{
+		{
+			ID:        "climate_warming_reduces_density",
+			Statement: "Climate warming reduces density",
+			Unit:      logDensity,
+			Monotone:  -1,
+			Observations: []cardgen.Observation{
+				{Label: "+0.00 °C/yr", Value: warm0},
+				{Label: "+0.04", Value: warm4},
+				{Label: "+0.08", Value: warm8},
+			},
+		},
+		{
+			ID:        "reduced_abstraction_higher_flow_raises_density",
+			Statement: "Higher river flow (reduced abstraction) raises density",
+			Unit:      logDensity,
+			Monotone:  1,
+			Observations: []cardgen.Observation{
+				{Label: "base flow", Value: base60},
+				{Label: "flow ×2", Value: higherFlow},
+			},
+		},
+		{
+			ID:        "drought_lower_flow_reduces_density",
+			Statement: "Drought (lower flow) reduces density",
+			Unit:      logDensity,
+			Monotone:  -1,
+			Observations: []cardgen.Observation{
+				{Label: "base flow", Value: base60},
+				{Label: "flow ×0.25", Value: drought},
+			},
+		},
+		{
+			ID:        "water_quality_improvement_higher_dissolved_oxygen_raises_density",
+			Statement: "Higher dissolved oxygen (pollution reduction) raises density",
+			Unit:      logDensity,
+			Monotone:  1,
+			Observations: []cardgen.Observation{
+				{Label: "base DO", Value: base60},
+				{Label: "DO +3 mg/l", Value: cleaner},
+			},
+		},
+		{
+			ID:        "higher_growth_rate_raises_density",
+			Statement: "Higher intrinsic growth rate raises density",
+			Unit:      logDensity,
+			Monotone:  1,
+			Observations: []cardgen.Observation{
+				{Label: "base r0", Value: base60},
+				{Label: "r0=1.0", Value: faster},
+			},
+		},
+		{
+			ID:        "stronger_density_dependence_reduces_density",
+			Statement: "Stronger density dependence reduces density",
+			Unit:      logDensity,
+			Monotone:  -1,
+			Observations: []cardgen.Observation{
+				{Label: "base α", Value: base60},
+				{Label: "α=2.0", Value: crowded},
+			},
+		},
+		{
+			ID:        "higher_process_noise_widens_density_distribution",
+			Statement: "Higher process noise widens the outcome distribution",
+			Unit:      "ensemble std of final log-density",
+			Monotone:  1,
+			Observations: []cardgen.Observation{
+				{Label: "σ=0.05", Value: lowNoise},
+				{Label: "σ=0.6", Value: highNoise},
+			},
+		},
+		{
+			ID:        "allee_effect_slows_recovery_from_low_density",
+			Statement: "The Allee effect slows recovery from low density",
+			Unit:      logDensity + " from a low start",
+			Monotone:  -1,
+			Observations: []cardgen.Observation{
+				{Label: "standard Ricker", Value: noAllee},
+				{Label: "Allee γ=30", Value: withAllee},
+			},
+		},
+	}
+}

--- a/models/anglersim/behaviour_test.go
+++ b/models/anglersim/behaviour_test.go
@@ -1,221 +1,52 @@
 package anglersim
 
 import (
-	"math"
-	"sync"
 	"testing"
 
-	"github.com/umbralcalc/stochadex/pkg/simulator"
+	"github.com/umbralcalc/stochadex/models/cardgen"
 )
 
-// runStubOverride runs the stub with an override hook applied to the generated
-// config before the run, so a behaviour test can vary any partition's params
-// without bloating BuildStub's signature — BuildStub still exposes only the one
-// headline driver (the warming trend).
-func runStubOverride(
-	t *testing.T,
-	numSteps int,
-	seed uint64,
-	override func(*simulator.ConfigGenerator),
-) *simulator.StateTimeStorage {
-	t.Helper()
-	gen := BuildStub(DefaultWarmingTrend, numSteps, seed)
-	if override != nil {
-		override(gen)
-	}
-	settings, implementations := gen.GenerateConfigs()
-	store := simulator.NewStateTimeStorage()
-	implementations.OutputFunction = &simulator.StateTimeStorageOutputFunction{Store: store}
-	coordinator := simulator.NewPartitionCoordinator(settings, implementations)
-	var wg sync.WaitGroup
-	for !coordinator.ReadyToTerminate() {
-		coordinator.Step(&wg)
-	}
-	return store
-}
-
-// meanFinalDensityOverride returns the ensemble-mean final log-density under an
-// override, averaging over both the final-window and an ensemble of seeds.
-func meanFinalDensityOverride(
-	t *testing.T,
-	numSteps, window, nMembers int,
-	override func(*simulator.ConfigGenerator),
-) float64 {
-	t.Helper()
-	sum := 0.0
-	for m := 0; m < nMembers; m++ {
-		store := runStubOverride(t, numSteps, uint64(4000+m), override)
-		sum += meanFinalLogDensity(store.GetValues("population"), window)
-	}
-	return sum / float64(nMembers)
-}
-
-// stdFinalDensityOverride returns the across-ensemble standard deviation of the
-// final log-density under an override — the spread of outcomes, used to test the
-// process-noise claim.
-func stdFinalDensityOverride(
-	t *testing.T,
-	numSteps, nMembers int,
-	override func(*simulator.ConfigGenerator),
-) float64 {
-	t.Helper()
-	finals := make([]float64, nMembers)
-	mean := 0.0
-	for m := 0; m < nMembers; m++ {
-		store := runStubOverride(t, numSteps, uint64(7000+m), override)
-		rows := store.GetValues("population")
-		finals[m] = rows[len(rows)-1][0]
-		mean += finals[m]
-	}
-	mean /= float64(nMembers)
-	varSum := 0.0
-	for _, v := range finals {
-		d := v - mean
-		varSum += d * d
-	}
-	return math.Sqrt(varSum / float64(nMembers))
-}
-
-// setCovariateBaseline overwrites one entry of the covariate baseline vector.
-func setCovariateBaseline(gen *simulator.ConfigGenerator, index int, value float64) {
-	b := gen.GetPartition("covariates").Params.Map["baseline_levels"]
-	c := make([]float64, len(b))
-	copy(c, b)
-	c[index] = value
-	gen.GetPartition("covariates").Params.Map["baseline_levels"] = c
-}
-
-// setPopulationParam overwrites a scalar param on the population partition.
-func setPopulationParam(gen *simulator.ConfigGenerator, key string, value float64) {
-	gen.GetPartition("population").Params.Map[key] = []float64{value}
-}
-
-// TestAnglersimExpectedBehaviour is the expected-behaviour suite: each subtest
-// name is a plain-language response claim, and the body varies one input and
-// asserts the output moves as the name says. It covers both the actionable
-// habitat/water-management levers a downstream decision-maker controls (flow and
-// dissolved-oxygen management, mapping to the downstream abstraction / drought /
-// water-quality scenarios) and the structural drivers the world sets (climate
-// warming, growth, density dependence, process noise, depensation) whose correct
-// signs earn the model out-of-sample credibility.
+// TestAnglersimExpectedBehaviour is the expected-behaviour suite. Each subtest is
+// named by a claim ID from ObservedBehaviour and asserts that the claim's observed
+// values move in the direction the claim states (Monotone) — covering both the
+// actionable habitat/water-management levers a downstream decision-maker controls
+// (flow and dissolved-oxygen management) and the structural drivers the world sets
+// (warming, growth, density dependence, process noise, depensation).
+//
+// ObservedBehaviour is the single source of BOTH these assertions and the numbers
+// rendered on the card, so the card cannot show a value the test did not observe.
 func TestAnglersimExpectedBehaviour(t *testing.T) {
-	// --- Decision-path responses (actionable habitat / water-management levers) ---
+	claims := ObservedBehaviour()
+	if len(claims) == 0 {
+		t.Fatal("ObservedBehaviour returned no claims")
+	}
+	for _, c := range claims {
+		t.Run(c.ID, func(t *testing.T) {
+			assertMonotone(t, c)
+		})
+	}
+}
 
-	// Reduced water abstraction raises mean river flow; flow helps trout
-	// (beta_flow > 0), so density rises.
-	t.Run("reduced_abstraction_higher_flow_raises_density", func(t *testing.T) {
-		const steps, window, nMembers = 60, 20, 12
-		base := meanFinalDensityOverride(t, steps, window, nMembers, nil)
-		higherFlow := meanFinalDensityOverride(t, steps, window, nMembers, func(g *simulator.ConfigGenerator) {
-			setCovariateBaseline(g, 0, 2.0*DefaultBaselineFlow)
-		})
-		if !(higherFlow > base) {
-			t.Fatalf("expected higher river flow to raise density: base=%.4f higherFlow=%.4f", base, higherFlow)
+// assertMonotone checks a claim's observations move strictly in its stated
+// direction across the listed points (+1 increasing, -1 decreasing).
+func assertMonotone(t *testing.T, c cardgen.Claim) {
+	t.Helper()
+	if len(c.Observations) < 2 {
+		t.Fatalf("claim %q needs at least two observations to test a direction", c.ID)
+	}
+	if c.Monotone != 1 && c.Monotone != -1 {
+		t.Fatalf("claim %q has invalid Monotone %d (want +1 or -1)", c.ID, c.Monotone)
+	}
+	for i := 1; i < len(c.Observations); i++ {
+		prev, cur := c.Observations[i-1], c.Observations[i]
+		delta := cur.Value - prev.Value
+		if c.Monotone == 1 && !(delta > 0) {
+			t.Fatalf("%s: expected increase from %q (%.4f) to %q (%.4f)",
+				c.ID, prev.Label, prev.Value, cur.Label, cur.Value)
 		}
-	})
-
-	// Drought cuts river flow; less flow lowers trout density.
-	t.Run("drought_lower_flow_reduces_density", func(t *testing.T) {
-		const steps, window, nMembers = 60, 20, 12
-		base := meanFinalDensityOverride(t, steps, window, nMembers, nil)
-		drought := meanFinalDensityOverride(t, steps, window, nMembers, func(g *simulator.ConfigGenerator) {
-			setCovariateBaseline(g, 0, 0.25*DefaultBaselineFlow)
-		})
-		if !(drought < base) {
-			t.Fatalf("expected drought (lower flow) to reduce density: base=%.4f drought=%.4f", base, drought)
+		if c.Monotone == -1 && !(delta < 0) {
+			t.Fatalf("%s: expected decrease from %q (%.4f) to %q (%.4f)",
+				c.ID, prev.Label, prev.Value, cur.Label, cur.Value)
 		}
-	})
-
-	// Pollution reduction raises dissolved oxygen; oxygen helps trout
-	// (beta_do > 0), so density rises.
-	t.Run("water_quality_improvement_higher_dissolved_oxygen_raises_density", func(t *testing.T) {
-		const steps, window, nMembers = 60, 20, 12
-		base := meanFinalDensityOverride(t, steps, window, nMembers, nil)
-		cleaner := meanFinalDensityOverride(t, steps, window, nMembers, func(g *simulator.ConfigGenerator) {
-			setCovariateBaseline(g, 2, DefaultBaselineDO+3.0)
-		})
-		if !(cleaner > base) {
-			t.Fatalf("expected higher dissolved oxygen to raise density: base=%.4f cleaner=%.4f", base, cleaner)
-		}
-	})
-
-	// --- Structural-driver responses (non-actionable levers the world sets) ---
-
-	// Climate warming raises water temperature, which hurts trout
-	// (beta_temp < 0), so density falls. (Also the headline claim.)
-	t.Run("climate_warming_reduces_density", func(t *testing.T) {
-		const steps, window, nMembers = 80, 20, 16
-		base := meanFinalDensityOverride(t, steps, window, nMembers, nil)
-		warmed := meanFinalDensityOverride(t, steps, window, nMembers, func(g *simulator.ConfigGenerator) {
-			g.GetPartition("covariates").Params.Map["warming_trend"] = []float64{0.08}
-		})
-		if !(warmed < base) {
-			t.Fatalf("expected warming to reduce density: base=%.4f warmed=%.4f", base, warmed)
-		}
-	})
-
-	// A higher intrinsic growth rate raises the Ricker equilibrium density.
-	t.Run("higher_growth_rate_raises_density", func(t *testing.T) {
-		const steps, window, nMembers = 60, 20, 12
-		base := meanFinalDensityOverride(t, steps, window, nMembers, nil)
-		faster := meanFinalDensityOverride(t, steps, window, nMembers, func(g *simulator.ConfigGenerator) {
-			setPopulationParam(g, "growth_rate", 1.0)
-		})
-		if !(faster > base) {
-			t.Fatalf("expected higher growth rate to raise density: base=%.4f faster=%.4f", base, faster)
-		}
-	})
-
-	// Stronger density-dependent mortality lowers the equilibrium density
-	// (N* = (r0 + env)/alpha falls as alpha rises).
-	t.Run("stronger_density_dependence_reduces_density", func(t *testing.T) {
-		const steps, window, nMembers = 60, 20, 12
-		base := meanFinalDensityOverride(t, steps, window, nMembers, nil)
-		crowded := meanFinalDensityOverride(t, steps, window, nMembers, func(g *simulator.ConfigGenerator) {
-			setPopulationParam(g, "density_dependence", 2.0)
-		})
-		if !(crowded < base) {
-			t.Fatalf("expected stronger density dependence to reduce density: base=%.4f crowded=%.4f", base, crowded)
-		}
-	})
-
-	// Higher process noise widens the distribution of outcomes (larger spread of
-	// final densities across realisations), even where the mean is little changed.
-	t.Run("higher_process_noise_widens_density_distribution", func(t *testing.T) {
-		const steps, nMembers = 60, 40
-		lowNoise := stdFinalDensityOverride(t, steps, nMembers, func(g *simulator.ConfigGenerator) {
-			setPopulationParam(g, "process_noise_sd", 0.05)
-		})
-		highNoise := stdFinalDensityOverride(t, steps, nMembers, func(g *simulator.ConfigGenerator) {
-			setPopulationParam(g, "process_noise_sd", 0.6)
-		})
-		if !(highNoise > lowNoise) {
-			t.Fatalf("expected higher process noise to widen the density spread: "+
-				"lowNoise std=%.4f highNoise std=%.4f", lowNoise, highNoise)
-		}
-	})
-
-	// The Allee effect (depensation) suppresses the growth term at low density, so
-	// a population starting far below equilibrium recovers more slowly than under
-	// the standard Ricker (gamma = 0). Measured over a short horizon from a low
-	// seed density, with near-zero noise so the mechanism is isolated.
-	t.Run("allee_effect_slows_recovery_from_low_density", func(t *testing.T) {
-		const steps, window, nMembers = 8, 1, 8
-		lowStart := func(g *simulator.ConfigGenerator) {
-			setPopulationParam(g, "process_noise_sd", 0.001)
-			g.GetPartition("population").InitStateValues = []float64{-8.0}
-		}
-		noAllee := meanFinalDensityOverride(t, steps, window, nMembers, func(g *simulator.ConfigGenerator) {
-			lowStart(g)
-			setPopulationParam(g, "allee_effect", 0.0)
-		})
-		withAllee := meanFinalDensityOverride(t, steps, window, nMembers, func(g *simulator.ConfigGenerator) {
-			lowStart(g)
-			setPopulationParam(g, "allee_effect", 30.0)
-		})
-		if !(withAllee < noAllee) {
-			t.Fatalf("expected the Allee effect to slow recovery from low density: "+
-				"noAllee=%.4f withAllee=%.4f", noAllee, withAllee)
-		}
-	})
+	}
 }

--- a/models/anglersim/card.md
+++ b/models/anglersim/card.md
@@ -126,24 +126,44 @@ manager can influence?*
 2. **Physical invariants** — flow ≥ 0 and dissolved oxygen ≥ 0 every step; all
    covariates and the log-density stay finite (no NaN / ±Inf divergence).
 3. **Correct direction of parameter response** — raising the `warming_trend` lowers
-   the ensemble-mean final log-density. (Observed: mean final logN
-   −0.297 → −0.375 → −0.460 for warming 0.00 → 0.04 → 0.08 °C/yr, a 16-member
-   ensemble averaged over the final 20 years.) A stub that merely "runs" would not
-   catch an inverted climate response.
+   the ensemble-mean final log-density (the observed warming sweep is the first row
+   of the generated **Observed behaviour** table below). A stub that merely "runs"
+   would not catch an inverted climate response.
 
 The **expected-behaviour suite** ([`behaviour_test.go`](behaviour_test.go)) adds
-named, plain-language response claims, covering both kinds of lever:
+named, plain-language response claims, covering both kinds of lever. The observed
+number for every claim is emitted by the test run and generated into the **Observed
+behaviour** table below — never hand-typed, so it cannot drift from the code:
 
 - **Decision-path (actionable habitat / water management).** Higher river flow
   (reduced abstraction) raises density; drought (lower flow) reduces it; a
   dissolved-oxygen improvement (pollution reduction) raises it. These map to the
-  downstream scenario levers (abstraction / drought / water-quality). (Observed at a
-  60-year horizon: base −0.29; flow 0.5→1.0 m³/s → −0.23; DO 9→12 mg/l → −0.11.)
+  downstream scenario levers (abstraction / drought / water-quality).
 - **Structural drivers (the world sets).** Warming reduces density (`β_temp<0`);
   higher intrinsic growth raises it; stronger density dependence lowers it; higher
   process noise widens the spread of outcomes; and the Allee effect (γ>0) slows
   recovery from low density relative to the standard Ricker — the mechanism behind a
   minimum viable population.
+
+
+<!-- BEGIN generated: observed-behaviour (regenerate with `go run ./cmd/model-graphs`) -->
+
+## Observed behaviour
+
+Generated from the model's expected-behaviour suite — each row is a named response claim whose direction is asserted by a binding test, shown with the ensemble observations that claim produces (rounded to 2 dp). Regenerate with `go run ./cmd/model-graphs`; the card cannot silently drift because `TestCardsUpToDate` fails CI if these numbers no longer match the code.
+
+| Response claim | Binding test | Observed |
+|---|---|---|
+| Climate warming reduces density | `climate_warming_reduces_density` | ensemble-mean final log-density — +0.00 °C/yr -0.26 · +0.04 -0.34 · +0.08 -0.42 |
+| Higher river flow (reduced abstraction) raises density | `reduced_abstraction_higher_flow_raises_density` | ensemble-mean final log-density — base flow -0.29 · flow ×2 -0.23 |
+| Drought (lower flow) reduces density | `drought_lower_flow_reduces_density` | ensemble-mean final log-density — base flow -0.29 · flow ×0.25 -0.34 |
+| Higher dissolved oxygen (pollution reduction) raises density | `water_quality_improvement_higher_dissolved_oxygen_raises_density` | ensemble-mean final log-density — base DO -0.29 · DO +3 mg/l -0.11 |
+| Higher intrinsic growth rate raises density | `higher_growth_rate_raises_density` | ensemble-mean final log-density — base r0 -0.29 · r0=1.0 0.22 |
+| Stronger density dependence reduces density | `stronger_density_dependence_reduces_density` | ensemble-mean final log-density — base α -0.29 · α=2.0 -0.98 |
+| Higher process noise widens the outcome distribution | `higher_process_noise_widens_density_distribution` | ensemble std of final log-density — σ=0.05 0.08 · σ=0.6 0.60 |
+| The Allee effect slows recovery from low density | `allee_effect_slows_recovery_from_low_density` | ensemble-mean final log-density from a low start — standard Ricker -2.00 · Allee γ=30 -5.75 |
+
+<!-- END generated: observed-behaviour -->
 
 ## Bespoke extensions (staged beside the stub)
 

--- a/models/anglersim/stub_test.go
+++ b/models/anglersim/stub_test.go
@@ -2,53 +2,14 @@ package anglersim
 
 import (
 	"math"
-	"sync"
 	"testing"
 
 	"github.com/umbralcalc/stochadex/pkg/simulator"
 )
 
-// runStub runs the stub to completion and returns the recorded state history for
-// every partition, keyed by partition name.
-func runStub(t *testing.T, warmingTrend float64, numSteps int, seed uint64) *simulator.StateTimeStorage {
-	t.Helper()
-	settings, implementations := BuildStub(warmingTrend, numSteps, seed).GenerateConfigs()
-	store := simulator.NewStateTimeStorage()
-	implementations.OutputFunction = &simulator.StateTimeStorageOutputFunction{Store: store}
-	coordinator := simulator.NewPartitionCoordinator(settings, implementations)
-	var wg sync.WaitGroup
-	for !coordinator.ReadyToTerminate() {
-		coordinator.Step(&wg)
-	}
-	return store
-}
-
-// meanFinalLogDensity averages the population log-density over the final window of
-// a run, damping the per-step process noise so the level is about the trajectory,
-// not one noisy year.
-func meanFinalLogDensity(rows [][]float64, window int) float64 {
-	if window > len(rows) {
-		window = len(rows)
-	}
-	sum := 0.0
-	for i := len(rows) - window; i < len(rows); i++ {
-		sum += rows[i][0]
-	}
-	return sum / float64(window)
-}
-
-// meanFinalLogDensityEnsemble averages meanFinalLogDensity across an ensemble of
-// independent realisations (varying the seed) to make each claim about the
-// distribution rather than a single trajectory.
-func meanFinalLogDensityEnsemble(t *testing.T, warmingTrend float64, numSteps, window, nMembers int) float64 {
-	t.Helper()
-	sum := 0.0
-	for m := 0; m < nMembers; m++ {
-		store := runStub(t, warmingTrend, numSteps, uint64(1000+m))
-		sum += meanFinalLogDensity(store.GetValues("population"), window)
-	}
-	return sum / float64(nMembers)
-}
+// The run helpers (runStub, meanFinalLogDensity, meanFinalLogDensityEnsemble) and
+// the override helpers live in behaviour.go so they can be shared with the card
+// generator; the tests below exercise them.
 
 func TestAnglersimStub(t *testing.T) {
 	// Standard convention: the stub must pass the test harness (NaN, state-width,
@@ -62,7 +23,7 @@ func TestAnglersimStub(t *testing.T) {
 
 	// Structural / physical invariants of the generative core.
 	t.Run("invariants", func(t *testing.T) {
-		store := runStub(t, DefaultWarmingTrend, 200, 42)
+		store := runStub(DefaultWarmingTrend, 200, 42)
 
 		covariates := store.GetValues("covariates")
 		if len(covariates) == 0 {
@@ -93,12 +54,14 @@ func TestAnglersimStub(t *testing.T) {
 	// warming climate (higher warming trend on water temperature) lowers brown
 	// trout density, because the temperature covariate coefficient is negative.
 	// This is the reason the model exists — a stub that merely "runs" would not
-	// catch an inverted climate response. Averaged over an ensemble.
+	// catch an inverted climate response. Averaged over an ensemble. (The full
+	// set of response claims, with their observed numbers, is in behaviour_test.go
+	// via ObservedBehaviour.)
 	t.Run("warming climate lowers trout density", func(t *testing.T) {
 		const numSteps, window, nMembers = 80, 20, 16
 
-		baseline := meanFinalLogDensityEnsemble(t, 0.0, numSteps, window, nMembers)
-		warmed := meanFinalLogDensityEnsemble(t, 0.08, numSteps, window, nMembers)
+		baseline := meanFinalLogDensityEnsemble(0.0, numSteps, window, nMembers)
+		warmed := meanFinalLogDensityEnsemble(0.08, numSteps, window, nMembers)
 
 		if !(warmed < baseline) {
 			t.Fatalf("expected warming to lower mean final log-density: "+

--- a/models/cardgen/cardgen.go
+++ b/models/cardgen/cardgen.go
@@ -1,0 +1,86 @@
+// Package cardgen holds the shared types and rendering for the generated
+// "Observed behaviour" block in a model card. A model exposes its verified
+// response claims (each a plain-language statement plus the ensemble numbers it
+// produces) as []Claim; cmd/model-graphs renders them into card.md between
+// generated-block markers, and TestCardsUpToDate guards that the committed cards
+// match — so a card's numbers are emitted by the model's own behaviour suite and
+// cannot silently drift from the code.
+//
+// Numbers are rendered rounded (see decimals) so the committed cards are stable
+// across architectures: the model iterations are pure-Go float math, whose only
+// cross-arch wobble is FMA contraction (~1e-12), far below the rounding boundary.
+package cardgen
+
+import (
+	"fmt"
+	"strings"
+)
+
+// decimals is the fixed precision every observed value is rendered to. Coarse
+// enough to be architecture-stable, fine enough to show the response.
+const decimals = 2
+
+// Observation is one measured point in a claim: a label (the varied input or the
+// baseline) and the value the model produced for it.
+type Observation struct {
+	Label string
+	Value float64
+}
+
+// Claim is a named, plain-language response claim whose direction is asserted by
+// a binding test, carrying the ensemble observations that claim produces.
+//
+//   - ID matches the binding test's subtest name (the claim↔test bond).
+//   - Statement is the human-readable claim rendered on the card.
+//   - Unit annotates what the values are (e.g. "ensemble-mean final log-density").
+//   - Monotone is the direction the values should move across Observations in
+//     order: +1 increasing, -1 decreasing. The binding test asserts exactly this.
+type Claim struct {
+	ID           string
+	Statement    string
+	Unit         string
+	Monotone     int
+	Observations []Observation
+}
+
+// FormatValue renders a single value at the fixed card precision.
+func FormatValue(v float64) string {
+	return fmt.Sprintf("%.*f", decimals, v)
+}
+
+// renderObservations joins a claim's points as "label value" separated by " · ".
+func renderObservations(obs []Observation) string {
+	parts := make([]string, len(obs))
+	for i, o := range obs {
+		parts[i] = fmt.Sprintf("%s %s", o.Label, FormatValue(o.Value))
+	}
+	return strings.Join(parts, " · ")
+}
+
+// ObservedBehaviourMarkdown renders the body of the generated block (without the
+// markers) for a model's claims. Returns "" if there are no claims.
+func ObservedBehaviourMarkdown(claims []Claim, regenCmd string) string {
+	if len(claims) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("## Observed behaviour\n\n")
+	fmt.Fprintf(&b,
+		"Generated from the model's expected-behaviour suite — each row is a named "+
+			"response claim whose direction is asserted by a binding test, shown with the "+
+			"ensemble observations that claim produces (rounded to %d dp). Regenerate with "+
+			"`%s`; the card cannot silently drift because `TestCardsUpToDate` fails CI if "+
+			"these numbers no longer match the code.\n\n",
+		decimals, regenCmd,
+	)
+	b.WriteString("| Response claim | Binding test | Observed |\n")
+	b.WriteString("|---|---|---|\n")
+	for _, c := range claims {
+		observed := renderObservations(c.Observations)
+		if c.Unit != "" {
+			observed = fmt.Sprintf("%s — %s", c.Unit, observed)
+		}
+		fmt.Fprintf(&b, "| %s | `%s` | %s |\n", c.Statement, c.ID, observed)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}


### PR DESCRIPTION
PLAN.md step **1.4 — generated card numbers**, proven end-to-end on the flagship (anglersim).

**What changes.** A model's card now carries an **Observed behaviour** table whose numbers are *emitted by the model's own expected-behaviour suite* and rendered into `card.md` by `cmd/model-graphs` — never hand-typed. This closes the drift liability the plan flags: a hand-copied observation that silently diverges from the code.

**How it's bound.**
- `models/cardgen` — shared `Claim`/`Observation` types + block renderer (values rounded to 2 dp; the anglersim iterations are pure-Go float math, so the only cross-arch wobble is FMA contraction ~1e-12, far below the rounding boundary → committed cards are architecture-stable).
- `anglersim.ObservedBehaviour()` is the **single source** of both the test assertions and the card numbers, so the card cannot show a value the test did not observe. Helpers moved from `_test.go` into `behaviour.go` to share one computation.
- `behaviour_test.go` now consumes `ObservedBehaviour()` and asserts each claim's stated direction; **subtests are named by claim id**, which sets up 1.5 (claim↔test binding).
- `cmd/model-graphs` splices the observed-behaviour block; **`TestCardsUpToDate` guards it** → CI fails if a number drifts. Verified locally: tampering a card number fails the guard; restoring it passes.

**Done-when (from the plan):** changing the generative behaviour and regenerating changes the card numbers with zero manual editing; no card carries a hand-entered numeric result. ✅

Next: generalise the mechanism to the other flagship cards, then 1.5 binds each claim line to its test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)