### PR TITLE
Bind each anglersim card claim to its enforcing test (1.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ an exact version rather than assume stability across minors.
   `anglersim.ObservedBehaviour()` is the single source of both the test assertions
   and the card numbers, so the card cannot show a value the test did not observe.
   `TestCardsUpToDate` fails CI if the committed numbers drift from the code.
+- **Claim↔test binding on the card (flagship: anglersim).** The generated "Observed
+  behaviour" table now renders every response claim as one bound object — the
+  plain-language statement, a link to the exact test subtest that enforces it
+  (`TestAnglersimExpectedBehaviour/<claim-id>`), and the number that test produced.
+  A claim cannot appear without a test enforcing it, nor carry a number the test did
+  not produce; a broken claim fails CI (the binding test on a sign break, or
+  `TestCardsUpToDate` on a number move). Folded into the frozen card format in
+  `models/CONVENTIONS.md` so new entries adopt it from birth.
 
 ### Changed
 - `cmd/model-graphs` now regenerates both the partition-wiring diagram and the

--- a/cmd/model-graphs/main.go
+++ b/cmd/model-graphs/main.go
@@ -50,14 +50,20 @@ import (
 // "Observed behaviour" block. Only models whose behaviour suite exposes an
 // ObservedBehaviour() supply it (anglersim leads; others follow as generalised).
 type model struct {
-	dir string
-	gen *simulator.ConfigGenerator
-	obs []cardgen.Claim
+	dir     string
+	gen     *simulator.ConfigGenerator
+	obs     []cardgen.Claim
+	binding cardgen.Binding
 }
 
 func models() []model {
 	return []model{
-		{dir: "anglersim", gen: anglersim.BuildStub(anglersim.DefaultWarmingTrend, 60, 42), obs: anglersim.ObservedBehaviour()},
+		{
+			dir:     "anglersim",
+			gen:     anglersim.BuildStub(anglersim.DefaultWarmingTrend, 60, 42),
+			obs:     anglersim.ObservedBehaviour(),
+			binding: cardgen.Binding{TestName: "TestAnglersimExpectedBehaviour", TestFile: "behaviour_test.go"},
+		},
 		{dir: "antimicrobial-resistance", gen: amr.BuildStub(amr.BaselinePrescribingRate, 20)},
 		{dir: "bathing-water-forecaster", gen: bathingwater.BuildStub(bathingwater.DefaultAnomalyVolatility, 60, 42)},
 		{dir: "business-survival", gen: bizsurvival.BuildStub(bizsurvival.DefaultPolicyHazardScale, 24, 7001)},
@@ -103,8 +109,8 @@ func block(mermaid string) string {
 
 // obsBlock renders the marker-wrapped "Observed behaviour" block from a model's
 // claims. Returns "" when the model has no claims (so no block is spliced).
-func obsBlock(claims []cardgen.Claim) string {
-	body := cardgen.ObservedBehaviourMarkdown(claims, regenCmd)
+func obsBlock(claims []cardgen.Claim, binding cardgen.Binding) string {
+	body := cardgen.ObservedBehaviourMarkdown(claims, binding, regenCmd)
 	if body == "" {
 		return ""
 	}
@@ -152,7 +158,7 @@ func desiredCard(root string, m model) (current, desired string, err error) {
 	if err != nil {
 		return "", "", err
 	}
-	if ob := obsBlock(m.obs); ob != "" {
+	if ob := obsBlock(m.obs, m.binding); ob != "" {
 		out, err = splice(out, ob, obsBeginMarker, obsEndMarker, obsInsertBefore)
 		if err != nil {
 			return "", "", err

--- a/models/CONVENTIONS.md
+++ b/models/CONVENTIONS.md
@@ -57,7 +57,16 @@ headings, in order:
 - **Validity regime** — where the model is trustworthy, and where it stops being so.
 - **Failure modes** — how it misleads when pushed out of regime.
 - **Question answered** — the single question the model exists to answer, in italics.
-- **Generative behaviour under test** — enumerate what `stub_test.go` asserts.
+- **Generative behaviour under test** — enumerate what `stub_test.go` asserts (harness,
+  invariants, headline direction). Prose only — put no hand-typed numeric results here; the
+  numbers live in the generated *Observed behaviour* block below.
+- **Observed behaviour** — *generated, do not hand-write.* A table in which every row is one
+  bound object: a named response claim, a link to the exact test subtest that enforces it
+  (`Test…ExpectedBehaviour/<claim-id>`), and the number that test produced. Spliced between
+  `<!-- BEGIN/END generated: observed-behaviour -->` markers by `cmd/model-graphs` from the
+  model's `ObservedBehaviour()` (run `go generate ./cmd/model-graphs`). This is the model's
+  claim↔test bond made mechanical: a claim cannot appear without a test that enforces it, nor
+  carry a number the test did not produce. `TestCardsUpToDate` fails CI if any number drifts.
 - **Bespoke extensions** — which iterations sit beside the stub, and the note on what a
   future promotion signal would look like.
 - **Downstream** — a link to the project repo owning inference, data, and the decision layer.
@@ -151,6 +160,29 @@ Mechanics:
 
 The point is not exhaustive parameter coverage — it is that the crucial decision paths and
 the credibility-bearing structural drivers each have a checked, named, sign-correct claim.
+
+**Claim↔test binding (the reference pattern — `anglersim`).** So the card's claims cannot
+drift from the tests that back them, define the claims *in code* as the single source of both
+the assertions and the card numbers, rather than asserting in the test and re-typing numbers
+into the card:
+
+- Expose `func ObservedBehaviour() []cardgen.Claim` in a non-`_test.go` file (`behaviour.go`)
+  so it is shared by the test and the card generator. Each `cardgen.Claim` carries a stable
+  `ID` (the claim's contract, e.g. `climate_warming_reduces_density`), a plain-language
+  `Statement`, a `Monotone` direction (+1/−1), and the ordered `Observations` (label + value)
+  it produces. Put the ensemble helpers in `behaviour.go` too, not the test file.
+- `behaviour_test.go` *consumes* `ObservedBehaviour()`: it runs one subtest per claim, named
+  by `ID`, asserting the observations move in the claim's `Monotone` direction. The subtest
+  name is therefore the claim id, and the test cannot pass while a claim's stated direction is
+  false.
+- Register the model's `ObservedBehaviour()` and its `cardgen.Binding` (test function name +
+  file) in `cmd/model-graphs`; it renders the *Observed behaviour* block and
+  `TestCardsUpToDate` guards it.
+
+The result is one bond — claim → test → observed number — that fails CI in either direction:
+break a claim's sign and the binding test fails; change a number without regenerating and the
+card guard fails. New entries should adopt this from birth; older entries are being migrated
+to it.
 
 ## Bespoke extensions
 

--- a/models/anglersim/card.md
+++ b/models/anglersim/card.md
@@ -150,18 +150,18 @@ behaviour** table below — never hand-typed, so it cannot drift from the code:
 
 ## Observed behaviour
 
-Generated from the model's expected-behaviour suite — each row is a named response claim whose direction is asserted by a binding test, shown with the ensemble observations that claim produces (rounded to 2 dp). Regenerate with `go run ./cmd/model-graphs`; the card cannot silently drift because `TestCardsUpToDate` fails CI if these numbers no longer match the code.
+Every row below is one *bound* object: a plain-language response claim, the test subtest that enforces it, and the number that test produced (ensemble values rounded to 2 dp). Nothing here is hand-written — the claims and their numbers are emitted by `TestAnglersimExpectedBehaviour` (via `go run ./cmd/model-graphs`), so a claim cannot drift from its test or its result. If the model's behaviour changes, either the binding test fails (a claim's direction broke) or `TestCardsUpToDate` fails (a number moved) — a broken claim cannot reach the card silently.
 
-| Response claim | Binding test | Observed |
+| Response claim | Enforced by | Observed |
 |---|---|---|
-| Climate warming reduces density | `climate_warming_reduces_density` | ensemble-mean final log-density — +0.00 °C/yr -0.26 · +0.04 -0.34 · +0.08 -0.42 |
-| Higher river flow (reduced abstraction) raises density | `reduced_abstraction_higher_flow_raises_density` | ensemble-mean final log-density — base flow -0.29 · flow ×2 -0.23 |
-| Drought (lower flow) reduces density | `drought_lower_flow_reduces_density` | ensemble-mean final log-density — base flow -0.29 · flow ×0.25 -0.34 |
-| Higher dissolved oxygen (pollution reduction) raises density | `water_quality_improvement_higher_dissolved_oxygen_raises_density` | ensemble-mean final log-density — base DO -0.29 · DO +3 mg/l -0.11 |
-| Higher intrinsic growth rate raises density | `higher_growth_rate_raises_density` | ensemble-mean final log-density — base r0 -0.29 · r0=1.0 0.22 |
-| Stronger density dependence reduces density | `stronger_density_dependence_reduces_density` | ensemble-mean final log-density — base α -0.29 · α=2.0 -0.98 |
-| Higher process noise widens the outcome distribution | `higher_process_noise_widens_density_distribution` | ensemble std of final log-density — σ=0.05 0.08 · σ=0.6 0.60 |
-| The Allee effect slows recovery from low density | `allee_effect_slows_recovery_from_low_density` | ensemble-mean final log-density from a low start — standard Ricker -2.00 · Allee γ=30 -5.75 |
+| Climate warming reduces density | [`TestAnglersimExpectedBehaviour/climate_warming_reduces_density`](behaviour_test.go) | ensemble-mean final log-density — +0.00 °C/yr -0.26 · +0.04 -0.34 · +0.08 -0.42 |
+| Higher river flow (reduced abstraction) raises density | [`TestAnglersimExpectedBehaviour/reduced_abstraction_higher_flow_raises_density`](behaviour_test.go) | ensemble-mean final log-density — base flow -0.29 · flow ×2 -0.23 |
+| Drought (lower flow) reduces density | [`TestAnglersimExpectedBehaviour/drought_lower_flow_reduces_density`](behaviour_test.go) | ensemble-mean final log-density — base flow -0.29 · flow ×0.25 -0.34 |
+| Higher dissolved oxygen (pollution reduction) raises density | [`TestAnglersimExpectedBehaviour/water_quality_improvement_higher_dissolved_oxygen_raises_density`](behaviour_test.go) | ensemble-mean final log-density — base DO -0.29 · DO +3 mg/l -0.11 |
+| Higher intrinsic growth rate raises density | [`TestAnglersimExpectedBehaviour/higher_growth_rate_raises_density`](behaviour_test.go) | ensemble-mean final log-density — base r0 -0.29 · r0=1.0 0.22 |
+| Stronger density dependence reduces density | [`TestAnglersimExpectedBehaviour/stronger_density_dependence_reduces_density`](behaviour_test.go) | ensemble-mean final log-density — base α -0.29 · α=2.0 -0.98 |
+| Higher process noise widens the outcome distribution | [`TestAnglersimExpectedBehaviour/higher_process_noise_widens_density_distribution`](behaviour_test.go) | ensemble std of final log-density — σ=0.05 0.08 · σ=0.6 0.60 |
+| The Allee effect slows recovery from low density | [`TestAnglersimExpectedBehaviour/allee_effect_slows_recovery_from_low_density`](behaviour_test.go) | ensemble-mean final log-density from a low start — standard Ricker -2.00 · Allee γ=30 -5.75 |
 
 <!-- END generated: observed-behaviour -->
 

--- a/models/cardgen/cardgen.go
+++ b/models/cardgen/cardgen.go
@@ -57,30 +57,44 @@ func renderObservations(obs []Observation) string {
 	return strings.Join(parts, " · ")
 }
 
+// Binding names the test that enforces a model's claims: the test function whose
+// subtests are its claim ids, and the source file it lives in (a card-relative
+// path, so the link resolves both on GitHub and on the rendered docs site).
+type Binding struct {
+	TestName string // e.g. "TestAnglersimExpectedBehaviour"
+	TestFile string // e.g. "behaviour_test.go"
+}
+
 // ObservedBehaviourMarkdown renders the body of the generated block (without the
-// markers) for a model's claims. Returns "" if there are no claims.
-func ObservedBehaviourMarkdown(claims []Claim, regenCmd string) string {
+// markers) for a model's claims. Each row is one bound object — the plain-language
+// claim, a link to the exact test/subtest that enforces it, and the number that
+// test produced — so claim, test, and result cannot drift apart. Returns "" if
+// there are no claims.
+func ObservedBehaviourMarkdown(claims []Claim, binding Binding, regenCmd string) string {
 	if len(claims) == 0 {
 		return ""
 	}
 	var b strings.Builder
 	b.WriteString("## Observed behaviour\n\n")
 	fmt.Fprintf(&b,
-		"Generated from the model's expected-behaviour suite — each row is a named "+
-			"response claim whose direction is asserted by a binding test, shown with the "+
-			"ensemble observations that claim produces (rounded to %d dp). Regenerate with "+
-			"`%s`; the card cannot silently drift because `TestCardsUpToDate` fails CI if "+
-			"these numbers no longer match the code.\n\n",
-		decimals, regenCmd,
+		"Every row below is one *bound* object: a plain-language response claim, the "+
+			"test subtest that enforces it, and the number that test produced (ensemble "+
+			"values rounded to %d dp). Nothing here is hand-written — the claims and their "+
+			"numbers are emitted by `%s` (via `%s`), so a claim cannot drift from its test "+
+			"or its result. If the model's behaviour changes, either the binding test fails "+
+			"(a claim's direction broke) or `TestCardsUpToDate` fails (a number moved) — a "+
+			"broken claim cannot reach the card silently.\n\n",
+		decimals, binding.TestName, regenCmd,
 	)
-	b.WriteString("| Response claim | Binding test | Observed |\n")
+	b.WriteString("| Response claim | Enforced by | Observed |\n")
 	b.WriteString("|---|---|---|\n")
 	for _, c := range claims {
 		observed := renderObservations(c.Observations)
 		if c.Unit != "" {
 			observed = fmt.Sprintf("%s — %s", c.Unit, observed)
 		}
-		fmt.Fprintf(&b, "| %s | `%s` | %s |\n", c.Statement, c.ID, observed)
+		test := fmt.Sprintf("[`%s/%s`](%s)", binding.TestName, c.ID, binding.TestFile)
+		fmt.Fprintf(&b, "| %s | %s | %s |\n", c.Statement, test, observed)
 	}
 	return strings.TrimRight(b.String(), "\n")
 }


### PR DESCRIPTION
PLAN.md step **1.5 — claim↔test binding**, on the flagship (anglersim). Builds directly on 1.4.

**What changes.** The generated "Observed behaviour" table now renders each response claim as **one bound object**: the plain-language statement, a link to the exact test subtest that enforces it (`TestAnglersimExpectedBehaviour/<claim-id>` → `behaviour_test.go`), and the number that test produced. A skeptic no longer has to *trust* that the prose matches the tests — the chain claim → test → result is one visible, clickable object.

**The bond is mechanical, in both directions:**
- A claim cannot appear on the card without a test enforcing it (both come from `ObservedBehaviour()`; the test runs one subtest per claim id).
- A claim cannot carry a number the test did not produce (`TestCardsUpToDate` guards it).
- Break a claim's sign → the binding test fails. Move a number without regenerating → the card guard fails. **A broken claim can't reach the card silently.**

**Folded into the frozen card format** (`models/CONVENTIONS.md`): a new generated *Observed behaviour* heading, plus the `ObservedBehaviour()` / claim-id reference pattern in the expected-behaviour spec — so new entries adopt it from birth (older entries are being migrated next).

**Verified:** the `Enforced by` links rewrite to GitHub blob URLs on the docs site (10 links resolve on the model page) and resolve relatively on GitHub; guard + behaviour tests green.

Next: generalise 1.4+1.5 to the other flagship cards, then 1.6 (cross-model index).

🤖 Generated with [Claude Code](https://claude.com/claude-code)