### PR TITLE
Release v0.2.0: version badge + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ an exact version rather than assume stability across minors.
 
 ## [Unreleased]
 
+_Nothing yet. New behaviour/API-changing PRs add their entries here._
+
+## [0.2.0] — 2026-07-13
+
+The trust layer: every published card claim is now bound to an enforced test and
+every card number is generated from the code, across all nine catalogue models, made
+checkable by a generated cross-model index — on top of the CI, docs-automation, and
+versioning foundation. (Phase 1 of the improvement plan — the credibility spine.)
+
 ### Added
 - **Generated card numbers (flagship: anglersim).** A model's card now shows an
   "Observed behaviour" table whose numbers are emitted by the model's own
@@ -182,5 +191,6 @@ treat the intermediates as internal, never shipped API.
   stochastic-process formalism (diffusions, Poisson noise, windowed history for noise
   dependencies) before any Go engine existed. The pivot to Go begins Feb 2023.
 
-[Unreleased]: https://github.com/umbralcalc/stochadex/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/umbralcalc/stochadex/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/umbralcalc/stochadex/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/umbralcalc/stochadex/releases/tag/v0.1.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ title: "Home"
 
 <img src="./assets/logo.svg" width=600/>
 
-<div class="badges"><a href="https://github.com/umbralcalc/stochadex"><img src="https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&amp;logo=github&amp;logoColor=white" alt="Github" /></a> <a href="https://github.com/umbralcalc/stochadex/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="MIT" /></a> <a href="https://go.dev/"><img src="https://img.shields.io/badge/go-%2300ADD8.svg?style=for-the-badge&logo=go&logoColor=white" alt="Go" /></a></div>
+<div class="badges"><a href="https://github.com/umbralcalc/stochadex/releases"><img src="https://img.shields.io/github/v/tag/umbralcalc/stochadex?style=for-the-badge&amp;label=version&amp;color=4D7F37" alt="Latest version" /></a> <a href="https://github.com/umbralcalc/stochadex/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/umbralcalc/stochadex/ci.yml?branch=main&amp;style=for-the-badge&amp;label=CI" alt="CI" /></a> <a href="https://github.com/umbralcalc/stochadex"><img src="https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&amp;logo=github&amp;logoColor=white" alt="Github" /></a> <a href="https://github.com/umbralcalc/stochadex/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="MIT" /></a> <a href="https://go.dev/"><img src="https://img.shields.io/badge/go-%2300ADD8.svg?style=for-the-badge&logo=go&logoColor=white" alt="Go" /></a></div>
 <div style="height:0.75em;"></div>
 
 ## So what is the 'stochadex' project?


### PR DESCRIPTION
Cuts **v0.2.0** and adds an auto-updating version badge to the docs frontpage.

- **Version badge** (`shields.io/github/v/tag`) — reads the latest git tag directly, so it refreshes whenever a new tag is pushed, no site rebuild needed. Plus a CI-status badge. Both on the frontpage `docs/README.md`.
- **CHANGELOG** — moves the accumulated `[Unreleased]` entries under `## [0.2.0] — 2026-07-13` (the Phase-1 credibility-spine work: CI, docs automation, versioning, generated + test-bound card numbers across all nine models, cross-model index).

After this merges, I'll tag `v0.2.0` on the merge commit and publish the release, at which point the badge shows `v0.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)