### PR TITLE
Fix badge SVG text + reference badges by absolute Pages URL

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ title: "Home"
 
 <img src="./assets/logo.svg" width=600/>
 
-<div class="badges"><a href="https://github.com/umbralcalc/stochadex/releases"><img src="./version.svg" alt="Latest version" /></a> <a href="https://github.com/umbralcalc/stochadex/blob/main/CHANGELOG.md"><img src="./coverage.svg" alt="Test coverage" /></a> <a href="https://github.com/umbralcalc/stochadex"><img src="https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&amp;logo=github&amp;logoColor=white" alt="Github" /></a> <a href="https://github.com/umbralcalc/stochadex/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge" alt="MIT" /></a> <a href="https://go.dev/"><img src="https://img.shields.io/badge/go-%2300ADD8.svg?style=for-the-badge&logo=go&logoColor=white" alt="Go" /></a></div>
+<div class="badges"><a href="https://github.com/umbralcalc/stochadex/releases"><img src="https://stochadex.github.io/version.svg" alt="Latest version" /></a> <a href="https://github.com/umbralcalc/stochadex/blob/main/CHANGELOG.md"><img src="https://stochadex.github.io/coverage.svg" alt="Test coverage" /></a> <a href="https://github.com/umbralcalc/stochadex"><img src="https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&amp;logo=github&amp;logoColor=white" alt="Github" /></a> <a href="https://github.com/umbralcalc/stochadex/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge" alt="MIT" /></a> <a href="https://go.dev/"><img src="https://img.shields.io/badge/go-%2300ADD8.svg?style=for-the-badge&logo=go&logoColor=white" alt="Go" /></a></div>
 <div style="height:0.75em;"></div>
 
 ## So what is the 'stochadex' project?

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -500,11 +500,11 @@ make_badge() {
     <rect x="${lw}" width="${mw}" height="20" fill="${color}"/>
     <rect width="${total}" height="20" fill="url(#s)"/>
   </g>
-  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
-    <text x="${lcx}" y="15" transform="scale(.1)" fill="#010101" fill-opacity=".3" textLength="$(( ${#label} * 70 ))">${label}</text>
-    <text x="${lcx}" y="14" transform="scale(.1)" textLength="$(( ${#label} * 70 ))">${label}</text>
-    <text x="${mcx}" y="15" transform="scale(.1)" fill="#010101" fill-opacity=".3" textLength="$(( ${#message} * 70 ))">${message}</text>
-    <text x="${mcx}" y="14" transform="scale(.1)" textLength="$(( ${#message} * 70 ))">${message}</text>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="110" text-rendering="geometricPrecision">
+    <text x="${lcx}" y="150" transform="scale(.1)" fill="#010101" fill-opacity=".3" textLength="$(( ${#label} * 70 ))">${label}</text>
+    <text x="${lcx}" y="140" transform="scale(.1)" textLength="$(( ${#label} * 70 ))">${label}</text>
+    <text x="${mcx}" y="150" transform="scale(.1)" fill="#010101" fill-opacity=".3" textLength="$(( ${#message} * 70 ))">${message}</text>
+    <text x="${mcx}" y="140" transform="scale(.1)" textLength="$(( ${#message} * 70 ))">${message}</text>
   </g>
 </svg>
 EOF


### PR DESCRIPTION
Two follow-up fixes to the self-hosted badges (#17):

- **SVG text was invisible** (badge showed as a coloured bar, no text) on the Pages site. The text used `font-size="11"` with `transform="scale(.1)"`, shrinking it to ~1px. Switched to the shields flat template's 10× coordinate system (`font-size="110"`, `y="140/150"`) so `scale(.1)` brings it back to 11px; text now renders centered via `textLength`.
- **No badge on the GitHub README.** The frontpage referenced `./version.svg` / `./coverage.svg` (relative) — which only resolve on the Pages site. GitHub renders `docs/README.md` as the repo readme (there's no root README) and 404'd them. Now referenced by absolute Pages URL (`https://stochadex.github.io/*.svg`), so both GitHub and the Pages site load the live SVGs from gh-pages.

After merge, the site rebuild republishes the corrected `version.svg`/`coverage.svg` to gh-pages and both surfaces pick them up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)