### PR TITLE
Add concise "When to use it" to the docs frontpage (2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ an exact version rather than assume stability across minors.
 ## [Unreleased]
 
 ### Added
+- **"When to use it" on the docs frontpage** — a short, defensible positioning section:
+  the combination stochadex uniquely offers in Go, and links ceding the ground it doesn't
+  hold (Stan/PyMC/SciML, `godes`, gonum, Python for neural-net training).
 - **Frontpage status badges.** Version (from the latest git tag), CI status, and test
   coverage badges on the docs frontpage. Coverage is published to Codecov from CI
   (`go test -coverprofile` → `codecov/codecov-action`); version and CI use shields.io.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,15 @@ For software engineers, the stochadex simulation framework abstracts away many o
 
 This simulation engine is designed based on the simulation software fundamentals described in [this collection of blog posts](https://umbralcalc.github.io/posts/simulating_real_world_systems_as_a_programmer_introduction.html).
 
+## When to use it
+
+stochadex fits when you're in [Go](https://go.dev/) and want stochastic simulation, online Bayesian inference, and simulation-based decision-making (MCTS) together over one composable primitive and a single deployable binary — a combination no other Go library offers. Reach for something else when:
+
+- **Large fixed-shape, GPU, or autodiff-heavy Bayesian modelling** → [Stan](https://mc-stan.org/), [PyMC](https://www.pymc.io/), or Julia's [SciML](https://sciml.ai/).
+- **Pure discrete-event simulation** (entities through queues and servers) → [godes](https://github.com/agoussia/godes).
+- **Plain numerics or classical ML in Go** → [gonum](https://github.com/gonum/gonum), which stochadex is built on.
+- **Training neural networks or deep RL** → train in Python, then import a frozen ONNX/TorchScript model to run inference behind an `Iteration`.
+
 ## Projects using the software
 
 - [Event-based rugby match simulations to evaluate manager decision-making](https://github.com/umbralcalc/trywizard)

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,14 +17,16 @@ This simulation engine is designed based on the simulation software fundamentals
 
 ## When to use it
 
-stochadex fits when you're in [Go](https://go.dev/) and want stochastic simulation, online Bayesian inference, and simulation-based decision-making (MCTS) together over one composable primitive and a single deployable binary — a combination no other Go library offers. Reach for something else when:
+The stochadex fits best when you're in [Go](https://go.dev/) and want stochastic simulation and online inference or simulation-based decision-making (like MCTS) together over one composable primitive and a single deployable binary. This is a combination no other Go library offers (to our knowledge).
+
+It's a powerful framework with tons of features, really generalisable abstractions and principled design. However, you should probably reach for something else when:
 
 - **Large fixed-shape, GPU, or autodiff-heavy Bayesian modelling** → [Stan](https://mc-stan.org/), [PyMC](https://www.pymc.io/), or Julia's [SciML](https://sciml.ai/).
 - **Pure discrete-event simulation** (entities through queues and servers) → [godes](https://github.com/agoussia/godes).
-- **Plain numerics or classical ML in Go** → [gonum](https://github.com/gonum/gonum), which stochadex is built on.
+- **Plain numerics or classical ML in Go** → [gonum](https://github.com/gonum/gonum), which the stochadex is built on.
 - **Training neural networks or deep RL** → train in Python, then import a frozen ONNX/TorchScript model to run inference behind an `Iteration`.
 
-## Projects using the software
+## Projects using it
 
 - [Event-based rugby match simulations to evaluate manager decision-making](https://github.com/umbralcalc/trywizard)
 - [Fish ecosystem simulations using environment data to evaluate sustanability policies](https://github.com/umbralcalc/anglersim)


### PR DESCRIPTION
PLAN.md step **2.1 — positioning**, reworked per feedback: instead of a long, introspective standalone `WHEN_TO_USE.md`, a **short, defensible section on the docs frontpage README**.

Adds a "When to use it" section: the one combination stochadex uniquely offers in Go, and four crisp "reach for something else when…" bullets with links — [Stan](https://mc-stan.org/)/[PyMC](https://www.pymc.io/)/[SciML](https://sciml.ai/) for large/GPU/autodiff Bayesian work, [godes](https://github.com/agoussia/godes) for discrete-event sim, [gonum](https://github.com/gonum/gonum) for plain numerics, and Python for neural-net training (import a frozen ONNX/TorchScript model for inference).

Claims were verified, not copied: godes is an active DES incumbent since 2013; Go has Bayesian optimization and naive-Bayes but no online simulation-based inference framework — hence the precise "combination no other Go library offers".

🤖 Generated with [Claude Code](https://claude.com/claude-code)