### PR TITLE
Fix race in JsonLogChannelOutputFunction.Close flushing

### DIFF
--- a/pkg/simulator/output.go
+++ b/pkg/simulator/output.go
@@ -140,6 +140,7 @@ func NewJsonLogOutputFunction(
 // goroutine using a channel for improved throughput.
 type JsonLogChannelOutputFunction struct {
 	logChannel chan JsonLogEntry
+	done       chan struct{}
 }
 
 func (j *JsonLogChannelOutputFunction) Configure(*Settings) {}
@@ -160,8 +161,12 @@ func (j *JsonLogChannelOutputFunction) Output(
 }
 
 // Close flushes and stops the background writer. Defer it after construction.
+// It blocks until the writer goroutine has drained the channel and flushed
+// every buffered entry to the file, so callers may read the file once Close
+// returns.
 func (j *JsonLogChannelOutputFunction) Close() {
 	close(j.logChannel)
+	<-j.done
 }
 
 // NewJsonLogChannelOutputFunction creates a JsonLogChannelOutputFunction.
@@ -170,12 +175,15 @@ func NewJsonLogChannelOutputFunction(
 	filePath string,
 ) *JsonLogChannelOutputFunction {
 	logChannel := make(chan JsonLogEntry)
+	done := make(chan struct{})
 	file, err := os.Create(filePath)
 	if err != nil {
 		log.Fatal("Error creating log file:", err)
 		panic(err)
 	}
 	go func() {
+		defer close(done)
+		defer file.Close()
 		for logEntry := range logChannel {
 			jsonData, err := json.Marshal(logEntry)
 			if err != nil {
@@ -188,7 +196,7 @@ func NewJsonLogChannelOutputFunction(
 			}
 		}
 	}()
-	return &JsonLogChannelOutputFunction{logChannel: logChannel}
+	return &JsonLogChannelOutputFunction{logChannel: logChannel, done: done}
 }
 
 // WebsocketOutputFunction serialises and sends outputs via a websocket


### PR DESCRIPTION
## Problem

`TestJsonLogChannelOutputFunction` failed on `main` in CI under `-race` ([run #29397045171](https://github.com/umbralcalc/stochadex/actions/runs/29397045171)) with `got 0 entries, want 1`.

This is a **real race**, not merely a flaky test. `JsonLogChannelOutputFunction` writes entries on a background goroutine via a channel. `Close()` closed the channel but returned immediately without waiting for the writer goroutine to drain it and flush to disk. The test reads the file right after `Close()`, so when the goroutine hadn't been scheduled yet, the file was empty. Earlier runs passed by scheduling luck; the `-race` build perturbed timing enough to expose it.

## Fix

- Add a `done` channel the writer goroutine closes (via `defer`) when it returns.
- `Close()` now blocks on `<-done` after closing the log channel, so every buffered entry is flushed before `Close()` returns — callers may safely read the file once `Close()` returns.
- Also `defer file.Close()` in the writer goroutine (the file was previously never closed — a latent leak).

## Verification

- The previously-failing test passes 20/20 under `-race`.
- `pkg/simulator` + `pkg/api` pass 10× consecutively under `-race`.
- Reviewed the other tests added in #27 for similar flakiness; this channel test was the only concurrent one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)