### PR TITLE
Rewrite quickstart to lead with a runnable win (2.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,12 @@ an exact version rather than assume stability across minors.
   (Superseded the short-lived self-hosted-SVG badge approach.)
 
 ### Changed
+- **Quickstart rewritten to lead with a win (2.4).** The quickstart now opens with a complete,
+  runnable ~25-line Go program (a recorded random walk that prints its output) before any
+  partition/iteration/history vocabulary — then backfills that worldview, points at where
+  results flow (CSV/DB/Arrow → pandas/DuckDB), and demotes the CLI/YAML/Docker path to a
+  secondary section. Directly targets the plan's "biggest bounce risk is the mental model —
+  lead with a win, explain second." The example is verified to run and produce the shown output.
 - **Clean `database/sql` write path (2.3.c).** `analysis.PostgresDb` now accepts a
   caller-provided `*sql.DB` (new exported `DB` field + `NewPostgresDb(db, table)` constructor);
   `OpenTableConnection` only opens a local Postgres from `User`/`Password`/`Dbname` when no

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -14,7 +14,7 @@ Add the module:
 go get github.com/umbralcalc/stochadex
 ```
 
-Then this is a complete, runnable program — a random walk advanced for five steps, with every step recorded and printed:
+Then this is a complete, runnable program: a random walk advanced for five steps, with every step recorded and printed:
 
 ```go
 package main
@@ -71,25 +71,25 @@ That is a working stochastic simulation. Change `MaxNumberOfSteps` for a longer 
 
 Three ideas, in the order they appear above:
 
-- A **partition** is one component of the simulation — here, the single `walk`. A simulation is a *set* of partitions advancing together each step; add more `SetPartition` calls to run and couple several.
-- An **`Iteration`** is the rule that advances a partition one step. `WienerProcessIteration` is one of many built in — but you write your own by implementing the two-method [`Iteration`](https://stochadex.github.io/pkg/simulator.html#Iteration) interface (`Configure` once, `Iterate` each step), and it slots in exactly the same way. This one interface is what the whole engine is built on.
-- The **state history** is what each partition remembers. `StateHistoryDepth: 1` keeps only the latest value; a larger depth lets an iteration read its own past (needed for memory-ful processes like Hawkes). The `OutputFunction` copies each step into storage so you can read it back — as above, or straight to CSV, a database, or Apache Arrow.
+- A **partition** is one component of the simulation (here, the single `walk`). A simulation is a *set* of partitions advancing together each step; add more `SetPartition` calls to run and couple several.
+- An **`Iteration`** is the rule that advances a partition one step. `WienerProcessIteration` is one of many built in, but you write your own by implementing the two-method [`Iteration`](https://stochadex.github.io/pkg/simulator.html#Iteration) interface (`Configure` once, `Iterate` each step), and it slots in exactly the same way. This one interface is what the whole engine is built on.
+- The **state history** is what each partition remembers. `StateHistoryDepth: 1` keeps only the latest value; a larger depth lets an iteration read its own past (needed for memory-ful processes like Hawkes). The `OutputFunction` copies each step into storage so you can read it back, as above, or straight to CSV, a database, or Apache Arrow.
 
-For the full picture — coupling partitions, writing custom iterations, and worked examples (Itô's lemma, Hawkes processes, embedded simulations, online parameter inference) — see [How it works](https://stochadex.github.io/pkg/how_it_works.html).
+See [How it works](https://stochadex.github.io/pkg/how_it_works.html) for the full picture: coupling partitions, writing custom iterations, and worked examples (Itô's lemma, Hawkes processes, embedded simulations, online parameter inference).
 
 ## Where the results go
 
 The `walk` output above is plain `[][]float64`, but the same recorded run flows straight into the data ecosystem:
 
-- **CSV / DataFrame / JSON logs** — the [`analysis`](https://stochadex.github.io/pkg/analysis.html) package reads and writes these directly.
-- **PostgreSQL / TimescaleDB / QuestDB** — write output to, or load history from, any Postgres-wire database (supply your own `*sql.DB`).
-- **Apache Arrow → Polars / pandas / DuckDB** — the opt-in [`arrowstore`](https://stochadex.github.io/pkg/arrowstore.html) module builds Arrow directly, for zero-conversion columnar interchange.
+- **CSV / DataFrame / JSON logs**: the [`analysis`](https://stochadex.github.io/pkg/analysis.html) package reads and writes these directly.
+- **PostgreSQL / TimescaleDB / QuestDB**: write output to, or load history from, any Postgres-wire database (supply your own `*sql.DB`).
+- **Apache Arrow → Polars / pandas / DuckDB**: the opt-in [`arrowstore`](https://stochadex.github.io/pkg/arrowstore.html) module builds Arrow directly, for zero-conversion columnar interchange.
 
 See the [Integrations table](https://stochadex.github.io/#integrations) for the full set.
 
 ## Running from a config file
 
-You can also drive the engine from YAML instead of Go — build the CLI once and point it at a config:
+You can also drive the engine from YAML instead of Go. Build the CLI once and point it at a config:
 
 ```bash
 git clone git@github.com:umbralcalc/stochadex.git && cd stochadex

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,43 +6,108 @@ logo: true
 # Quickstart
 <div style="height:0.75em;"></div>
 
-## Cloning the repository
+## Your first simulation
+
+Add the module:
 
 ```bash
-git clone git@github.com:umbralcalc/stochadex.git
-cd stochadex
+go get github.com/umbralcalc/stochadex
 ```
 
-## Building and running the binary
+Then this is a complete, runnable program — a random walk advanced for five steps, with every step recorded and printed:
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/umbralcalc/stochadex/pkg/continuous"
+	"github.com/umbralcalc/stochadex/pkg/simulator"
+)
+
+func main() {
+	gen := simulator.NewConfigGenerator()
+
+	// One component: a Wiener process (random walk) starting at 0.
+	gen.SetPartition(&simulator.PartitionConfig{
+		Name:              "walk",
+		Iteration:         &continuous.WienerProcessIteration{},
+		Params:            simulator.NewParams(map[string][]float64{"variances": {1.0}}),
+		InitStateValues:   []float64{0.0},
+		StateHistoryDepth: 1,
+		Seed:              42,
+	})
+
+	// Run for five steps, recording every step into storage.
+	store := simulator.NewStateTimeStorage()
+	gen.SetSimulation(&simulator.SimulationConfig{
+		OutputCondition:      &simulator.EveryStepOutputCondition{},
+		OutputFunction:       &simulator.StateTimeStorageOutputFunction{Store: store},
+		TerminationCondition: &simulator.NumberOfStepsTerminationCondition{MaxNumberOfSteps: 5},
+		TimestepFunction:     &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+	})
+	simulator.NewPartitionCoordinator(gen.GenerateConfigs()).Run()
+
+	fmt.Println("times:", store.GetTimes())
+	fmt.Println("walk: ", store.GetValues("walk"))
+}
+```
+
+Run it:
 
 ```bash
-# Update the go modules
-go mod tidy
+go run .
+```
 
-# Build the binary
+```
+times: [0 1 2 3 4 5]
+walk:  [[0] [-0.27282789148858066] [-1.3375369499117022] [-2.548435603601376] [-0.6832544462398817] [-0.3886233811019282]]
+```
+
+That is a working stochastic simulation. Change `MaxNumberOfSteps` for a longer run, `variances` for a wilder walk, or `Seed` for a different trajectory.
+
+## What you just built
+
+Three ideas, in the order they appear above:
+
+- A **partition** is one component of the simulation — here, the single `walk`. A simulation is a *set* of partitions advancing together each step; add more `SetPartition` calls to run and couple several.
+- An **`Iteration`** is the rule that advances a partition one step. `WienerProcessIteration` is one of many built in — but you write your own by implementing the two-method [`Iteration`](https://stochadex.github.io/pkg/simulator.html#Iteration) interface (`Configure` once, `Iterate` each step), and it slots in exactly the same way. This one interface is what the whole engine is built on.
+- The **state history** is what each partition remembers. `StateHistoryDepth: 1` keeps only the latest value; a larger depth lets an iteration read its own past (needed for memory-ful processes like Hawkes). The `OutputFunction` copies each step into storage so you can read it back — as above, or straight to CSV, a database, or Apache Arrow.
+
+For the full picture — coupling partitions, writing custom iterations, and worked examples (Itô's lemma, Hawkes processes, embedded simulations, online parameter inference) — see [How it works](https://stochadex.github.io/pkg/how_it_works.html).
+
+## Where the results go
+
+The `walk` output above is plain `[][]float64`, but the same recorded run flows straight into the data ecosystem:
+
+- **CSV / DataFrame / JSON logs** — the [`analysis`](https://stochadex.github.io/pkg/analysis.html) package reads and writes these directly.
+- **PostgreSQL / TimescaleDB / QuestDB** — write output to, or load history from, any Postgres-wire database (supply your own `*sql.DB`).
+- **Apache Arrow → Polars / pandas / DuckDB** — the opt-in [`arrowstore`](https://stochadex.github.io/pkg/arrowstore.html) module builds Arrow directly, for zero-conversion columnar interchange.
+
+See the [Integrations table](https://stochadex.github.io/#integrations) for the full set.
+
+## Running from a config file
+
+You can also drive the engine from YAML instead of Go — build the CLI once and point it at a config:
+
+```bash
+git clone git@github.com:umbralcalc/stochadex.git && cd stochadex
 go build -o bin/ ./cmd/stochadex
-
-# Run your config
 ./bin/stochadex --config ./cfg/example_config.yaml
 ```
 
-## Running over websocket
+Stream results over a websocket (for live dashboards):
 
 ```bash
-# Run the stochadex with a socket config
-./bin/stochadex --config ./cfg/example_config.yaml \
-    --socket ./cfg/socket.yaml
+./bin/stochadex --config ./cfg/example_config.yaml --socket ./cfg/socket.yaml
 ```
 
-## Building and running the containerised version (may need sudo)
+Or run it containerised (may need `sudo`):
 
 ```bash
-# Build the stochadex container
 docker build -t stochadex -f Dockerfile.stochadex .
-
-# Run the binary in the container with your configs
-docker run -p 2112:2112 stochadex --config ./cfg/example_config.yaml \
-    --socket ./cfg/socket.yaml
+docker run -p 2112:2112 stochadex --config ./cfg/example_config.yaml --socket ./cfg/socket.yaml
 ```
 
 ## Example analysis notebooks


### PR DESCRIPTION
Plan item **2.4 (onboarding)** — the quickstart.

## The problem

The old quickstart was a *"clone the repo, build the CLI, run `example_config.yaml`"* guide. It led with repo-cloning and an opaque YAML config, and assumed the partition/iteration/history vocabulary. The plan is explicit that the idiosyncratic mental model is the **biggest bounce risk** — so lead with a win, explain second.

## The rewrite

1. **Lead with the win** — `go get` + a complete, runnable ~25-line Go program: a recorded random walk that prints its output. Copy, `go run`, see numbers.
2. **Backfill the worldview *after*** — the three ideas in the order they appear in the code (a **partition**, the **`Iteration`** interface, the **state history**), then a link to *How it works* for depth.
3. **Where results go** — points at the permeability already delivered by 2.3 (CSV/DB, and Arrow → Polars/pandas/DuckDB).
4. **CLI/YAML/websocket/Docker path kept but demoted** below the code-first win — not deleted, just no longer the front door.

## Verified

The **exact** Go code block from the page runs and produces the output shown on the page (`times: [0 1 2 3 4 5]` + the walk values); the page renders cleanly through pandoc; all cross-page links are absolute so they resolve from `pkg/quickstart.html`.

Docs-only change. The permeability half of 2.4 was already delivered by 2.3, and the WASM angle is deliberately Phase 3 — so this is the whole of 2.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)