### PR TITLE
Make every execution strategy steppable (0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ an exact version rather than assume stability across minors.
 
 ## [Unreleased]
 
+## [0.3.0] — 2026-07-17
+
 ### Added
 - **Opt-in Apache Arrow egress (`pkg/arrowstore`, a separate module).** An Arrow-native
   `simulator.OutputFunction` + storage (`ArrowStateTimeStorage`) at the output boundary, kept
@@ -75,6 +77,24 @@ an exact version rather than assume stability across minors.
   (Superseded the short-lived self-hosted-SVG badge approach.)
 
 ### Changed
+- **Every execution strategy is now steppable (breaking: the `ExecutionStrategy`
+  interface).** Execution strategies previously owned the whole run loop via a single
+  `Run(c)` method, so selecting `PersistentWorkerExecution` or `InlineExecution` silently
+  gave up the step-by-step driving the default algorithm supports — the interactive,
+  keyboard, websocket, and embedded paths, plus the harness's per-step checks, all fell back
+  to default execution. The interface's single primitive is now `NewStepper(c) Stepper`
+  (`Stepper` is `{ Step(); Close() }`), which holds whatever per-run state the policy needs
+  (e.g. persistent worker goroutines) and advances exactly one committed tick per `Step`.
+  Both batch `PartitionCoordinator.Run` and the new stepwise
+  `PartitionCoordinator.NewStepper` are expressed in terms of it, so **any** strategy can be
+  driven one step at a time exactly as the default can — dropping `Run` from the interface
+  makes steppability structural rather than per-strategy. The test harness now runs its
+  per-step correctness checks (params mutation, NaN, state width, history integrity) under
+  *every* strategy instead of only the default, and the websocket run path honours the
+  configured strategy. Output stays byte-identical and performance is unchanged (benchstat
+  over 8 runs: timing within run-to-run noise, allocations flat — the one extra `Stepper`
+  allocation is per-run, not per-step). `PartitionCoordinator.Step(wg)` is retained for the
+  default single-step path.
 - **Quickstart rewritten to lead with a win (2.4).** The quickstart now opens with a complete,
   runnable ~25-line Go program (a recorded random walk that prints its output) before any
   partition/iteration/history vocabulary — then backfills that worldview, points at where
@@ -294,6 +314,7 @@ treat the intermediates as internal, never shipped API.
   stochastic-process formalism (diffusions, Poisson noise, windowed history for noise
   dependencies) before any Go engine existed. The pivot to Go begins Feb 2023.
 
-[Unreleased]: https://github.com/umbralcalc/stochadex/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/umbralcalc/stochadex/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/umbralcalc/stochadex/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/umbralcalc/stochadex/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/umbralcalc/stochadex/releases/tag/v0.1.0

--- a/pkg/api/run.go
+++ b/pkg/api/run.go
@@ -47,10 +47,13 @@ func StepAndServeWebsocket(
 				generator.GenerateConfigs(),
 			)
 
-			var wg sync.WaitGroup
+			// step under the configured execution strategy, sleeping between
+			// steps so the websocket streams state at a watchable rate
+			stepper := coordinator.NewStepper()
+			defer stepper.Close()
 			// terminate the for loop if the condition has been met
 			for !coordinator.ReadyToTerminate() {
-				coordinator.Step(&wg)
+				stepper.Step()
 				time.Sleep(stepDelay * time.Millisecond)
 			}
 		},

--- a/pkg/simulator/coordinator.go
+++ b/pkg/simulator/coordinator.go
@@ -51,10 +51,11 @@ import (
 //	// Run simulation until termination
 //	coordinator.Run()
 //
-//	// Or step-by-step control
+//	// Or step-by-step control under the configured execution strategy
+//	stepper := coordinator.NewStepper()
+//	defer stepper.Close()
 //	for !coordinator.ReadyToTerminate() {
-//	    var wg sync.WaitGroup
-//	    coordinator.Step(&wg)
+//	    stepper.Step()
 //	}
 //
 // Performance:
@@ -111,6 +112,25 @@ func (c *PartitionCoordinator) UpdateHistory(wg *sync.WaitGroup) {
 		channel <- c.Shared
 	}
 
+	c.advanceTimestepsHistory()
+}
+
+// beginStep opens a simulation tick: it advances the step counter and computes
+// the next timestep increment. It is the shared prologue of every strategy's
+// Stepper (and of Step), so the "how do we start a step" logic lives in one
+// place.
+func (c *PartitionCoordinator) beginStep() {
+	c.Shared.TimestepsHistory.CurrentStepNumber += 1
+	c.Shared.TimestepsHistory.NextIncrement = c.TimestepFunction.NextIncrement(
+		c.Shared.TimestepsHistory,
+	)
+}
+
+// advanceTimestepsHistory closes a simulation tick: it shifts the timesteps
+// history back one and appends the next time value. It is the shared epilogue
+// of every strategy's Stepper (and of UpdateHistory), so the "how do we commit
+// the new time" logic lives in one place.
+func (c *PartitionCoordinator) advanceTimestepsHistory() {
 	// iterate over the history of timesteps and shift them back one
 	for i := c.Shared.TimestepsHistory.StateHistoryDepth - 1; i > 0; i-- {
 		c.Shared.TimestepsHistory.Values.SetVec(i,
@@ -122,14 +142,14 @@ func (c *PartitionCoordinator) UpdateHistory(wg *sync.WaitGroup) {
 			c.Shared.TimestepsHistory.NextIncrement)
 }
 
-// Step performs one simulation tick: compute dt, request iterations, then
-// apply state/time updates.
+// Step performs one simulation tick under the default spawn-per-step execution:
+// compute dt, request iterations, then apply state/time updates. It is the
+// single-step primitive the SpawnPerStepExecution stepper delegates to; other
+// strategies advance a step through their own Stepper. Callers that want to
+// drive a step under the coordinator's configured strategy should use
+// NewStepper instead.
 func (c *PartitionCoordinator) Step(wg *sync.WaitGroup) {
-	// update the overall step count and get the next time increment
-	c.Shared.TimestepsHistory.CurrentStepNumber += 1
-	c.Shared.TimestepsHistory.NextIncrement = c.TimestepFunction.NextIncrement(
-		c.Shared.TimestepsHistory,
-	)
+	c.beginStep()
 
 	// begin by requesting iterations for the next step and waiting
 	c.RequestMoreIterations(wg)
@@ -148,22 +168,40 @@ func (c *PartitionCoordinator) ReadyToTerminate() bool {
 	)
 }
 
-// Run advances by repeatedly calling Step until termination.
+// NewStepper returns a Stepper that advances the coordinator one step at a
+// time under its configured RunStrategy (a nil RunStrategy selects the default
+// spawn-per-step execution). This is the strategy-aware counterpart to Step:
+// it lets callers drive any execution strategy stepwise — inspecting or
+// mutating state between steps — exactly as the default algorithm can be driven
+// with Step, while keeping that strategy's execution policy (persistent
+// workers, inline execution, ...).
 //
-// When RunStrategy is non-nil it owns the whole run loop; otherwise Run uses
-// the default spawn-per-step two-phase execution that is equivalent to
-// repeatedly calling Step.
-func (c *PartitionCoordinator) Run() {
+// The caller drives Step until ReadyToTerminate reports true and must call the
+// stepper's Close when done to release any resources it holds:
+//
+//	stepper := coordinator.NewStepper()
+//	defer stepper.Close()
+//	for !coordinator.ReadyToTerminate() {
+//	    stepper.Step()
+//	}
+func (c *PartitionCoordinator) NewStepper() Stepper {
 	if c.RunStrategy != nil {
-		c.RunStrategy.Run(c)
-		return
+		return c.RunStrategy.NewStepper(c)
 	}
+	return (&SpawnPerStepExecution{}).NewStepper(c)
+}
 
-	var wg sync.WaitGroup
+// Run advances the coordinator to termination under its configured RunStrategy
+// (a nil RunStrategy selects the default spawn-per-step two-phase execution).
+// It is the canonical run loop shared by every strategy: build a Stepper, step
+// until termination, then release the stepper.
+func (c *PartitionCoordinator) Run() {
+	stepper := c.NewStepper()
+	defer stepper.Close()
 
 	// terminate the for loop if the condition has been met
 	for !c.ReadyToTerminate() {
-		c.Step(&wg)
+		stepper.Step()
 	}
 }
 

--- a/pkg/simulator/execution.go
+++ b/pkg/simulator/execution.go
@@ -2,41 +2,86 @@ package simulator
 
 import "sync"
 
-// ExecutionStrategy drives a PartitionCoordinator's Run loop.
+// ExecutionStrategy chooses how a PartitionCoordinator advances — the policy
+// for turning per-partition work into completed steps (spawn a goroutine per
+// partition per step, keep one persistent worker per partition, run everything
+// inline on the calling goroutine, ...).
 //
 // A nil ExecutionStrategy on a coordinator (or on Implementations) selects the
-// default spawn-per-step two-phase execution, which is exactly equivalent to
-// repeatedly calling Step until termination. Strategies only ever change how
-// Run advances the simulation; single Step semantics are never affected, so
-// callers that drive a coordinator one Step at a time (including the test
-// harnesses) always observe the default behaviour.
-//
-// Every strategy must produce byte-identical output to the default for the
-// same Settings and Implementations: a strategy is purely an execution-policy
-// choice, not a semantic one. This invariant is enforced by the cross-strategy
+// default spawn-per-step two-phase execution. A strategy is purely an
+// execution-policy choice, not a semantic one: every strategy must produce
+// byte-identical output to the default for the same Settings and
+// Implementations. This invariant is enforced by the cross-strategy
 // equivalence tests.
+//
+// A strategy's single primitive is NewStepper, which builds a Stepper holding
+// whatever per-run state the policy needs. Both batch execution
+// (PartitionCoordinator.Run) and manual stepwise driving
+// (PartitionCoordinator.NewStepper) are expressed in terms of it, so every
+// strategy is steppable in exactly the same way the default two-phase
+// algorithm is — there is no strategy that can only run to termination.
 type ExecutionStrategy interface {
-	// Run advances the coordinator from its current state until its
-	// TerminationCondition is met.
-	Run(c *PartitionCoordinator)
+	// NewStepper returns a Stepper that advances c one step at a time under
+	// this strategy's execution policy.
+	NewStepper(c *PartitionCoordinator) Stepper
+}
+
+// Stepper advances a PartitionCoordinator one step at a time under a specific
+// ExecutionStrategy's policy. It owns the per-run state that policy needs —
+// e.g. the persistent worker goroutines of PersistentWorkerExecution — which
+// is why stepping is a distinct object rather than a bare coordinator method:
+// that state lives across steps and must be released with Close when the run
+// ends.
+//
+// Typical stepwise use, which mirrors the default algorithm's step-by-step
+// control but keeps the chosen strategy's execution policy:
+//
+//	stepper := coordinator.NewStepper()
+//	defer stepper.Close()
+//	for !coordinator.ReadyToTerminate() {
+//	    stepper.Step()
+//	    // inspect or mutate state between steps here (keyboard input,
+//	    // external coupling, output throttling, per-step assertions, ...)
+//	}
+//
+// Step advances by exactly one simulation tick — compute the next timestep
+// increment, run the iteration phase for every partition, then the update
+// phase — leaving the coordinator in the same committed state the default
+// algorithm reaches after one Step. Close releases resources and must be
+// called exactly once; Step must not be called after Close.
+type Stepper interface {
+	Step()
+	Close()
 }
 
 // SpawnPerStepExecution is the default execution strategy: each step spawns one
 // goroutine per partition for the iteration phase and again for the update
 // phase, synchronised by a two-phase barrier. It is the named, explicitly
-// selectable form of the behaviour Run uses when no strategy is configured.
+// selectable form of the behaviour used when no strategy is configured.
 //
 // This strategy is stateless and safe to share across coordinators.
 type SpawnPerStepExecution struct{}
 
-// Run advances the coordinator until termination using the default
-// spawn-per-step two-phase execution.
-func (e *SpawnPerStepExecution) Run(c *PartitionCoordinator) {
-	var wg sync.WaitGroup
-	for !c.ReadyToTerminate() {
-		c.Step(&wg)
-	}
+// NewStepper returns a Stepper that advances the coordinator using the default
+// spawn-per-step two-phase execution (one goroutine per partition per phase).
+func (e *SpawnPerStepExecution) NewStepper(c *PartitionCoordinator) Stepper {
+	return &spawnPerStepStepper{coordinator: c}
 }
+
+// spawnPerStepStepper delegates each step to PartitionCoordinator.Step, which
+// spawns the per-phase goroutines. The reused WaitGroup carries no state
+// between steps (it always returns to zero), so Close is a no-op.
+type spawnPerStepStepper struct {
+	coordinator *PartitionCoordinator
+	waitGroup   sync.WaitGroup
+}
+
+// Step advances the coordinator by one spawn-per-step tick.
+func (s *spawnPerStepStepper) Step() { s.coordinator.Step(&s.waitGroup) }
+
+// Close releases the stepper. Spawn-per-step holds no long-lived resources, so
+// this does nothing.
+func (s *spawnPerStepStepper) Close() {}
 
 // PersistentWorkerExecution runs the simulation with one long-lived goroutine
 // per partition rather than spawning a fresh goroutine per partition per phase
@@ -51,81 +96,90 @@ func (e *SpawnPerStepExecution) Run(c *PartitionCoordinator) {
 // serial floor for trivially small per-step work.
 //
 // Output is byte-identical to the default strategy: the per-partition work and
-// the barrier ordering are unchanged; only the goroutine lifetime differs.
+// the barrier ordering are unchanged; only the goroutine lifetime differs. The
+// workers are spawned by NewStepper and torn down by the returned Stepper's
+// Close, so a stepwise caller keeps the same persistent workers across every
+// Step rather than paying setup per step.
 //
 // This strategy is stateless and safe to share across coordinators; all
-// per-run state is created inside Run.
+// per-run state lives on the Stepper.
 type PersistentWorkerExecution struct{}
 
-// Run spins up one worker goroutine per partition, advances the simulation
-// through the two-phase barrier each step, then tears the workers down.
-func (e *PersistentWorkerExecution) Run(c *PartitionCoordinator) {
-	numPartitions := len(c.Iterators)
-
-	// quit is closed once the run loop has finished so workers blocked waiting
-	// for the next wake-up return instead of leaking.
-	quit := make(chan struct{})
-	var iterateWaitGroup, updateWaitGroup sync.WaitGroup
-
+// NewStepper spins up one long-lived worker goroutine per partition and returns
+// a Stepper that drives them through the two-phase barrier each Step. The
+// workers run until the Stepper's Close is called.
+func (e *PersistentWorkerExecution) NewStepper(c *PartitionCoordinator) Stepper {
+	s := &persistentWorkerStepper{
+		coordinator: c,
+		// quit is closed by Close so workers blocked waiting for the next
+		// iteration-phase wake-up return instead of leaking.
+		quit: make(chan struct{}),
+	}
 	for partitionIndex, iterator := range c.Iterators {
 		go func(partitionIndex int, iterator *StateIterator) {
 			workChannel := c.newWorkChannels[partitionIndex]
 			for {
 				// Iteration-phase wake-up. This is the only point at which a
-				// worker is parked when the run loop finishes, so it is the
-				// only receive that needs to be quit-aware.
+				// worker is parked between steps, so it is the only receive
+				// that needs to be quit-aware.
 				var message *IteratorInputMessage
 				select {
-				case <-quit:
+				case <-s.quit:
 					return
 				case message = <-workChannel:
 				}
 				iterator.IteratePending(message)
-				iterateWaitGroup.Done()
+				s.iterateWaitGroup.Done()
 
-				// Update-phase wake-up. The run loop always sends the update
-				// wake-up before it can terminate, so a plain receive is safe
-				// here and avoids the extra select overhead.
+				// Update-phase wake-up. A Step always sends the update wake-up
+				// before it returns, so a plain receive is safe here and avoids
+				// the extra select overhead.
 				iterator.ApplyHistoryUpdate(<-workChannel)
-				updateWaitGroup.Done()
+				s.updateWaitGroup.Done()
 			}
 		}(partitionIndex, iterator)
 	}
-
-	for !c.ReadyToTerminate() {
-		// update the overall step count and get the next time increment
-		c.Shared.TimestepsHistory.CurrentStepNumber += 1
-		c.Shared.TimestepsHistory.NextIncrement =
-			c.TimestepFunction.NextIncrement(c.Shared.TimestepsHistory)
-
-		// iteration phase: wake every worker, then wait for all to finish
-		iterateWaitGroup.Add(numPartitions)
-		for _, channel := range c.newWorkChannels {
-			channel <- c.Shared
-		}
-		iterateWaitGroup.Wait()
-
-		// update phase: wake every worker, then wait for all to finish
-		updateWaitGroup.Add(numPartitions)
-		for _, channel := range c.newWorkChannels {
-			channel <- c.Shared
-		}
-		updateWaitGroup.Wait()
-
-		// iterate over the history of timesteps and shift them back one
-		for i := c.Shared.TimestepsHistory.StateHistoryDepth - 1; i > 0; i-- {
-			c.Shared.TimestepsHistory.Values.SetVec(i,
-				c.Shared.TimestepsHistory.Values.AtVec(i-1))
-		}
-		// now update the history with the next time increment
-		c.Shared.TimestepsHistory.Values.SetVec(0,
-			c.Shared.TimestepsHistory.Values.AtVec(0)+
-				c.Shared.TimestepsHistory.NextIncrement)
-	}
-
-	// every worker is now blocked on an iteration-phase wake-up; release them
-	close(quit)
+	return s
 }
+
+// persistentWorkerStepper drives the long-lived workers created by
+// NewStepper. After every Step each worker is parked on its iteration-phase
+// wake-up, so Close can release them all by closing quit.
+type persistentWorkerStepper struct {
+	coordinator      *PartitionCoordinator
+	quit             chan struct{}
+	iterateWaitGroup sync.WaitGroup
+	updateWaitGroup  sync.WaitGroup
+}
+
+// Step advances the coordinator by one tick, waking every persistent worker
+// once for the iteration phase and once for the update phase.
+func (s *persistentWorkerStepper) Step() {
+	c := s.coordinator
+	numPartitions := len(c.Iterators)
+
+	c.beginStep()
+
+	// iteration phase: wake every worker, then wait for all to finish
+	s.iterateWaitGroup.Add(numPartitions)
+	for _, channel := range c.newWorkChannels {
+		channel <- c.Shared
+	}
+	s.iterateWaitGroup.Wait()
+
+	// update phase: wake every worker, then wait for all to finish
+	s.updateWaitGroup.Add(numPartitions)
+	for _, channel := range c.newWorkChannels {
+		channel <- c.Shared
+	}
+	s.updateWaitGroup.Wait()
+
+	c.advanceTimestepsHistory()
+}
+
+// Close releases the persistent workers. Every worker is parked on an
+// iteration-phase wake-up between steps, so closing quit returns them all.
+func (s *persistentWorkerStepper) Close() { close(s.quit) }
 
 // InlineExecution runs the simulation entirely on the calling goroutine: no
 // worker goroutines, no channel handshakes and no WaitGroup barrier. Each step
@@ -140,13 +194,14 @@ func (e *PersistentWorkerExecution) Run(c *PartitionCoordinator) {
 // Within-step params_from_upstream edges are supported, but because inline
 // execution has no blocking channel handshake to wait on, every upstream
 // producer must be ordered before its downstream consumers: the producer's
-// staged output is read directly, so it must already have run this step. Run
-// validates this up front and panics with a clear message if any consumer is
-// ordered before (or at the same index as) one of its upstreams — which also
-// catches cycles — rather than silently reading stale values. Reorder the
-// partitions so upstreams precede consumers, or use a concurrent strategy.
-// Partitions coupled only through state-history reads (which are lag-based and
-// need no within-step handshake) are unaffected by the ordering rule.
+// staged output is read directly, so it must already have run this step.
+// NewStepper validates this up front and panics with a clear message if any
+// consumer is ordered before (or at the same index as) one of its upstreams —
+// which also catches cycles — rather than silently reading stale values.
+// Reorder the partitions so upstreams precede consumers, or use a concurrent
+// strategy. Partitions coupled only through state-history reads (which are
+// lag-based and need no within-step handshake) are unaffected by the ordering
+// rule.
 //
 // Output is byte-identical to the default strategy: the two phases are still
 // applied in order, so the iteration phase observes the previous step's
@@ -156,11 +211,13 @@ func (e *PersistentWorkerExecution) Run(c *PartitionCoordinator) {
 // This strategy is stateless and safe to share across coordinators.
 type InlineExecution struct{}
 
-// Run advances the coordinator to termination inline on the calling goroutine.
-func (e *InlineExecution) Run(c *PartitionCoordinator) {
+// NewStepper validates the partition ordering and returns a Stepper that
+// advances the coordinator inline on the calling goroutine. It panics if any
+// consumer is not ordered strictly after all of its upstreams (which also
+// rejects cycles and self-edges).
+func (e *InlineExecution) NewStepper(c *PartitionCoordinator) Stepper {
 	// Fail loudly instead of reading stale producer output if any consumer is
-	// not ordered strictly after all of its upstreams (this also rejects
-	// cycles and self-edges).
+	// not ordered strictly after all of its upstreams.
 	for consumerIndex, iterator := range c.Iterators {
 		for _, upstream := range iterator.ValueChannels.Upstreams {
 			if upstream.Upstream >= consumerIndex {
@@ -171,34 +228,39 @@ func (e *InlineExecution) Run(c *PartitionCoordinator) {
 			}
 		}
 	}
-
-	for !c.ReadyToTerminate() {
-		// update the overall step count and get the next time increment
-		c.Shared.TimestepsHistory.CurrentStepNumber += 1
-		c.Shared.TimestepsHistory.NextIncrement =
-			c.TimestepFunction.NextIncrement(c.Shared.TimestepsHistory)
-
-		// iteration phase for every partition, then update phase for every
-		// partition: the same two-phase ordering as the default strategy, so a
-		// partition that reads another's history still sees the previous
-		// step's committed values. Upstream params are read directly from
-		// producers' staged output, which the ordering check guarantees is
-		// already set this step.
-		for _, iterator := range c.Iterators {
-			iterator.IteratePendingInline(c.Shared)
-		}
-		for _, iterator := range c.Iterators {
-			iterator.ApplyHistoryUpdate(c.Shared)
-		}
-
-		// iterate over the history of timesteps and shift them back one
-		for i := c.Shared.TimestepsHistory.StateHistoryDepth - 1; i > 0; i-- {
-			c.Shared.TimestepsHistory.Values.SetVec(i,
-				c.Shared.TimestepsHistory.Values.AtVec(i-1))
-		}
-		// now update the history with the next time increment
-		c.Shared.TimestepsHistory.Values.SetVec(0,
-			c.Shared.TimestepsHistory.Values.AtVec(0)+
-				c.Shared.TimestepsHistory.NextIncrement)
-	}
+	return &inlineStepper{coordinator: c}
 }
+
+// inlineStepper advances the coordinator on the calling goroutine with no
+// concurrency, so it holds no resources and Close is a no-op.
+type inlineStepper struct {
+	coordinator *PartitionCoordinator
+}
+
+// Step advances the coordinator by one tick, running the iteration phase for
+// every partition and then the update phase for every partition, in index
+// order, on the calling goroutine.
+func (s *inlineStepper) Step() {
+	c := s.coordinator
+
+	c.beginStep()
+
+	// iteration phase for every partition, then update phase for every
+	// partition: the same two-phase ordering as the default strategy, so a
+	// partition that reads another's history still sees the previous step's
+	// committed values. Upstream params are read directly from producers'
+	// staged output, which the ordering check guarantees is already set this
+	// step.
+	for _, iterator := range c.Iterators {
+		iterator.IteratePendingInline(c.Shared)
+	}
+	for _, iterator := range c.Iterators {
+		iterator.ApplyHistoryUpdate(c.Shared)
+	}
+
+	c.advanceTimestepsHistory()
+}
+
+// Close releases the stepper. Inline execution holds no long-lived resources,
+// so this does nothing.
+func (s *inlineStepper) Close() {}

--- a/pkg/simulator/execution_test.go
+++ b/pkg/simulator/execution_test.go
@@ -46,6 +46,41 @@ func runStrategyConfig(
 	return store
 }
 
+// stepStrategyConfig drives the given topology to termination one step at a
+// time through the strategy's Stepper (nil for the default), rather than via
+// coordinator.Run, and returns the recorded output. This is the stepwise path
+// callers use for interactive / externally-coupled runs, and it must match the
+// batch Run output exactly for every strategy.
+func stepStrategyConfig(
+	settings *Settings,
+	makeIterations func() []Iteration,
+	maxSteps int,
+	strategy ExecutionStrategy,
+) *StateTimeStorage {
+	iterations := makeIterations()
+	for index, iteration := range iterations {
+		iteration.Configure(index, settings)
+	}
+	store := NewStateTimeStorage()
+	implementations := &Implementations{
+		Iterations:      iterations,
+		OutputCondition: &EveryStepOutputCondition{},
+		OutputFunction:  &StateTimeStorageOutputFunction{Store: store},
+		TerminationCondition: &NumberOfStepsTerminationCondition{
+			MaxNumberOfSteps: maxSteps,
+		},
+		TimestepFunction:  &ConstantTimestepFunction{Stepsize: 1.0},
+		ExecutionStrategy: strategy,
+	}
+	coordinator := NewPartitionCoordinator(settings, implementations)
+	stepper := coordinator.NewStepper()
+	defer stepper.Close()
+	for !coordinator.ReadyToTerminate() {
+		stepper.Step()
+	}
+	return store
+}
+
 // assertStoresEqual fails the test unless got matches want for every partition,
 // timestep and value index exactly.
 func assertStoresEqual(t *testing.T, want, got *StateTimeStorage, label string) {
@@ -170,6 +205,26 @@ func TestExecutionStrategies(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("stepwise NewStepper matches batch Run for every strategy",
+		func(t *testing.T) {
+			// Every strategy must be driveable one Step at a time and produce
+			// the same output as its own batch Run — the property that lets
+			// interactive / externally-coupled callers pick any strategy.
+			strategies := namedStrategies()
+			strategies["default"] = nil
+			for topologyName, build := range topologies {
+				settings, makeIterations := build()
+				for strategyName, strategy := range strategies {
+					batch := runStrategyConfig(
+						settings, makeIterations, maxSteps, strategy)
+					stepwise := stepStrategyConfig(
+						settings, makeIterations, maxSteps, strategy)
+					assertStoresEqual(t, batch, stepwise,
+						"stepwise/"+topologyName+"/"+strategyName)
+				}
+			}
+		})
 
 	t.Run("default Run matches explicit SpawnPerStepExecution", func(t *testing.T) {
 		settings, makeIterations := chainSettings()

--- a/pkg/simulator/harness.go
+++ b/pkg/simulator/harness.go
@@ -2,7 +2,6 @@ package simulator
 
 import (
 	"fmt"
-	"sync"
 	"unsafe"
 
 	"gonum.org/v1/gonum/floats"
@@ -252,30 +251,24 @@ func RunWithHarnessesUsing(
 }
 
 // runHarnessedToTermination advances the coordinator to termination and
-// returns the first harness error found. For the default execution (no
-// strategy) it uses the manual Step loop so the per-step checks run between
-// every step exactly as before; for an explicit strategy it delegates the loop
-// to Run and checks the harnesses once it returns.
+// returns the first harness error found. It drives the coordinator through the
+// configured strategy's Stepper, checking the harnesses between every step, so
+// the per-step correctness checks run at the same granularity under every
+// strategy — not just the default. Between two Steps the strategy has committed
+// a full step and holds no work in flight, so inspecting the harnesses there is
+// safe for the concurrent strategies too.
 func runHarnessedToTermination(
 	coordinator *PartitionCoordinator,
 	harnesses []*IterationTestHarness,
 ) error {
-	if coordinator.RunStrategy == nil {
-		var wg sync.WaitGroup
-		for !coordinator.ReadyToTerminate() {
-			coordinator.Step(&wg)
-			for _, harness := range harnesses {
-				if harness.Err != nil {
-					return harness.Err
-				}
+	stepper := coordinator.NewStepper()
+	defer stepper.Close()
+	for !coordinator.ReadyToTerminate() {
+		stepper.Step()
+		for _, harness := range harnesses {
+			if harness.Err != nil {
+				return harness.Err
 			}
-		}
-		return nil
-	}
-	coordinator.Run()
-	for _, harness := range harnesses {
-		if harness.Err != nil {
-			return harness.Err
 		}
 	}
 	return nil


### PR DESCRIPTION
## What & why

`ExecutionStrategy` had a single method — `Run(c)` — that owned the **entire** run loop. But the default algorithm supports two modes: batch `coordinator.Run()` **and** stepwise `for !ReadyToTerminate() { Step() }`. The moment you picked `PersistentWorkerExecution` or `InlineExecution`, you lost stepwise control — those strategies baked their per-run state (worker goroutines, ordering validation) inside `Run` and never surfaced a single step. So the interactive / keyboard / websocket / embedded paths and the harness's per-step checks silently fell back to default execution.

This inverts the primitive so a strategy produces a **`Stepper`** instead of owning the loop.

## The change

- **`ExecutionStrategy` is now `NewStepper(c) Stepper`** (breaking) — `Stepper` is `{ Step(); Close() }`. It holds whatever per-run state the policy needs (e.g. persistent worker goroutines) and advances exactly one committed tick per `Step`. Dropping `Run` from the interface makes steppability **structural** — there's no strategy that can only run to termination.
- **`PartitionCoordinator.NewStepper()`** — strategy-aware stepwise driving (nil → spawn-per-step); `Run()` is now the shared `stepper := NewStepper(); for !ReadyToTerminate() { Step() }; Close()` loop. Extracted `beginStep()` / `advanceTimestepsHistory()` helpers (dedup the triplicated timestep-shift). `Step(wg)` retained for the default single-step path.
- **Harness** now drives via `NewStepper`, so per-step correctness checks (params mutation, NaN, state width, history integrity) run under **every** strategy, not just the default — a strict improvement.
- **Websocket run path** steps via `NewStepper`, honouring the configured strategy.

## Usage

```go
stepper := coordinator.NewStepper()
defer stepper.Close()
for !coordinator.ReadyToTerminate() {
    stepper.Step()
    // inspect/mutate between steps: keyboard, external coupling, throttling, assertions...
}
```

## Guarantees

- **Byte-identical output** — new test `stepwise NewStepper matches batch Run for every strategy`; existing equivalence, mis-ordered-edge panic, and `-race` long-run tests still pass.
- **No performance change** — benchstat over 8 runs (Apple M4): timing within run-to-run noise (geomean +0.7%), allocations flat. The only new cost is one `Stepper` allocation **per run**, not per step — confirmed by unchanged allocs/op.

## Release

Breaking API change → **minor** bump under the pre-1.0 versioning policy. CHANGELOG cut to **[0.3.0]** (bundles the accumulated `[Unreleased]` backlog). Tag to be applied after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)