### PR TITLE
Declarative expression iteration + api expressions field (0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,82 @@ an exact version rather than assume stability across minors.
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-07-17
+
+### Added
+- **`general.ExpressionIteration`: a whole partition specified as data (`pkg/general`).** The
+  per-step update is given as string expressions rather than Go, so a model needs no
+  compilation step and no Go toolchain — which is what lets a simulation be written by
+  something that does not write Go. The update is a small DAG: ordered `Bindings` are named
+  intermediates, then one `Outputs` expression per field. Everything is elementwise over
+  vectors with length-1 broadcasting, so one expression serves a scalar partition and a
+  10,000-element one. Expressions are parsed once at `Configure` by `go/parser`, so a
+  malformed spec is a configuration error rather than something found mid-run. Draws come from
+  `pkg/rng`, seeded exactly as a hand-written iteration's is, which is what makes a
+  declarative model comparable to compiled Go *by value* rather than only in distribution.
+  Deliberately not a general-purpose language: no assignment, no recursion, and the only
+  repetition is a bounded comprehension, so an expression always terminates.
+- **An `expressions:` root field on the API config (`pkg/api`).** Binds a declarative spec to a
+  partition by name, so a partition may omit its `iteration` exactly as an embedded-run-backed
+  one may. Unlike `iteration` — a Go expression requiring code generation — this is loaded
+  straight from YAML and evaluated at run time. Wired on `RunConfig` rather than
+  `ApiRunConfig`, so embedded runs get it too.
+- **A declarative twin for every catalogue entry (9 of 9).** Each model is now also stated as
+  data in a `declarative.yaml`, with an `expression_equivalence_test.go` proving it is the
+  *same* model rather than one that behaves similarly. Where the streams align — the common
+  case — agreement is exact to rounding (deviations of 0 to ~1e-14), so a twin reproduces its
+  card's numbers, not merely their directions. Verification is two mandatory layers, because
+  each is blind where the other sees: step-for-step catches a mis-stated formula, and re-running
+  `ObservedBehaviour()` against the declarative build catches wrong wiring, params or state
+  layout. Documented in `models/CONVENTIONS.md` §5.
+- **DSL constructs, each added because a real model proved it was needed.** `sin`/`cos`/`erf`/
+  `erfc` and `pi` (seasonality, and the Gaussian CDF a probit or exceedance probability needs);
+  `slice`/`concat` (a block inside a flat vector, and its assembly); `width`; `lag(name, n)` (a
+  partition's committed state *n* rows back, where a bare name gives only row 0); and
+  `each(n, i, expr)`, the one construct that is not elementwise — element *i* may read element
+  *i-1* (so a cohort ages), a lane's `where` is scalar and therefore lazy (so a switched-off
+  lane draws nothing), and lanes run in order (so a lane's draws interleave as a loop's do).
+
+### Changed
+- **A config key that nothing reads is now rejected (breaking: `pkg/api` config loading).**
+  `yaml.v2` ignores an unknown key in silence, so a typo, or a key left behind by an older
+  schema, did nothing at all while looking load-bearing — `state_width` sat in every config in
+  this repo doing exactly that (width comes from `init_state_values`), and `pkg/simulator`'s
+  partition fixture still named a wiring schema that no longer exists. Strict parsing alone
+  cannot express the rule, because the two views deliberately share one file and split its
+  keys: the concrete view owns `params` and `seed` but has no `iteration`, the
+  code-generation view owns `iteration` and `simulation` but has no `params`, and each rejects
+  the other's. Neither is the whole schema; their union is. A key is therefore dead only when
+  **both** views reject it, which is what is checked — needing no second copy of the schema to
+  drift out of sync. Configs carrying a dead key now panic naming it, where they previously
+  loaded and quietly ignored it.
+- **Promotion triage is no longer a frequency test (`models/CONVENTIONS.md`).** The old rule —
+  an extension recurring across several entries wants promoting — cannot fire until several
+  stubs exist. "Can the DSL express it?" is decidable on the *first* model, and splits
+  candidates in two: if it can, the bespoke Go is a convenience and promotion must be earned by
+  a measurement; if it cannot, the engine has a real capability gap and one model proves it.
+  All five gaps the catalogue surfaced are closed, and the four structural ones rhymed — every
+  one was about structured access or per-lane control of draws, the axis a strictly elementwise
+  evaluator gives up.
+- **`models/*/behaviour.go` helpers take a `stubBuilder`** so the claim suite can be *pointed
+  at* either assembly of a model rather than restated for each. `ObservedBehaviour()` keeps its
+  no-arg signature, which `cmd/model-index` detects by AST.
+
+### Fixed
+- **A NaN index silently read element 0 on arm64 and panicked on amd64
+  (`general.ExpressionIteration`).** Go leaves `int(NaN)` undefined: on arm64 it is 0, so a
+  non-finite index passed the bounds check and read the wrong element, while on amd64 it is the
+  most negative int and the same expression failed. An architecture-dependent wrong answer, in
+  a repo whose cards claim architecture stability. Every float that becomes an index or a count
+  is now checked. Found by writing a twin, not by running a model.
+- **`antimicrobial-resistance`'s card overclaimed its mechanism.** It said the selection test
+  "pins down *why* the stewardship lever works". It does not: prescribing reaches resistance
+  both by direct conversion and by competitive release, and *both* are selection-gated, so
+  switching selection off cannot separate them — deleting the model's stated causal heart
+  passes the entire claim suite. The card now says selection is *necessary* rather than
+  attributed, and names the test that does discriminate. The claim itself was always true, so
+  no generated number moved.
+
 ## [0.3.0] — 2026-07-17
 
 ### Added
@@ -314,7 +390,8 @@ treat the intermediates as internal, never shipped API.
   stochastic-process formalism (diffusions, Poisson noise, windowed history for noise
   dependencies) before any Go engine existed. The pivot to Go begins Feb 2023.
 
-[Unreleased]: https://github.com/umbralcalc/stochadex/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/umbralcalc/stochadex/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/umbralcalc/stochadex/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/umbralcalc/stochadex/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/umbralcalc/stochadex/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/umbralcalc/stochadex/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,11 +116,20 @@ models look like, and recurring bespoke extensions surface for promotion into co
 repo boundary follows the **generative/inferential split** — this engine owns the forward
 model; downstream repos own inference, data, calibration, and the decision layer.
 
-The full spec (four artifacts per entry — `card.md`, `stub.go`, `stub_test.go`, and the
-mandatory `behaviour_test.go` expected-behaviour suite — plus the actionable/structural
-response-claim taxonomy) lives in **`models/CONVENTIONS.md`**. Add entries with the
-`/new-model` skill; the reference entries are `models/antimicrobial-resistance/`,
-`models/floodrisk/`, and `models/energy-balancer/`.
+The full spec (per-entry artifacts — `card.md`, `stub.go`, `stub_test.go`, the mandatory
+`behaviour_test.go` expected-behaviour suite, and a `declarative.yaml` twin with its
+equivalence test — plus the actionable/structural response-claim taxonomy and the two-category
+promotion triage) lives in **`models/CONVENTIONS.md`**. Add entries with the `/new-model`
+skill; the reference entries are `models/antimicrobial-resistance/`, `models/floodrisk/`,
+and `models/energy-balancer/`.
+
+**The declarative twin is the promotion triage.** Each entry is also stated as data
+(`declarative.yaml`, a `general.ExpressionIteration` per partition, run through `pkg/api` with
+no Go). Whether that twin can be written is the test: if it can, the bespoke Go is a
+convenience and promotion is optional (earn it with a benchmark); if it cannot, the engine has
+a real capability gap and one model is enough to prove it. Never change a model to make its
+twin agree, and never widen a tolerance to hide a gap — step the oracle down instead
+(exact → claim-level → distributional) and say which you used.
 
 ## Build, run, and docs
 

--- a/models/CONVENTIONS.md
+++ b/models/CONVENTIONS.md
@@ -258,6 +258,29 @@ if any count is zero — an untriggered branch is a comparison that looks strong
 Choose input ranges that actually reach the clips and guards, including ranges the model would
 not ordinarily visit.
 
+**Both layers are load-bearing; neither is redundant.** In `antimicrobial-resistance`, deleting
+the direct conversion term from the resistant drift — the model's stated causal heart — passes
+the *entire* claim suite, because competitive release reproduces the same directional response.
+The step test catches it instantly. Conversely, a perturbed coefficient survives step tests that
+feed their own randomised params, and is caught only by the suite. Where a model can only have
+the claim-level oracle, know that you are covering direction and not mechanism.
+
+**Mutation-test the twin; do not trust a green run.** Deliberately corrupt the YAML — perturb a
+param, drop a term, mis-wire an upstream, unguard a draw — and confirm each is caught. This is
+how the reference twin's own defects were found, and two traps recur:
+
+- **A stepsize of 1 hides every `dt`.** At `dt = 1`, `* dt` and `sqrt(dt)` are no-ops, so a twin
+  that dropped one agrees anyway. Every model here runs at a constant stepsize of 1, so step
+  tests must **vary `dt`** — below, at, and above 1, since `sqrt(dt)` moves the opposite way
+  either side.
+- **Unknown YAML keys are ignored silently.** `yaml.v2` does not reject them, so a key that
+  does nothing looks load-bearing. `state_width` sat in seven twins doing nothing —
+  `PartitionConfig` has no such field, and the width comes from `init_state_values`.
+
+Verify the mutation actually landed before believing it passed: a `sed` that silently matched
+nothing reports the same green as a test that missed a real bug (BSD `sed` supports neither
+`\s` nor GNU's `0,/re/`).
+
 Where a model resists the DSL, the twin's **absence is the artifact**: record what could not
 be expressed and why, as a category 2 finding below.
 
@@ -311,13 +334,23 @@ Two shapes, with very different costs:
   `bathing-water-forecaster`. Prefer the mathematical primitive over the convenience wrapper:
   `erfc` rather than a `normal_cdf`, because it matches what compiled Go computes term for
   term, which is what keeps a twin exact.
-- **A missing structure.** The model's update is not elementwise at all, so no set of
-  functions rescues it. `business-survival` is the worked example: a cohort stock-and-flow
-  whose output element *i* reads input element *i−1* (an age shift), with an absorbing top
-  bucket. The DSL aligns element *i* with element *i* by construction, so this is a shape gap,
-  not a vocabulary gap. Resolving it means either a new operator (a shift, which enlarges what
-  the DSL *is*) or a core `Iteration` — a real design decision, and correspondingly slow.
-  Record it and let it wait for a second instance before choosing.
+- **A missing structure.** The model's update is not elementwise over the current row, so no
+  set of functions rescues it: the shape is what is wrong. These are slow and expensive —
+  each means either an operator that enlarges what the DSL *is*, or a core `Iteration`.
+  Record them and let a second instance argue for the design. The catalogue has surfaced
+  four, and they rhyme — all four are about *structured access* or *lane-wise control of
+  draws*, which is exactly the axis a strictly elementwise evaluator gives up:
+
+  | Gap | Found by | What it needs |
+  |---|---|---|
+  | Index shift — output *i* reads input *i−1*, with an absorbing boundary | `business-survival` (cohort/Leslie flow) | a shift, or a core aged-cohort iteration |
+  | Lag-*N* history read — only the current row is exposed | `trywizard` (ageing yellow cards out ten rows back) | a `lag(alias, n)` accessor |
+  | Slicing — no way to address a block within a flat vector | `trywizard` (9 coefficients at a stride-9 offset) | a slice/reshape primitive |
+  | Draw ordering and lane-wise laziness — an expression takes all its Gammas before any Poisson, and a vector-guarded `where` draws in every lane | `measles-risk-forecaster` (per-area interleaved draws, inactive areas skipped) | per-lane control the evaluator does not have |
+
+  The last one is worth reading twice: the DSL's own doc comment already predicts it ("a
+  vector-guarded draw consumes randomness in every lane"). A limitation you documented is
+  still a limitation — a model hitting it is evidence, not a duplicate of the note.
 
 **Do not resolve a category 2 finding by changing the model to suit the DSL.** The finding is
 the value; a model bent to fit tells you nothing. The promotion decision stays a maintainer

--- a/models/CONVENTIONS.md
+++ b/models/CONVENTIONS.md
@@ -20,8 +20,13 @@ models/
     stub.go            # data-free SDK generative core (BuildStub)
     stub_test.go       # engine-CI test: harness + invariants + headline direction-of-response
     behaviour_test.go  # expected-behaviour suite: named, human-legible response claims
+    declarative.yaml   # the same model stated as data — no Go, no compilation
+    expression_equivalence_test.go  # proves the twin is the same model
     <iteration>.go     # bespoke simulator.Iteration implementations, beside the stub
 ```
+
+The declarative twin is expected but not always possible — where the model resists the DSL,
+its absence is itself a recorded finding (see §5 and [Bespoke extensions](#bespoke-extensions)).
 
 The Go **package name** is a short identifier for the domain (`amr`, `floodrisk`) — it
 need not equal the directory name, but must be a valid Go identifier (no hyphens).
@@ -32,7 +37,7 @@ bespoke extensions lifted from the downstream repo and staged here for the "shou
 promoted into core?" question (see [Bespoke extensions](#bespoke-extensions)). Keep the
 comment in `doc.go` alone — do not also attach a package comment to a source file.
 
-## The three artifacts
+## The artifacts
 
 ### 1. Methodology card (`card.md`)
 
@@ -184,18 +189,139 @@ break a claim's sign and the binding test fails; change a number without regener
 card guard fails. New entries should adopt this from birth; older entries are being migrated
 to it.
 
+### 5. Declarative twin (`declarative.yaml` + `expression_equivalence_test.go`)
+
+The same model, stated as data: partitions and a `general.ExpressionIteration` spec per
+partition, loaded through `pkg/api` with no Go and no compilation step. See
+[`anglersim/declarative.yaml`](anglersim/declarative.yaml) for the reference entry.
+
+It earns its place twice over. It is the catalogue's answer to "can this engine be driven by
+something that does not write Go?" — a question the stub, being Go, cannot answer. And
+writing it is what triages the model for promotion (see [Bespoke extensions](#bespoke-extensions)):
+a twin that *can* be written says the bespoke Go is a convenience; a twin that *cannot* says
+the engine is missing something.
+
+The twin must be the **same model**, not a rewrite that behaves similarly: same partition
+names, same param keys, same state layout, same wiring. Two traps:
+
+- **Match the Go's actual read semantics**, not its surface. `params_from_upstream` is a
+  *within-step* read; the DSL's `upstreams:` alias is a *lag-1* state-history read. A model
+  that resolves an index via `params_as_partitions` and then reads `stateHistories` is doing
+  the lag-1 thing, so `upstreams:` is its faithful translation and `params_from_upstream`
+  would be a different model. Say which, and why, in a YAML comment.
+- **Draws must line up.** A draw's position in the stream is part of the model. Bindings are
+  eager, and a scalar `where` is lazy — so a guarded draw belongs *inside* the `where`, which
+  is what reproduces a Go early-return that skips the draw.
+
+Where the Go hardcodes an index constant, state it as a mask param instead
+(`anglersim`'s `warming_mask`/`nonneg_mask` replace a `tempIndex` constant). Pushing a
+constant out into data is a genuine improvement, not a translation artifact.
+
+#### How the twin is verified
+
+Two independent checks, because they fail differently. **Step-for-step**: randomised inputs
+through single `Iterate` calls on both, which catches a mis-stated formula exactly. **Whole
+suite**: re-run `ObservedBehaviour()` against the declarative build, which catches what
+per-step agreement cannot — wrong wiring, wrong params, wrong state layout. To make the
+second possible, thread a `stubBuilder` through the behaviour helpers so `ObservedBehaviour()`
+delegates to an `observedBehaviour(build)`; the claim suite is then *pointed at* either
+assembly rather than restated for each. `ObservedBehaviour()` must keep its no-arg signature —
+`cmd/model-index` detects it by AST.
+
+Prefer the **strongest oracle the model allows**, and say in the test header which one you
+used and why:
+
+1. **Exact (~1e-16).** Available when the bespoke iteration draws from the same generator the
+   evaluator does (`rng.New(seed)` is `rand.New(rand.NewPCG(seed, seed))`) *and* the
+   expressions take the same number of draws per step. Then both models run on the same
+   stream and equivalence is decidable directly. Assert a tight tolerance (1e-12), never
+   bit-identity: compiled Go contracts `a + b*c` into an FMA, which rounds differently from
+   the evaluator's separate operations. That residue is the FMA, not the model.
+2. **Claim-level.** When the streams cannot be aligned — a model on `math/rand` v1, or one
+   hand-rolling a sampler the engine implements differently — assert that every claim still
+   `cardgen.Verify`s, and do *not* assert the numbers match. The claims are ensemble-level and
+   threshold-based precisely so they survive a different stream while still discriminating a
+   wrong model.
+3. **Distributional.** Per-step moments with a tolerance justified as a Monte Carlo sampling
+   bound. Say in a comment that it is a sampling bound, not a rounding bound.
+
+Two rules that matter more than the tests passing:
+
+- **Step the oracle down, never the tolerance.** A fat tolerance that no longer tells
+  equivalence from similarity is a test that has stopped working while still going green.
+- **Never change the model to make the twin agree.** That inverts the point of the exercise,
+  and it can silently falsify the card. If a model and the engine disagree, that is a finding
+  to record, not a diff to apply.
+
+Step-for-step tests must **exercise every branch and count the cases that hit each**, failing
+if any count is zero — an untriggered branch is a comparison that looks stronger than it is.
+Choose input ranges that actually reach the clips and guards, including ranges the model would
+not ordinarily visit.
+
+Where a model resists the DSL, the twin's **absence is the artifact**: record what could not
+be expressed and why, as a category 2 finding below.
+
 ## Bespoke extensions
 
 Custom `simulator.Iteration` implementations a model needs live *beside* its stub, lifted
 from the downstream repo. Leave the downstream's data-fitting / calibration / inference
 helpers downstream — only the generative iterations travel. The catalogue is the staging
-ground for the "should this be promoted into core?" question: **an extension that recurs
-across several entries, doing substantially the same job, is signalling it wants
-promoting.** Do not design the promotion mechanism up front — let it emerge from the
-recurrence once several stubs exist. The **domain model index** ([`INDEX.md`](INDEX.md),
-generated by `cmd/model-index`) is where that recurrence becomes visible: it lists every
-model's core-package usage and bespoke iterations, so a concept appearing beside three or
-four models is legible at a glance. The promotion decision stays a maintainer judgement.
+ground for the "should this be promoted into core?" question.
+
+Recurrence is one signal: **an extension that recurs across several entries, doing
+substantially the same job, is signalling it wants promoting.** The **domain model index**
+([`INDEX.md`](INDEX.md), generated by `cmd/model-index`) is where that becomes visible — it
+lists every model's core-package usage and bespoke iterations, so a concept appearing beside
+three or four entries is legible at a glance.
+
+But recurrence is a slow signal: it cannot fire until several stubs exist. The declarative
+twin (§5) gives a sharper one that fires on the *first* model, because it asks a question
+with a decidable answer: **can `general.ExpressionIteration` express this?** That splits
+promotion candidates into two categories which are not the same kind of thing and should not
+be triaged the same way.
+
+### Category 1 — standardisation candidate (the DSL *can* express it)
+
+The evidence is a declarative twin that exists and whose claims hold. The bespoke Go is then
+a convenience or a performance choice, **not a capability**: the engine can already do this,
+just not as fast or not as tidily.
+
+Promotion here is **optional, and must be earned by a measurement** — a benchmark showing the
+evaluator is too slow for the job, or the same expression block recurring across entries.
+"It would be nicer in Go" is not evidence. Absent a measurement, the twin is the answer and
+no promotion is needed.
+
+One sub-signal lives here and is easy to misread as an engine gap: a twin that had to fall
+back to a weaker oracle (§5) because the bespoke hand-rolls what the engine already ships —
+`math/rand` v1 where core has standardised on `pkg/rng`'s v2 PCG, or a hand-written sampler
+beside `pkg/rng`'s. That is standardisation debt **in the model**, not a gap in core. It is
+still a category 1 finding, and the fix is to the model, on its own merits and its own PR —
+never as a side effect of making an equivalence test pass (see §5).
+
+### Category 2 — capability gap (the DSL *cannot* express it)
+
+The evidence is a twin that **cannot be written**, and the reason why. This is the strong
+signal: something is genuinely missing from the engine, and one model is enough to prove it.
+Two shapes, with very different costs:
+
+- **A missing primitive.** The model needs a function the evaluator lacks, but which fits its
+  existing shape — pure, elementwise, no draw-width question. Cheap and safe to promote
+  straight into the evaluator. Seasonality (`sin`) and a threshold-exceedance probability
+  (`erfc`, the primitive a Gaussian CDF is built from) arrived exactly this way, from
+  `bathing-water-forecaster`. Prefer the mathematical primitive over the convenience wrapper:
+  `erfc` rather than a `normal_cdf`, because it matches what compiled Go computes term for
+  term, which is what keeps a twin exact.
+- **A missing structure.** The model's update is not elementwise at all, so no set of
+  functions rescues it. `business-survival` is the worked example: a cohort stock-and-flow
+  whose output element *i* reads input element *i−1* (an age shift), with an absorbing top
+  bucket. The DSL aligns element *i* with element *i* by construction, so this is a shape gap,
+  not a vocabulary gap. Resolving it means either a new operator (a shift, which enlarges what
+  the DSL *is*) or a core `Iteration` — a real design decision, and correspondingly slow.
+  Record it and let it wait for a second instance before choosing.
+
+**Do not resolve a category 2 finding by changing the model to suit the DSL.** The finding is
+the value; a model bent to fit tells you nothing. The promotion decision stays a maintainer
+judgement.
 
 ## Adding an entry
 

--- a/models/CONVENTIONS.md
+++ b/models/CONVENTIONS.md
@@ -219,17 +219,30 @@ constant out into data is a genuine improvement, not a translation artifact.
 
 #### How the twin is verified
 
-Two independent checks, because they fail differently. **Step-for-step**: randomised inputs
-through single `Iterate` calls on both, which catches a mis-stated formula exactly. **Whole
-suite**: re-run `ObservedBehaviour()` against the declarative build, which catches what
-per-step agreement cannot — wrong wiring, wrong params, wrong state layout. To make the
-second possible, thread a `stubBuilder` through the behaviour helpers so `ObservedBehaviour()`
-delegates to an `observedBehaviour(build)`; the claim suite is then *pointed at* either
-assembly rather than restated for each. `ObservedBehaviour()` must keep its no-arg signature —
-`cmd/model-index` detects it by AST.
+**Both layers are required.** They are not alternatives and neither subsumes the other:
 
-Prefer the **strongest oracle the model allows**, and say in the test header which one you
-used and why:
+1. **Step-for-step** — randomised inputs through single `Iterate` calls on both sides. Catches
+   a mis-stated formula, exactly and immediately.
+2. **Whole-suite** — re-run `ObservedBehaviour()` against the declarative build. Catches what
+   per-step agreement cannot: wrong wiring, wrong param values, wrong state layout, a missing
+   partition.
+
+Neither is optional, because each is blind where the other sees. A perturbed coefficient
+survives step tests that feed their own randomised params, and only the suite catches it.
+Conversely — and this is the one that should settle the argument — in
+`antimicrobial-resistance`, **deleting the direct conversion term from the resistant drift, the
+model's stated causal heart, passes the entire claim suite**: competitive release reproduces
+the same directional response, so the claims cannot tell the two mechanisms apart. The step
+test catches it instantly. A claim suite checks *direction*; it does not pin *mechanism*.
+
+To make the suite layer possible, thread a `stubBuilder` through the behaviour helpers so
+`ObservedBehaviour()` delegates to an `observedBehaviour(build)`; the claim suite is then
+*pointed at* either assembly rather than restated for each. `ObservedBehaviour()` must keep
+its no-arg signature — `cmd/model-index` detects it by AST.
+
+Within each layer, use the **strongest oracle the model allows**, and say in the test header
+which one you used and why. The two layers step down independently — a model can be exact
+per-step and claim-level in the suite:
 
 1. **Exact (~1e-16).** Available when the bespoke iteration draws from the same generator the
    evaluator does (`rng.New(seed)` is `rand.New(rand.NewPCG(seed, seed))`) *and* the
@@ -239,11 +252,16 @@ used and why:
    the evaluator's separate operations. That residue is the FMA, not the model.
 2. **Claim-level.** When the streams cannot be aligned — a model on `math/rand` v1, or one
    hand-rolling a sampler the engine implements differently — assert that every claim still
-   `cardgen.Verify`s, and do *not* assert the numbers match. The claims are ensemble-level and
-   threshold-based precisely so they survive a different stream while still discriminating a
-   wrong model.
+   `cardgen.Verify`s, and do *not* assert the numbers match. Know what you have bought: this
+   covers direction, not mechanism, which is exactly why the step layer stays mandatory.
 3. **Distributional.** Per-step moments with a tolerance justified as a Monte Carlo sampling
    bound. Say in a comment that it is a sampling bound, not a rounding bound.
+
+Where the streams do not align, look for a **regime that recovers exactness** before settling
+for moments. `antimicrobial-resistance` compares exactly at `noise_scale = 0`, where both
+sides multiply their draw by zero and the streams stop mattering: the drift, the clamps and
+the renormalisation are then decidable value by value, and only the noise itself is left to
+distributional testing.
 
 Two rules that matter more than the tests passing:
 

--- a/models/CONVENTIONS.md
+++ b/models/CONVENTIONS.md
@@ -25,8 +25,9 @@ models/
     <iteration>.go     # bespoke simulator.Iteration implementations, beside the stub
 ```
 
-The declarative twin is expected but not always possible — where the model resists the DSL,
-its absence is itself a recorded finding (see §5 and [Bespoke extensions](#bespoke-extensions)).
+The declarative twin is expected. Every entry currently has one, so a model that resists the
+DSL is now news: its absence would be a recorded finding, not a gap to leave quiet (see §5 and
+[Bespoke extensions](#bespoke-extensions)).
 
 The Go **package name** is a short identifier for the domain (`amr`, `floodrisk`) — it
 need not equal the directory name, but must be a valid Go identifier (no hyphens).
@@ -339,6 +340,17 @@ beside `pkg/rng`'s. That is standardisation debt **in the model**, not a gap in 
 still a category 1 finding, and the fix is to the model, on its own merits and its own PR —
 never as a side effect of making an equivalence test pass (see §5).
 
+**Check what the sampler actually does before concluding the oracle must weaken**, because the
+two cases look identical from the outside and only one bites. `antimicrobial-resistance` really
+does hand-roll: a Knuth loop with a normal approximation above λ=30, a different algorithm
+consuming a different number of draws, so its streams cannot be aligned at all.
+`business-survival` reads the same way and is not: its `poissonSample` and `binomialSample` are
+thin wrappers that set `Lambda`/`N`/`P` on a `distuv` distribution and call `Rand`, and
+`pkg/rng` is a deliberate bit-identical reimplementation of `distuv`'s algorithms. Same
+generator, same algorithm, same draw order — so that twin is exact on its stochastic path, and
+the debt is cosmetic rather than semantic. Assuming otherwise costs the strongest oracle
+available for no reason.
+
 ### Category 2 — capability gap (the DSL *cannot* express it)
 
 The evidence is a twin that **cannot be written**, and the reason why. This is the strong
@@ -353,22 +365,32 @@ Two shapes, with very different costs:
   `erfc` rather than a `normal_cdf`, because it matches what compiled Go computes term for
   term, which is what keeps a twin exact.
 - **A missing structure.** The model's update is not elementwise over the current row, so no
-  set of functions rescues it: the shape is what is wrong. These are slow and expensive —
-  each means either an operator that enlarges what the DSL *is*, or a core `Iteration`.
-  Record them and let a second instance argue for the design. The catalogue has surfaced
-  four, and they rhyme — all four are about *structured access* or *lane-wise control of
-  draws*, which is exactly the axis a strictly elementwise evaluator gives up:
+  set of functions rescues it: the shape is what is wrong. These are the expensive ones —
+  each means either an operator that enlarges what the DSL *is*, or a core `Iteration`. Record
+  them and let a second instance argue for the design rather than reaching for it on the first.
 
-  | Gap | Found by | What it needs |
-  |---|---|---|
-  | Index shift — output *i* reads input *i−1*, with an absorbing boundary | `business-survival` (cohort/Leslie flow) | a shift, or a core aged-cohort iteration |
-  | Lag-*N* history read — only the current row is exposed | `trywizard` (ageing yellow cards out ten rows back) | a `lag(alias, n)` accessor |
-  | Slicing — no way to address a block within a flat vector | `trywizard` (9 coefficients at a stride-9 offset) | a slice/reshape primitive |
-  | Draw ordering and lane-wise laziness — an expression takes all its Gammas before any Poisson, and a vector-guarded `where` draws in every lane | `measles-risk-forecaster` (per-area interleaved draws, inactive areas skipped) | per-lane control the evaluator does not have |
+The catalogue has surfaced five capability gaps, and **all five are closed** — the table is the
+worked precedent for what the triage produces, not an open-issues list:
 
-  The last one is worth reading twice: the DSL's own doc comment already predicts it ("a
-  vector-guarded draw consumes randomness in every lane"). A limitation you documented is
-  still a limitation — a model hitting it is evidence, not a duplicate of the note.
+| Gap | Found by | What closed it |
+|---|---|---|
+| Seasonality, and a threshold-exceedance probability | `bathing-water-forecaster` | `sin`/`cos`/`erf`/`erfc` + `pi` (a missing primitive) |
+| Index shift — output *i* reads input *i−1*, with an absorbing boundary | `business-survival` (cohort/Leslie flow) | `each` |
+| Lag-*N* history read — only the current row is exposed | `trywizard` (ageing yellow cards out ten rows back) | `lag(name, n)` |
+| Slicing — no way to address a block within a flat vector | `trywizard` (9 coefficients at a stride-9 offset) | `slice` + `concat` |
+| Draw ordering and lane-wise laziness — an expression takes all its Gammas before any Poisson, and a vector-guarded `where` draws in every lane | `measles-risk-forecaster` (per-area interleaved draws, inactive areas skipped) | `each` |
+
+Two things that table is worth reading twice for. **The four structural gaps rhymed**: every
+one was about *structured access* or *per-lane control of draws*, which is exactly the axis a
+strictly elementwise evaluator gives up — so they were one design question, not four chores,
+and `each` closed two of them at once. And **the draw-ordering row was predicted by the DSL's
+own doc comment** ("a vector-guarded draw consumes randomness in every lane") long before a
+model hit it. A limitation you have documented is still a limitation: a model hitting it is
+evidence that it is time to fix it, not a duplicate of the note.
+
+Writing a twin also finds bugs in the engine that no model would: `business-survival`'s
+exposed a NaN index silently reading element 0 on arm64 while panicking on amd64, because Go
+leaves `int(NaN)` undefined. An architecture-dependent wrong answer, found by a config file.
 
 **Do not resolve a category 2 finding by changing the model to suit the DSL.** The finding is
 the value; a model bent to fit tells you nothing. The promotion decision stays a maintainer

--- a/models/README.md
+++ b/models/README.md
@@ -7,12 +7,11 @@ This catalogue enables downstream stochadex applications to 'teach' the engine w
 The repo boundary follows the **generative / inferential split**. This engine owns the
 **forward model** — the thing that *simulates*. Downstream project repos own inference,
 data ingestion, calibration, and the decision layer. Each catalogue entry is therefore
-three artifacts:
+these artifacts:
 
 1. **Methodology card** (`card.md`) — the primary human- and agent-legible description:
    the real-world system, what it ingests, its assumptions, validity regime, failure
-   modes, and the question it answers. Because the stub is Go (not a declarative YAML
-   file), the card carries the structural spec.
+   modes, and the question it answers.
 2. **SDK-based, data-free simulation stub** (`stub.go` + `*_test.go`) — the generative
    core only, built via the stochadex SDK (`Settings` + `Implementations`), wired into
    this engine's CI with at least one *meaningful* assertion about generative behaviour
@@ -20,12 +19,18 @@ three artifacts:
    "it runs."
 3. **Downstream pointer** — a link, in the card, to the project repo where inference,
    data, and the decision layer live.
+4. **Declarative twin** (`declarative.yaml` + `expression_equivalence_test.go`) — the same
+   model stated as data rather than Go, and a test proving it is the same model. It shows the
+   engine can be driven by something that does not write Go, which is a question the Go stub
+   cannot answer for itself.
 
 Any **bespoke `simulator.Iteration` implementations** a model needs sit *beside* its stub
 (e.g. `colonisation.go`). The catalogue is the staging ground for the "should this be in
-core?" question — an extension that recurs across several models, doing substantially the
-same job, is signalling it wants promoting. That mechanism is deliberately not designed up
-front; it emerges from the recurrence.
+core?" question, and the twin is what triages it: a model that *can* be stated as data says
+its bespoke Go is a convenience, so promotion must be earned by a benchmark; a model that
+*cannot* has found a real gap in the engine, and one model is enough to prove it. Recurrence
+across entries remains a second, slower signal. See
+[`CONVENTIONS.md`](CONVENTIONS.md#bespoke-extensions) for the triage.
 
 ## Entries
 

--- a/models/anglersim/behaviour.go
+++ b/models/anglersim/behaviour.go
@@ -28,16 +28,23 @@ func runStub(warmingTrend float64, numSteps int, seed uint64) *simulator.StateTi
 	return store
 }
 
+// stubBuilder assembles the model, matching BuildStub's signature. The behaviour
+// helpers take one rather than calling BuildStub directly so that an alternative
+// assembly of the same model — notably the declarative one in declarative.yaml —
+// can be put through this exact claim suite instead of a re-stated copy of it.
+type stubBuilder func(warmingTrend float64, numSteps int, seed uint64) *simulator.ConfigGenerator
+
 // runStubOverride runs the stub with an override hook applied to the generated
 // config before the run, so a behaviour can vary any partition's params without
 // bloating BuildStub's signature — BuildStub still exposes only the one headline
 // driver (the warming trend).
 func runStubOverride(
+	build stubBuilder,
 	numSteps int,
 	seed uint64,
 	override func(*simulator.ConfigGenerator),
 ) *simulator.StateTimeStorage {
-	gen := BuildStub(DefaultWarmingTrend, numSteps, seed)
+	gen := build(DefaultWarmingTrend, numSteps, seed)
 	if override != nil {
 		override(gen)
 	}
@@ -81,12 +88,13 @@ func meanFinalLogDensityEnsemble(warmingTrend float64, numSteps, window, nMember
 // meanFinalDensityOverride returns the ensemble-mean final log-density under an
 // override, averaging over both the final-window and an ensemble of seeds.
 func meanFinalDensityOverride(
+	build stubBuilder,
 	numSteps, window, nMembers int,
 	override func(*simulator.ConfigGenerator),
 ) float64 {
 	sum := 0.0
 	for m := 0; m < nMembers; m++ {
-		store := runStubOverride(numSteps, uint64(4000+m), override)
+		store := runStubOverride(build, numSteps, uint64(4000+m), override)
 		sum += meanFinalLogDensity(store.GetValues("population"), window)
 	}
 	return sum / float64(nMembers)
@@ -96,13 +104,14 @@ func meanFinalDensityOverride(
 // final log-density under an override — the spread of outcomes, used for the
 // process-noise claim.
 func stdFinalDensityOverride(
+	build stubBuilder,
 	numSteps, nMembers int,
 	override func(*simulator.ConfigGenerator),
 ) float64 {
 	finals := make([]float64, nMembers)
 	mean := 0.0
 	for m := 0; m < nMembers; m++ {
-		store := runStubOverride(numSteps, uint64(7000+m), override)
+		store := runStubOverride(build, numSteps, uint64(7000+m), override)
 		rows := store.GetValues("population")
 		finals[m] = rows[len(rows)-1][0]
 		mean += finals[m]
@@ -142,37 +151,44 @@ func setWarmingTrend(gen *simulator.ConfigGenerator, value float64) {
 //
 // The claim IDs match the subtest names under TestAnglersimExpectedBehaviour.
 func ObservedBehaviour() []cardgen.Claim {
+	return observedBehaviour(BuildStub)
+}
+
+// observedBehaviour computes the claims against a given assembly of the model. The
+// equivalence test runs it against the declarative build so that the data-only model
+// answers the same claims, measured the same way.
+func observedBehaviour(build stubBuilder) []cardgen.Claim {
 	const logDensity = "ensemble-mean final log-density"
 
 	// Shared 60-year baseline, reused across the actionable/structural claims that
 	// perturb one input against it (avoids recomputing the same base each time).
-	base60 := meanFinalDensityOverride(60, 20, 12, nil)
+	base60 := meanFinalDensityOverride(build, 60, 20, 12, nil)
 
 	// Headline climate sweep at the horizon/ensemble the warming claim uses.
-	warm0 := meanFinalDensityOverride(80, 20, 16, nil)
-	warm4 := meanFinalDensityOverride(80, 20, 16, func(g *simulator.ConfigGenerator) { setWarmingTrend(g, 0.04) })
-	warm8 := meanFinalDensityOverride(80, 20, 16, func(g *simulator.ConfigGenerator) { setWarmingTrend(g, 0.08) })
+	warm0 := meanFinalDensityOverride(build, 80, 20, 16, nil)
+	warm4 := meanFinalDensityOverride(build, 80, 20, 16, func(g *simulator.ConfigGenerator) { setWarmingTrend(g, 0.04) })
+	warm8 := meanFinalDensityOverride(build, 80, 20, 16, func(g *simulator.ConfigGenerator) { setWarmingTrend(g, 0.08) })
 
-	higherFlow := meanFinalDensityOverride(60, 20, 12, func(g *simulator.ConfigGenerator) {
+	higherFlow := meanFinalDensityOverride(build, 60, 20, 12, func(g *simulator.ConfigGenerator) {
 		setCovariateBaseline(g, 0, 2.0*DefaultBaselineFlow)
 	})
-	drought := meanFinalDensityOverride(60, 20, 12, func(g *simulator.ConfigGenerator) {
+	drought := meanFinalDensityOverride(build, 60, 20, 12, func(g *simulator.ConfigGenerator) {
 		setCovariateBaseline(g, 0, 0.25*DefaultBaselineFlow)
 	})
-	cleaner := meanFinalDensityOverride(60, 20, 12, func(g *simulator.ConfigGenerator) {
+	cleaner := meanFinalDensityOverride(build, 60, 20, 12, func(g *simulator.ConfigGenerator) {
 		setCovariateBaseline(g, 2, DefaultBaselineDO+3.0)
 	})
-	faster := meanFinalDensityOverride(60, 20, 12, func(g *simulator.ConfigGenerator) {
+	faster := meanFinalDensityOverride(build, 60, 20, 12, func(g *simulator.ConfigGenerator) {
 		setPopulationParam(g, "growth_rate", 1.0)
 	})
-	crowded := meanFinalDensityOverride(60, 20, 12, func(g *simulator.ConfigGenerator) {
+	crowded := meanFinalDensityOverride(build, 60, 20, 12, func(g *simulator.ConfigGenerator) {
 		setPopulationParam(g, "density_dependence", 2.0)
 	})
 
-	lowNoise := stdFinalDensityOverride(60, 40, func(g *simulator.ConfigGenerator) {
+	lowNoise := stdFinalDensityOverride(build, 60, 40, func(g *simulator.ConfigGenerator) {
 		setPopulationParam(g, "process_noise_sd", 0.05)
 	})
-	highNoise := stdFinalDensityOverride(60, 40, func(g *simulator.ConfigGenerator) {
+	highNoise := stdFinalDensityOverride(build, 60, 40, func(g *simulator.ConfigGenerator) {
 		setPopulationParam(g, "process_noise_sd", 0.6)
 	})
 
@@ -180,11 +196,11 @@ func ObservedBehaviour() []cardgen.Claim {
 		setPopulationParam(g, "process_noise_sd", 0.001)
 		g.GetPartition("population").InitStateValues = []float64{-8.0}
 	}
-	noAllee := meanFinalDensityOverride(8, 1, 8, func(g *simulator.ConfigGenerator) {
+	noAllee := meanFinalDensityOverride(build, 8, 1, 8, func(g *simulator.ConfigGenerator) {
 		lowStart(g)
 		setPopulationParam(g, "allee_effect", 0.0)
 	})
-	withAllee := meanFinalDensityOverride(8, 1, 8, func(g *simulator.ConfigGenerator) {
+	withAllee := meanFinalDensityOverride(build, 8, 1, 8, func(g *simulator.ConfigGenerator) {
 		lowStart(g)
 		setPopulationParam(g, "allee_effect", 30.0)
 	})

--- a/models/anglersim/declarative.yaml
+++ b/models/anglersim/declarative.yaml
@@ -24,7 +24,6 @@ main:
       warming_mask: [0.0, 1.0, 0.0]
       nonneg_mask: [1.0, 0.0, 1.0]
     init_state_values: [0.5, 12.0, 9.0]
-    state_width: 3
     state_history_depth: 1
     seed: 0
 
@@ -40,7 +39,6 @@ main:
       covariates:
         upstream: covariates
     init_state_values: [-0.27]
-    state_width: 1
     state_history_depth: 1
     seed: 997
 

--- a/models/anglersim/declarative.yaml
+++ b/models/anglersim/declarative.yaml
@@ -1,0 +1,68 @@
+# The anglersim generative core, written entirely as data: no Go, no compilation.
+#
+# This is the same model BuildStub assembles in stub.go, with the same partition names,
+# param keys and wiring, so the two can be compared directly (see
+# expression_equivalence_test.go, which checks per-step agreement and re-runs the whole
+# behaviour suite against this file). The run knobs BuildStub takes as arguments (seed,
+# horizon, warming trend) are injected by the caller; everything below is the model.
+#
+# Two masks appear here that have no counterpart in the params of stub.go, because the Go
+# code carries them as a hardcoded index instead (tempIndex): warming_mask selects the
+# covariate the warming drift acts on, and nonneg_mask selects the ones that are physically
+# non-negative. Stating them as data is what removes the index constant.
+main:
+  partitions:
+
+  # Mean-reverting flow, temperature and dissolved oxygen; temperature also carries the
+  # deterministic per-step warming drift.
+  - name: covariates
+    params:
+      baseline_levels: [0.5, 12.0, 9.0]
+      reversion_rates: [0.3, 0.0, 0.3]
+      volatilities: [0.05, 0.25, 0.4]
+      warming_trend: [0.0]
+      warming_mask: [0.0, 1.0, 0.0]
+      nonneg_mask: [1.0, 0.0, 1.0]
+    init_state_values: [0.5, 12.0, 9.0]
+    state_width: 3
+    state_history_depth: 1
+    seed: 0
+
+  # Stochastic Ricker log-density, forced within-step by the covariates above.
+  - name: population
+    params:
+      growth_rate: [0.5]
+      density_dependence: [1.0]
+      covariate_coefficients: [0.10, -0.02, 0.05]
+      process_noise_sd: [0.1]
+      allee_effect: [0.0]
+    params_from_upstream:
+      covariates:
+        upstream: covariates
+    init_state_values: [-0.27]
+    state_width: 1
+    state_history_depth: 1
+    seed: 997
+
+  expressions:
+
+  - partition: covariates
+    fields:
+    - {name: x, width: 3}
+    bindings:
+    - {name: reverted, expr: "x + reversion_rates * (baseline_levels - x)"}
+    - {name: shocked, expr: "reverted + normal(0, volatilities) + warming_trend * warming_mask"}
+    outputs: ["where(nonneg_mask > 0, max(shocked, 0), shocked)"]
+
+  - partition: population
+    fields:
+    - {name: log_density}
+    bindings:
+    - {name: density, expr: "exp(log_density)"}
+    # allee_effect = 0 means the standard Ricker, so the multiplier is 1 rather than the
+    # 1 - exp(0) = 0 the formula would give.
+    - {name: allee, expr: "where(allee_effect > 0, 1 - exp(-allee_effect * density), 1)"}
+    - {name: env, expr: "dot(covariate_coefficients, covariates)"}
+    - {name: noise, expr: "where(process_noise_sd > 0, shared(normal(0, process_noise_sd)), 0)"}
+    outputs:
+    - "log_density + growth_rate * allee + env - density_dependence * density + noise"

--- a/models/anglersim/expression_equivalence_test.go
+++ b/models/anglersim/expression_equivalence_test.go
@@ -1,0 +1,268 @@
+package anglersim
+
+// Does declarative.yaml — this model written as data, with no Go — reproduce the model
+// stub.go builds in code?
+//
+// Two independent checks, because they fail in different ways. The step-for-step tests
+// compare single Iterate calls over randomised inputs, which catches a mis-stated formula
+// exactly. The suite test re-runs the model's own claim computations against the
+// declarative build, which catches a model that is subtly different in a way per-step
+// agreement would not: wrong wiring, wrong param values, wrong state layout.
+//
+// Both iterations draw from a stream seeded exactly as the declarative one is
+// (rng.New(seed) and rand.New(rand.NewPCG(seed, seed)) are the same generator), and both
+// take the same number of draws per step, so the two stay in lockstep and equivalence is
+// decidable directly rather than only in distribution. Agreement is asserted to a tight
+// tolerance rather than bit-for-bit: compiled Go is free to contract a + b*c into a fused
+// multiply-add, which rounds differently from the evaluator's separate operations.
+
+import (
+	"math"
+	"math/rand/v2"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+
+	"github.com/umbralcalc/stochadex/models/cardgen"
+	"github.com/umbralcalc/stochadex/pkg/api"
+	"github.com/umbralcalc/stochadex/pkg/general"
+	"github.com/umbralcalc/stochadex/pkg/simulator"
+)
+
+// tolerance is well above FMA rounding and well below any difference a real modelling
+// discrepancy would produce.
+const tolerance = 1e-12
+
+// declarativeBuildStub assembles the model from declarative.yaml, matching BuildStub's
+// signature so it can be dropped into the behaviour helpers. The YAML holds the model; the
+// run knobs BuildStub takes as arguments are injected here, exactly as BuildStub injects
+// them into its Go partitions.
+func declarativeBuildStub(
+	warmingTrend float64,
+	numSteps int,
+	seed uint64,
+) *simulator.ConfigGenerator {
+	config := api.LoadApiRunConfigFromYaml("declarative.yaml")
+	config.Main.Simulation = simulator.SimulationConfig{
+		OutputCondition: &simulator.EveryStepOutputCondition{},
+		TerminationCondition: &simulator.NumberOfStepsTerminationCondition{
+			MaxNumberOfSteps: numSteps,
+		},
+		TimestepFunction: &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+		InitTimeValue:    0.0,
+	}
+	gen := config.Main.GetConfigGenerator()
+	gen.GetPartition("covariates").Params.Map["warming_trend"] = []float64{warmingTrend}
+	gen.GetPartition("covariates").Seed = seed
+	gen.GetPartition("population").Seed = seed + 997
+	return gen
+}
+
+// declarativeIteration returns the expression iteration the YAML supplies for a partition,
+// alongside the params it declares.
+func declarativeIteration(
+	t *testing.T,
+	partition string,
+) (*general.ExpressionIteration, map[string][]float64) {
+	t.Helper()
+	config := declarativeBuildStub(DefaultWarmingTrend, 10, 0).GetPartition(partition)
+	iteration, ok := config.Iteration.(*general.ExpressionIteration)
+	if !ok {
+		t.Fatalf("%s is not expression-backed: got %T", partition, config.Iteration)
+	}
+	return iteration, config.Params.Map
+}
+
+// assertClose fails when two values differ by more than the FMA-scale tolerance, comparing
+// relatively once the magnitude exceeds 1.
+func assertClose(t *testing.T, got, want float64, context string) float64 {
+	t.Helper()
+	d := math.Abs(got - want)
+	if s := math.Abs(want); s > 1 {
+		d /= s
+	}
+	if d > tolerance {
+		t.Fatalf("%s: declarative=%v bespoke=%v deviation=%g", context, got, want, d)
+	}
+	return d
+}
+
+func TestDeclarativeCovariatesMatchBespoke(t *testing.T) {
+	bespoke := &ClimateCovariatesIteration{}
+	declarative, params := declarativeIteration(t, "covariates")
+	settings := &simulator.Settings{
+		Iterations: []simulator.IterationSettings{{Name: "covariates", Seed: 5}},
+	}
+	bespoke.Configure(0, settings)
+	declarative.Configure(0, settings)
+
+	rng := rand.New(rand.NewPCG(11, 12))
+	clipped, warmed, maxDev := 0, 0, 0.0
+
+	const cases = 20000
+	for i := 0; i < cases; i++ {
+		// Ranged well below zero — further than mean reversion can pull back in one step —
+		// so the non-negativity clip on flow and dissolved oxygen actually triggers often,
+		// and with a warming trend so the masked drift is exercised.
+		state := []float64{
+			rng.Float64()*1.5 - 1.0,
+			8 + rng.Float64()*10,
+			rng.Float64()*11 - 2.0,
+		}
+		warming := rng.Float64()*0.2 - 0.1
+		p := simulator.NewParams(map[string][]float64{
+			"baseline_levels": params["baseline_levels"],
+			"reversion_rates": params["reversion_rates"],
+			"volatilities":    params["volatilities"],
+			"warming_mask":    params["warming_mask"],
+			"nonneg_mask":     params["nonneg_mask"],
+			"warming_trend":   {warming},
+		})
+		mk := func() []*simulator.StateHistory {
+			return []*simulator.StateHistory{{
+				Values:            mat.NewDense(1, 3, append([]float64{}, state...)),
+				StateWidth:        3,
+				StateHistoryDepth: 1,
+			}}
+		}
+		ts := &simulator.CumulativeTimestepsHistory{
+			Values:            mat.NewVecDense(1, []float64{float64(i)}),
+			NextIncrement:     1.0,
+			CurrentStepNumber: i + 1,
+		}
+
+		want := bespoke.Iterate(&p, 0, mk(), ts)
+		got := declarative.Iterate(&p, 0, mk(), ts)
+
+		if want[0] == 0 || want[2] == 0 {
+			clipped++
+		}
+		if warming != 0 {
+			warmed++
+		}
+		for k := range want {
+			maxDev = math.Max(maxDev, assertClose(t, got[k], want[k], "covariate"))
+		}
+		// The warming drift must land on temperature and nowhere else, which is the whole
+		// job of warming_mask replacing the Go tempIndex constant.
+		if want[1] != got[1] && math.Abs(want[1]-got[1]) > tolerance {
+			t.Fatalf("case %d: warming drift diverged", i)
+		}
+	}
+	if clipped == 0 {
+		t.Error("the non-negativity clip never triggered; the comparison is weak")
+	}
+	t.Logf("cases where a covariate was clipped at zero: %d/%d", clipped, cases)
+	t.Logf("max deviation: %g", maxDev)
+}
+
+func TestDeclarativeRickerMatchesBespoke(t *testing.T) {
+	bespoke := &RickerIteration{}
+	declarative, params := declarativeIteration(t, "population")
+	settings := &simulator.Settings{
+		Iterations: []simulator.IterationSettings{{Name: "population", Seed: 5}},
+	}
+	bespoke.Configure(0, settings)
+	declarative.Configure(0, settings)
+
+	rng := rand.New(rand.NewPCG(21, 22))
+	branches := map[string]int{}
+	maxDev := 0.0
+
+	const cases = 20000
+	for i := 0; i < cases; i++ {
+		logN := rng.Float64()*6 - 5
+		// Sweep the two guarded paths — the Allee multiplier and the noise draw — so both
+		// sides of each guard are compared, and both stay in step on the draw stream.
+		gamma := 0.0
+		if i%3 == 0 {
+			gamma = rng.Float64() * 40
+		}
+		sigma := 0.0
+		if i%5 != 0 {
+			sigma = rng.Float64() * 0.5
+		}
+		p := simulator.NewParams(map[string][]float64{
+			"growth_rate":            {rng.Float64() * 1.5},
+			"density_dependence":     {0.2 + rng.Float64()*2},
+			"covariate_coefficients": params["covariate_coefficients"],
+			"process_noise_sd":       {sigma},
+			"allee_effect":           {gamma},
+			"covariates": {
+				rng.Float64(),
+				8 + rng.Float64()*10,
+				5 + rng.Float64()*6,
+			},
+		})
+		mk := func() []*simulator.StateHistory {
+			return []*simulator.StateHistory{{
+				Values:            mat.NewDense(1, 1, []float64{logN}),
+				StateWidth:        1,
+				StateHistoryDepth: 1,
+			}}
+		}
+		ts := &simulator.CumulativeTimestepsHistory{
+			Values:            mat.NewVecDense(1, []float64{float64(i)}),
+			NextIncrement:     1.0,
+			CurrentStepNumber: i + 1,
+		}
+
+		want := bespoke.Iterate(&p, 0, mk(), ts)
+		got := declarative.Iterate(&p, 0, mk(), ts)
+
+		if gamma > 0 {
+			branches["allee"]++
+		} else {
+			branches["standard_ricker"]++
+		}
+		if sigma > 0 {
+			branches["noisy"]++
+		} else {
+			branches["deterministic"]++
+		}
+		maxDev = math.Max(maxDev, assertClose(t, got[0], want[0], "log density"))
+	}
+	for _, b := range []string{"allee", "standard_ricker", "noisy", "deterministic"} {
+		if branches[b] == 0 {
+			t.Errorf("branch %q never exercised; the comparison is weaker than it looks", b)
+		}
+	}
+	t.Logf("branches exercised: %v", branches)
+	t.Logf("max deviation: %g", maxDev)
+}
+
+func TestDeclarativeAnglersimAnswersTheSameClaims(t *testing.T) {
+	// The oracle is the model's own behaviour suite: every claim recomputed against the
+	// declarative build must still hold, and must hold with the same numbers the card
+	// reports — not merely point the same way.
+	if testing.Short() {
+		t.Skip("runs the full claim ensemble twice")
+	}
+	bespoke := ObservedBehaviour()
+	declarative := observedBehaviour(declarativeBuildStub)
+
+	if len(declarative) != len(bespoke) {
+		t.Fatalf("got %d claims, want %d", len(declarative), len(bespoke))
+	}
+	maxDev := 0.0
+	for i, claim := range declarative {
+		reference := bespoke[i]
+		if claim.ID != reference.ID {
+			t.Fatalf("claim %d: got ID %q, want %q", i, claim.ID, reference.ID)
+		}
+		// Still a true claim when the model is data.
+		if err := cardgen.Verify(claim); err != nil {
+			t.Errorf("claim %q does not hold for the declarative model: %v", claim.ID, err)
+			continue
+		}
+		if len(claim.Observations) != len(reference.Observations) {
+			t.Fatalf("claim %q: got %d observations, want %d",
+				claim.ID, len(claim.Observations), len(reference.Observations))
+		}
+		for k, obs := range claim.Observations {
+			maxDev = math.Max(maxDev, assertClose(t, obs.Value,
+				reference.Observations[k].Value, claim.ID+" / "+obs.Label))
+		}
+	}
+	t.Logf("max deviation across every observation on every claim: %g", maxDev)
+}

--- a/models/antimicrobial-resistance/behaviour.go
+++ b/models/antimicrobial-resistance/behaviour.go
@@ -27,16 +27,23 @@ func runStub(prescribingRate float64, numSteps int) *simulator.StateTimeStorage 
 	return store
 }
 
+// stubBuilder assembles the model, matching BuildStub's signature. The behaviour
+// helpers take one rather than calling BuildStub directly so that an alternative
+// assembly of the same model — notably the declarative one in declarative.yaml —
+// can be put through this exact claim suite instead of a re-stated copy of it.
+type stubBuilder func(prescribingRate float64, numSteps int) *simulator.ConfigGenerator
+
 // runStubOverride runs the stub with an override hook applied to the generated
 // config before the run. BuildStub takes no seed, so the ensemble varies via
 // SetGlobalSeed.
 func runStubOverride(
+	build stubBuilder,
 	prescribingRate float64,
 	numSteps int,
 	seed uint64,
 	override func(*simulator.ConfigGenerator),
 ) *simulator.StateTimeStorage {
-	gen := BuildStub(prescribingRate, numSteps)
+	gen := build(prescribingRate, numSteps)
 	gen.SetGlobalSeed(seed)
 	if override != nil {
 		override(gen)
@@ -90,6 +97,7 @@ func totalResistantBSI(rows [][]float64) float64 {
 // ensemble averages a per-run sample over nMembers seeds under a fixed prescribing
 // rate and override.
 func ensemble(
+	build stubBuilder,
 	prescribingRate float64,
 	numSteps, nMembers int,
 	override func(*simulator.ConfigGenerator),
@@ -97,7 +105,7 @@ func ensemble(
 ) float64 {
 	var sum float64
 	for m := 0; m < nMembers; m++ {
-		sum += sample(runStubOverride(prescribingRate, numSteps, uint64(7000+m), override))
+		sum += sample(runStubOverride(build, prescribingRate, numSteps, uint64(7000+m), override))
 	}
 	return sum / float64(nMembers)
 }
@@ -120,6 +128,16 @@ func resistantBSI(s *simulator.StateTimeStorage) float64 {
 //
 // Claim IDs match the subtest names under TestAMRExpectedBehaviour.
 func ObservedBehaviour() []cardgen.Claim {
+	return observedBehaviour(BuildStub)
+}
+
+// observedBehaviour computes the claims against a given assembly of the model. The
+// equivalence test runs it against the declarative build so that the data-only model
+// answers the same claims, measured the same way. Its numbers will not match the
+// bespoke build's — the two sample from different generators — but the claims are
+// ensemble-level and threshold-based precisely so that they discriminate the model
+// rather than the draw stream.
+func observedBehaviour(build stubBuilder) []cardgen.Claim {
 	const steps, nMembers = 200, 8
 	const rFrac = "ensemble-mean resistant fraction"
 
@@ -128,28 +146,28 @@ func ObservedBehaviour() []cardgen.Claim {
 	}
 
 	// Prescribing sweep with selection ON (the default) — the headline lever.
-	r002 := ensemble(0.02, steps, nMembers, nil, resistantFrac)
-	r030 := ensemble(0.3, steps, nMembers, nil, resistantFrac)
-	r080 := ensemble(0.8, steps, nMembers, nil, resistantFrac)
+	r002 := ensemble(build, 0.02, steps, nMembers, nil, resistantFrac)
+	r030 := ensemble(build, 0.3, steps, nMembers, nil, resistantFrac)
+	r080 := ensemble(build, 0.8, steps, nMembers, nil, resistantFrac)
 
 	// Same sweep with selection OFF — prescribing should have no pathway to act.
-	offLow := ensemble(0.02, steps, nMembers, noSelection, resistantFrac)
-	offHigh := ensemble(0.8, steps, nMembers, noSelection, resistantFrac)
+	offLow := ensemble(build, 0.02, steps, nMembers, noSelection, resistantFrac)
+	offHigh := ensemble(build, 0.8, steps, nMembers, noSelection, resistantFrac)
 	offDelta := math.Abs(offHigh - offLow)
 	onDelta := r080 - r002
 
-	base := ensemble(BaselinePrescribingRate, steps, nMembers, nil, resistantFrac)
-	costly := ensemble(BaselinePrescribingRate, steps, nMembers, func(g *simulator.ConfigGenerator) {
+	base := ensemble(build, BaselinePrescribingRate, steps, nMembers, nil, resistantFrac)
+	costly := ensemble(build, BaselinePrescribingRate, steps, nMembers, func(g *simulator.ConfigGenerator) {
 		g.GetPartition("colonisation").Params.Map["fitness_cost"] = []float64{0.15}
 	}, resistantFrac)
 
-	colBase := ensemble(BaselinePrescribingRate, steps, nMembers, nil, totalColonisation)
-	colHigh := ensemble(BaselinePrescribingRate, steps, nMembers, func(g *simulator.ConfigGenerator) {
+	colBase := ensemble(build, BaselinePrescribingRate, steps, nMembers, nil, totalColonisation)
+	colHigh := ensemble(build, BaselinePrescribingRate, steps, nMembers, func(g *simulator.ConfigGenerator) {
 		g.GetPartition("colonisation").Params.Map["transmission_rate"] = []float64{0.09}
 	}, totalColonisation)
 
-	bsiBase := ensemble(BaselinePrescribingRate, steps, nMembers, nil, resistantBSI)
-	bsiHigh := ensemble(BaselinePrescribingRate, steps, nMembers, func(g *simulator.ConfigGenerator) {
+	bsiBase := ensemble(build, BaselinePrescribingRate, steps, nMembers, nil, resistantBSI)
+	bsiHigh := ensemble(build, BaselinePrescribingRate, steps, nMembers, func(g *simulator.ConfigGenerator) {
 		g.GetPartition("infection").Params.Map["infection_probability"] = []float64{0.03}
 	}, resistantBSI)
 

--- a/models/antimicrobial-resistance/card.md
+++ b/models/antimicrobial-resistance/card.md
@@ -127,7 +127,15 @@ into the **Observed behaviour** table below (never hand-typed):
 - *Decision-path / mechanism (the actionable stewardship lever):* prescribing raises
   resistance **only through the selection term** — with `selection_coefficient` set to zero,
   a low-vs-high prescribing sweep leaves the resistant fraction unchanged, while with
-  selection on the same sweep moves it. This pins down *why* the stewardship lever works.
+  selection on the same sweep moves it. This establishes that selection is *necessary* for
+  the stewardship lever to work. It does **not** identify which selection-gated pathway
+  carries the effect: prescribing reaches resistance both by direct conversion
+  (`selection · ceph · S`) and by competitive release (suppressing S frees uncolonised
+  capacity for R), and both vanish when selection is off. Deleting the conversion term
+  outright still satisfies every claim here — competitive release alone reproduces the same
+  direction. No behavioural claim in this suite separates the two; only the per-step
+  comparison in `expression_equivalence_test.go` does. Treat the mechanism as *selection-gated*
+  rather than *attributed*.
 - *Structural drivers (out-of-sample credibility):* a higher fitness cost lowers resistance;
   higher transmission raises total colonisation; a higher per-patient infection probability
   raises the resistant BSI burden (the colonisation → infection outcome path).

--- a/models/antimicrobial-resistance/declarative.yaml
+++ b/models/antimicrobial-resistance/declarative.yaml
@@ -35,7 +35,6 @@ main:
       noise_scale: [0.01]
       prescribing_rate: [0.3]
     init_state_values: [0.15, 0.05]
-    state_width: 2
     state_history_depth: 1
     seed: 9182
 
@@ -46,7 +45,6 @@ main:
       infection_probability: [0.01]
       patient_population: [500.0]
     init_state_values: [0.0, 0.0]
-    state_width: 2
     state_history_depth: 1
     seed: 3347
 

--- a/models/antimicrobial-resistance/declarative.yaml
+++ b/models/antimicrobial-resistance/declarative.yaml
@@ -1,0 +1,96 @@
+# The antimicrobial-resistance generative core, written entirely as data: no Go, no
+# compilation.
+#
+# This is the same model BuildStub assembles in stub.go, with the same partition names,
+# param keys, state layout and wiring, so the two can be compared (see
+# expression_equivalence_test.go). The run knobs BuildStub takes as arguments (the
+# prescribing rate, the horizon) are injected by the caller; everything below is the model.
+#
+# Unlike anglersim's twin, this one is NOT a step-for-step reproduction of the Go model's
+# draw stream — colonisation.go and infection.go sample from math/rand v1 while the
+# expression evaluator samples from pkg/rng's v2 PCG, and infection.go rolls its own Poisson
+# sampler where the evaluator calls the engine's. The two are the same generative process
+# drawn from different samplers. expression_equivalence_test.go says exactly what that costs
+# and what is still checked.
+#
+# infection reads colonisation with `upstreams:` rather than `params_from_upstream:` because
+# that is what the Go model actually does: stub.go wires it with params_as_partitions and
+# infection.go then reads stateHistories[colonisation] directly, which is a lag-1 read of the
+# previous step's committed state. params_from_upstream would be a within-step read — a
+# different model. The rule is to match the Go model's read semantics, not its config keys.
+main:
+  partitions:
+
+  # Two-strain S/R colonisation SDE, integrated Euler-Maruyama, with a constant prescribing
+  # pressure entering through the selection term. prescribing_rate is a plain param, not an
+  # upstream partition: the policy layer is downstream, not part of the generative core.
+  - name: colonisation
+    params:
+      community_susceptible_prevalence: [0.15]
+      community_resistant_prevalence: [0.1164]
+      turnover_rate: [0.1]
+      transmission_rate: [0.0384]
+      selection_coefficient: [0.1351]
+      fitness_cost: [0.0170]
+      noise_scale: [0.01]
+      prescribing_rate: [0.3]
+    init_state_values: [0.15, 0.05]
+    state_width: 2
+    state_history_depth: 1
+    seed: 9182
+
+  # Poisson bloodstream-infection counts, driven by the colonisation fractions of the
+  # previous step.
+  - name: infection
+    params:
+      infection_probability: [0.01]
+      patient_population: [500.0]
+    init_state_values: [0.0, 0.0]
+    state_width: 2
+    state_history_depth: 1
+    seed: 3347
+
+  expressions:
+
+  - partition: colonisation
+    fields:
+    - {name: susceptible}
+    - {name: resistant}
+    bindings:
+    - {name: uncolonised, expr: "max(1 - susceptible - resistant, 0)"}
+    - {name: drift_s, expr: "turnover_rate * (community_susceptible_prevalence - susceptible)
+        + transmission_rate * susceptible * uncolonised
+        - selection_coefficient * prescribing_rate * susceptible
+        + fitness_cost * resistant"}
+    - {name: drift_r, expr: "turnover_rate * (community_resistant_prevalence - resistant)
+        + transmission_rate * resistant * uncolonised
+        + selection_coefficient * prescribing_rate * susceptible
+        - fitness_cost * resistant"}
+    # Demographic noise scales with sqrt(fraction), so it vanishes as a strain does. Two
+    # separate shared() draws rather than one 2-wide draw: the Go code draws susceptible
+    # first and resistant second, and bindings evaluate in order, so this keeps the two
+    # sides drawing the same quantities in the same order even though the streams differ.
+    - {name: noise_s, expr: "shared(normal(0, noise_scale * sqrt(max(susceptible, 0)) * sqrt(dt)))"}
+    - {name: noise_r, expr: "shared(normal(0, noise_scale * sqrt(max(resistant, 0)) * sqrt(dt)))"}
+    - {name: raw_s, expr: "max(susceptible + drift_s * dt + noise_s, 0)"}
+    - {name: raw_r, expr: "max(resistant + drift_r * dt + noise_r, 0)"}
+    # S and R partition the population, so renormalise only when the step has pushed the
+    # pair outside the simplex; a scale of 1 leaves an in-range pair untouched.
+    - {name: total, expr: "raw_s + raw_r"}
+    - {name: scale, expr: "where(total > 1, total, 1)"}
+    outputs:
+    - "raw_s / scale"
+    - "raw_r / scale"
+
+  - partition: infection
+    fields:
+    - {name: susceptible_bsi}
+    - {name: resistant_bsi}
+    upstreams:
+      colonisation: colonisation
+    bindings:
+    - {name: lambda_s, expr: "infection_probability * (patient_population * colonisation[0]) * dt"}
+    - {name: lambda_r, expr: "infection_probability * (patient_population * colonisation[1]) * dt"}
+    outputs:
+    - "shared(poisson(lambda_s))"
+    - "shared(poisson(lambda_r))"

--- a/models/antimicrobial-resistance/expression_equivalence_test.go
+++ b/models/antimicrobial-resistance/expression_equivalence_test.go
@@ -1,0 +1,498 @@
+package amr
+
+// Does declarative.yaml — this model written as data, with no Go — reproduce the model
+// stub.go builds in code?
+//
+// # Why this model gets a weaker oracle than anglersim's twin
+//
+// anglersim's declarative twin is checked step-for-step to ~1e-16, because its bespoke
+// iterations happen to draw from math/rand/v2's rand.New(rand.NewPCG(seed, seed)) — exactly
+// the generator the expression evaluator builds via rng.New(seed). Same stream, same draw
+// order, so equivalence is decidable value-by-value. That was a bonus of a coincidence, not
+// the standard.
+//
+// This model cannot have that, for two independent reasons:
+//
+//  1. colonisation.go and infection.go sample from math/rand v1
+//     (rand.New(rand.NewSource(int64(seed)))), a different generator family from pkg/rng's
+//     v2 PCG. The streams diverge from the first draw and cannot be aligned: rng.NewFromSource
+//     takes a math/rand/v2 Source, a v1 Source is not one, and ExpressionIteration seeds its
+//     sampler internally from the partition seed with no injection point regardless.
+//  2. infection.go's poissonSample is a hand-rolled sampler — Knuth's product-of-uniforms
+//     loop below lambda=30, a rounded normal approximation above it — where the evaluator's
+//     poisson() calls the engine's rng.Poisson (exponential-interarrival below lambda=10,
+//     Hoermann PTRS above). Different algorithms consuming different numbers of draws. The
+//     Knuth loop is not expressible in the DSL in any case: it is unbounded, and the DSL has
+//     no loops or recursion by design. Above lambda=30 the bespoke sampler is not even
+//     exactly Poisson — the normal approximation matches only the first two moments.
+//
+// So the declarative twin is a deliberately different sampler for the same generative
+// process. Neither of those facts is a defect in the DSL, and neither is worth changing the
+// model to remove: AMR's iterations are lifted verbatim from the downstream repo, and
+// card.md documents the lambda=30 branch as part of the validity regime. (Both are recorded
+// as standardisation signals — v1 math/rand where the engine has settled on pkg/rng, and a
+// hand-rolled sampler where the engine now ships one — but that is a decision about the
+// bespoke code, not about this test.)
+//
+// # What is checked instead
+//
+//   - The drift, clamp and renormalisation logic is still checked EXACTLY, by switching the
+//     noise off: at noise_scale = 0 both sides multiply their draw by zero, so every
+//     deterministic branch is comparable value-by-value despite the streams differing.
+//   - The stochastic parts are compared by their moments at fixed inputs, over many samples.
+//     Those tolerances are SAMPLING bounds, not rounding bounds — see mcTolerance.
+//   - The whole claim suite is re-run against the declarative build and every claim must
+//     still hold. It asserts the claims, NOT that the numbers match the bespoke ones: they
+//     will not, and a near-equality assertion with a tolerance fat enough to pass would be
+//     an assertion about nothing. The catalogue's claims are ensemble-level and
+//     threshold-based precisely so they survive a different draw stream while still
+//     discriminating a wrong model.
+
+import (
+	"math"
+	"math/rand/v2"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+
+	"github.com/umbralcalc/stochadex/models/cardgen"
+	"github.com/umbralcalc/stochadex/pkg/api"
+	"github.com/umbralcalc/stochadex/pkg/general"
+	"github.com/umbralcalc/stochadex/pkg/simulator"
+)
+
+// exactTolerance is well above FMA rounding — compiled Go is free to contract a + b*c into a
+// fused multiply-add, which rounds differently from the evaluator's separate operations —
+// and well below any difference a real modelling discrepancy would produce. It applies only
+// where the comparison is genuinely exact, i.e. with the noise switched off.
+const exactTolerance = 1e-12
+
+// mcSamples is the sample count behind every moment comparison, and mcSigmas the width of
+// the bound in standard errors. Six sigma puts the false-failure rate of each assertion near
+// 2e-9, which keeps a distributional test from being a flaky one.
+const (
+	mcSamples = 200000
+	mcSigmas  = 6.0
+)
+
+// declarativeBuildStub assembles the model from declarative.yaml, matching BuildStub's
+// signature so it can be dropped into the behaviour helpers. The YAML holds the model; the
+// run knobs BuildStub takes as arguments are injected here, exactly as BuildStub injects
+// them into its Go partitions. Seeds come from the YAML and match stub.go's, though the
+// claim suite overrides them per ensemble member via SetGlobalSeed.
+func declarativeBuildStub(
+	prescribingRate float64,
+	numSteps int,
+) *simulator.ConfigGenerator {
+	config := api.LoadApiRunConfigFromYaml("declarative.yaml")
+	config.Main.Simulation = simulator.SimulationConfig{
+		OutputCondition: &simulator.EveryStepOutputCondition{},
+		TerminationCondition: &simulator.NumberOfStepsTerminationCondition{
+			MaxNumberOfSteps: numSteps,
+		},
+		TimestepFunction: &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+		InitTimeValue:    0.0,
+	}
+	gen := config.Main.GetConfigGenerator()
+	gen.GetPartition("colonisation").Params.Map["prescribing_rate"] =
+		[]float64{prescribingRate}
+	return gen
+}
+
+// declarativeIteration returns the expression iteration the YAML supplies for a partition,
+// alongside the params it declares.
+func declarativeIteration(
+	t *testing.T,
+	partition string,
+) (*general.ExpressionIteration, map[string][]float64) {
+	t.Helper()
+	config := declarativeBuildStub(BaselinePrescribingRate, 10).GetPartition(partition)
+	iteration, ok := config.Iteration.(*general.ExpressionIteration)
+	if !ok {
+		t.Fatalf("%s is not expression-backed: got %T", partition, config.Iteration)
+	}
+	return iteration, config.Params.Map
+}
+
+// assertClose fails when two values differ by more than tol, comparing relatively once the
+// magnitude exceeds 1. It returns the deviation so callers can report the worst one.
+func assertClose(t *testing.T, got, want, tol float64, context string) float64 {
+	t.Helper()
+	d := math.Abs(got - want)
+	if s := math.Abs(want); s > 1 {
+		d /= s
+	}
+	if d > tol {
+		t.Fatalf("%s: declarative=%v bespoke=%v deviation=%g tolerance=%g",
+			context, got, want, d, tol)
+	}
+	return d
+}
+
+// timesteps builds a one-step timesteps history with the given increment.
+func timesteps(step int, dt float64) *simulator.CumulativeTimestepsHistory {
+	return &simulator.CumulativeTimestepsHistory{
+		Values:            mat.NewVecDense(1, []float64{float64(step)}),
+		NextIncrement:     dt,
+		CurrentStepNumber: step + 1,
+	}
+}
+
+// history wraps a single state row as a depth-1 history.
+func history(values []float64) *simulator.StateHistory {
+	return &simulator.StateHistory{
+		Values:            mat.NewDense(1, len(values), append([]float64{}, values...)),
+		StateWidth:        len(values),
+		StateHistoryDepth: 1,
+	}
+}
+
+// moments returns the sample mean and standard deviation of xs.
+func moments(xs []float64) (float64, float64) {
+	mean := 0.0
+	for _, x := range xs {
+		mean += x
+	}
+	mean /= float64(len(xs))
+	varSum := 0.0
+	for _, x := range xs {
+		d := x - mean
+		varSum += d * d
+	}
+	return mean, math.Sqrt(varSum / float64(len(xs)))
+}
+
+// mcTolerance returns the bound for comparing a statistic between the two builds. This is a
+// SAMPLING bound, not a rounding bound: the two draw from different generators, so their
+// estimates of the same moment differ by Monte Carlo error alone, and the only honest
+// tolerance is one derived from that error. For a difference of two independent sample means
+// the standard error is sd*sqrt(2/n); for a difference of two independent sample standard
+// deviations it is about sd/sqrt(n). Both are widened to mcSigmas standard errors.
+//
+// A lane can be deterministic — a strain at zero kills its own noise — which makes the
+// sampling bound zero. The bound is floored at a few parts per billion of the value's scale
+// so such a lane absorbs the float accumulation of summing n identical samples instead of
+// knife-edging on it; that floor is still orders of magnitude below any modelling difference.
+func mcTolerance(sd, scale float64, n int, forMean bool) float64 {
+	bound := mcSigmas * sd / math.Sqrt(float64(n))
+	if forMean {
+		bound = mcSigmas * sd * math.Sqrt(2/float64(n))
+	}
+	return math.Max(bound, 1e-9*math.Abs(scale))
+}
+
+// drawSamples calls Iterate n times at a fixed input, returning one slice of samples per
+// state element. The output slice is copied on every call: ExpressionIteration returns a
+// reused buffer.
+func drawSamples(
+	iteration simulator.Iteration,
+	n, partitionIndex, width int,
+	params *simulator.Params,
+	histories []*simulator.StateHistory,
+) [][]float64 {
+	out := make([][]float64, width)
+	for k := range out {
+		out[k] = make([]float64, n)
+	}
+	for i := 0; i < n; i++ {
+		v := iteration.Iterate(params, partitionIndex, histories, timesteps(i, 1.0))
+		for k := 0; k < width; k++ {
+			out[k][i] = v[k]
+		}
+	}
+	return out
+}
+
+// colonisationSettings configures both builds for the colonisation partition. Params is left
+// empty of prescribing_partition, so ColonisationDynamicsIteration takes its direct
+// prescribing_rate path — the one BuildStub actually assembles. (The prescribing_partition
+// and learned_params branches are inference/policy hooks the stub never configures, so they
+// are outside the model this twin states and outside this comparison.)
+func colonisationSettings() *simulator.Settings {
+	return &simulator.Settings{
+		Iterations: []simulator.IterationSettings{{Name: "colonisation", Seed: 5}},
+	}
+}
+
+func TestDeclarativeColonisationDriftMatchesBespokeExactly(t *testing.T) {
+	// With noise_scale = 0 both sides multiply their draw by zero, so the streams stop
+	// mattering and the drift, the uncolonised clamp, the zero clamp and the simplex
+	// renormalisation are all comparable value-by-value. This is the strongest check
+	// available for this model, and it covers everything except the noise magnitude.
+	bespoke := &ColonisationDynamicsIteration{}
+	declarative, _ := declarativeIteration(t, "colonisation")
+	settings := colonisationSettings()
+	bespoke.Configure(0, settings)
+	declarative.Configure(0, settings)
+
+	rng := rand.New(rand.NewPCG(31, 32))
+	branches := map[string]int{}
+	maxDev := 0.0
+
+	const cases = 20000
+	for i := 0; i < cases; i++ {
+		// Ranged above the simplex and below zero — further than one step of drift can
+		// correct — so the clamps and the renormalisation trigger often rather than
+		// occasionally. Physical trajectories never leave [0,1], so only a range this wide
+		// exercises the code that keeps them there.
+		s := rng.Float64()*1.1 - 0.2
+		r := rng.Float64()*1.1 - 0.2
+		dt := 0.5 + rng.Float64()
+		p := simulator.NewParams(map[string][]float64{
+			"community_susceptible_prevalence": {rng.Float64() * 0.3},
+			"community_resistant_prevalence":   {rng.Float64() * 0.3},
+			"turnover_rate":                    {rng.Float64() * 0.2},
+			"transmission_rate":                {rng.Float64() * 0.1},
+			"selection_coefficient":            {rng.Float64() * 0.3},
+			"fitness_cost":                     {rng.Float64() * 0.2},
+			"noise_scale":                      {0.0},
+			"prescribing_rate":                 {rng.Float64()},
+		})
+		mk := func() []*simulator.StateHistory {
+			return []*simulator.StateHistory{history([]float64{s, r})}
+		}
+		ts := timesteps(i, dt)
+
+		want := bespoke.Iterate(&p, 0, mk(), ts)
+		got := declarative.Iterate(&p, 0, mk(), ts)
+
+		if 1-s-r <= 0 {
+			branches["uncolonised_clamped"]++
+		} else {
+			branches["uncolonised_positive"]++
+		}
+		if s < 0 || r < 0 {
+			branches["sqrt_argument_clamped"]++
+		} else {
+			branches["sqrt_argument_positive"]++
+		}
+		if want[0] == 0 || want[1] == 0 {
+			branches["output_clamped_at_zero"]++
+		}
+		if math.Abs(want[0]+want[1]-1) < 1e-12 {
+			branches["renormalised"]++
+		} else {
+			branches["inside_simplex"]++
+		}
+		for k := range want {
+			maxDev = math.Max(maxDev,
+				assertClose(t, got[k], want[k], exactTolerance, "colonisation fraction"))
+		}
+	}
+	for _, b := range []string{
+		"uncolonised_clamped", "uncolonised_positive",
+		"sqrt_argument_clamped", "sqrt_argument_positive",
+		"output_clamped_at_zero", "renormalised", "inside_simplex",
+	} {
+		if branches[b] == 0 {
+			t.Errorf("branch %q never exercised; the comparison is weaker than it looks", b)
+		}
+	}
+	t.Logf("branches exercised: %v", branches)
+	t.Logf("max deviation: %g", maxDev)
+}
+
+func TestDeclarativeColonisationNoiseMatchesInDistribution(t *testing.T) {
+	// The noise magnitude is the one part of colonisation the exact test above cannot reach,
+	// because the two sides draw from different generators. Compare its moments instead.
+	bespoke := &ColonisationDynamicsIteration{}
+	declarative, _ := declarativeIteration(t, "colonisation")
+	settings := colonisationSettings()
+	bespoke.Configure(0, settings)
+	declarative.Configure(0, settings)
+
+	scenarios := []struct {
+		name       string
+		state      []float64
+		noiseScale float64
+	}{
+		// Well inside the simplex: nothing clamps, so the sd is purely the diffusion term
+		// and the comparison is about the noise itself.
+		{"interior", []float64{0.15, 0.05}, 0.01},
+		// A strain at zero: sqrt(0) kills its noise entirely, so the resistant lane must be
+		// deterministic on both sides. This is the "extinction is absorbing" property.
+		{"resistant_extinct", []float64{0.3, 0.0}, 0.01},
+		// Noise large enough that the zero clamp and the renormalisation bite, so the
+		// compared distributions are the clamped ones, not clean Gaussians.
+		{"clamping", []float64{0.02, 0.96}, 0.2},
+	}
+
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			p := simulator.NewParams(map[string][]float64{
+				"community_susceptible_prevalence": {DefaultCommunitySusceptiblePrevalence},
+				"community_resistant_prevalence":   {DefaultCommunityResistantPrevalence},
+				"turnover_rate":                    {DefaultTurnoverRate},
+				"transmission_rate":                {DefaultTransmissionRate},
+				"selection_coefficient":            {DefaultSelectionCoefficient},
+				"fitness_cost":                     {DefaultFitnessCost},
+				"noise_scale":                      {sc.noiseScale},
+				"prescribing_rate":                 {BaselinePrescribingRate},
+			})
+			histories := []*simulator.StateHistory{history(sc.state)}
+			want := drawSamples(bespoke, mcSamples, 0, 2, &p, histories)
+			got := drawSamples(declarative, mcSamples, 0, 2, &p, histories)
+
+			for k, lane := range []string{"susceptible", "resistant"} {
+				wantMean, wantSd := moments(want[k])
+				gotMean, gotSd := moments(got[k])
+				meanTol := mcTolerance(wantSd, wantMean, mcSamples, true)
+				sdTol := mcTolerance(wantSd, wantMean, mcSamples, false)
+				assertClose(t, gotMean, wantMean, meanTol, lane+" mean")
+				assertClose(t, gotSd, wantSd, sdTol, lane+" sd")
+				t.Logf("%s: mean %.8f vs %.8f (tol %.2e), sd %.8f vs %.8f (tol %.2e)",
+					lane, gotMean, wantMean, meanTol, gotSd, wantSd, sdTol)
+			}
+		})
+	}
+}
+
+func TestDeclarativeInfectionMatchesInDistribution(t *testing.T) {
+	// infection is distributional-only: even with a matching generator, the bespoke Knuth
+	// sampler and the engine's rng.Poisson are different algorithms. What a moment
+	// comparison does check is the part that can actually be wrong in translation — the
+	// lambda plumbing: the upstream lag-1 read of colonisation, the field layout, and
+	// lambda = infection_probability * population * fraction * dt.
+	bespoke := &InfectionProcessIteration{}
+	declarative, _ := declarativeIteration(t, "infection")
+	settings := &simulator.Settings{
+		Iterations: []simulator.IterationSettings{
+			{Name: "colonisation", Seed: 5},
+			{Name: "infection", Seed: 7, Params: simulator.NewParams(
+				map[string][]float64{"colonisation_partition": {0}},
+			)},
+		},
+	}
+	bespoke.Configure(1, settings)
+	declarative.Configure(1, settings)
+
+	scenarios := []struct {
+		name            string
+		fractions       []float64
+		infectionProb   float64
+		population      float64
+		expectedLambdas []float64
+	}{
+		// A strain at zero: lambda = 0, where the bespoke sampler returns without drawing at
+		// all and rng.Poisson draws once and returns 0. Both must be identically zero.
+		{"zero_lambda", []float64{0.15, 0.0}, 0.01, 500, []float64{0.75, 0.0}},
+		// The flagship regime: lambda well under 1.
+		{"flagship", []float64{0.15, 0.05}, 0.01, 500, []float64{0.75, 0.25}},
+		// Straddles rng.Poisson's own lambda=10 switch from direct to PTRS while the bespoke
+		// side is still in Knuth.
+		{"ptrs_vs_knuth", []float64{0.024, 0.05}, 0.5, 500, []float64{6.0, 12.5}},
+		// Above the bespoke lambda=30 switch, where poissonSample stops being Poisson and
+		// becomes a rounded normal. Its normal approximation is constructed to match
+		// Poisson's mean and variance, so a two-moment comparison cannot distinguish the two
+		// here and does not claim to — it is checking the lambda, not the tail shape.
+		{"normal_approximation", []float64{0.16, 0.2}, 0.5, 500, []float64{40.0, 50.0}},
+	}
+
+	// Which sampler branch each lane lands in is derived from its lambda rather than
+	// declared alongside the scenario, so the counts cannot claim a branch the inputs do not
+	// actually reach. The thresholds are the ones in the two implementations: poissonSample
+	// returns early at lambda<=0 and switches to its normal approximation at 30; rng.Poisson
+	// switches from exponential-interarrival to PTRS at 10.
+	branchesFor := func(lambda float64) []string {
+		switch {
+		case lambda <= 0:
+			return []string{"bespoke_no_draw", "declarative_direct"}
+		case lambda < 10:
+			return []string{"bespoke_knuth", "declarative_direct"}
+		case lambda < 30:
+			return []string{"bespoke_knuth", "declarative_ptrs"}
+		default:
+			return []string{"bespoke_normal_approximation", "declarative_ptrs"}
+		}
+	}
+
+	branches := map[string]int{}
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			for _, lambda := range sc.expectedLambdas {
+				for _, b := range branchesFor(lambda) {
+					branches[b]++
+				}
+			}
+			p := simulator.NewParams(map[string][]float64{
+				"infection_probability":  {sc.infectionProb},
+				"patient_population":     {sc.population},
+				"colonisation_partition": {0},
+			})
+			histories := []*simulator.StateHistory{
+				history(sc.fractions),
+				history([]float64{0, 0}),
+			}
+			want := drawSamples(bespoke, mcSamples, 1, 2, &p, histories)
+			got := drawSamples(declarative, mcSamples, 1, 2, &p, histories)
+
+			for k, lane := range []string{"susceptible_bsi", "resistant_bsi"} {
+				wantMean, wantSd := moments(want[k])
+				gotMean, gotSd := moments(got[k])
+				lambda := sc.expectedLambdas[k]
+				// Both samplers must be centred on the lambda the wiring implies; this is
+				// what pins the upstream read and the rate formula. The reference sd is
+				// Poisson's own sqrt(lambda), floored at 1 so the lambda=0 lane (which is
+				// deterministically zero on both sides) still gets a usable bound.
+				refSd := math.Sqrt(math.Max(lambda, 1))
+				meanTol := mcTolerance(refSd, refSd, mcSamples, true)
+				sdTol := mcTolerance(refSd, refSd, mcSamples, false)
+				assertClose(t, gotMean, lambda, meanTol, lane+" mean vs lambda")
+				assertClose(t, wantMean, lambda, meanTol, lane+" bespoke mean vs lambda")
+				assertClose(t, gotMean, wantMean, meanTol, lane+" mean")
+				assertClose(t, gotSd, wantSd, sdTol, lane+" sd")
+				t.Logf("%s: lambda %.4f, mean %.6f vs %.6f, sd %.6f vs %.6f",
+					lane, lambda, gotMean, wantMean, gotSd, wantSd)
+			}
+		})
+	}
+	for _, b := range []string{
+		"bespoke_no_draw", "bespoke_knuth", "bespoke_normal_approximation",
+		"declarative_direct", "declarative_ptrs",
+	} {
+		if branches[b] == 0 {
+			t.Errorf("branch %q never exercised; the comparison is weaker than it looks", b)
+		}
+	}
+	t.Logf("sampler branches exercised: %v", branches)
+}
+
+func TestDeclarativeAMRAnswersTheSameClaims(t *testing.T) {
+	// The oracle is the model's own behaviour suite: every claim recomputed against the
+	// declarative build must still hold — same direction, same thresholds.
+	//
+	// It deliberately does NOT assert the observations match the bespoke numbers. The two
+	// builds sample from different generators, so they will not match, and a tolerance wide
+	// enough to admit them would assert nothing. What survives a change of draw stream is
+	// exactly what the claims are made of: the direction of each response and the magnitude
+	// thresholds. A twin with the wrong wiring, the wrong params or the wrong state layout
+	// still fails here.
+	if testing.Short() {
+		t.Skip("runs the full claim ensemble")
+	}
+	bespoke := ObservedBehaviour()
+	declarative := observedBehaviour(declarativeBuildStub)
+
+	if len(declarative) != len(bespoke) {
+		t.Fatalf("got %d claims, want %d", len(declarative), len(bespoke))
+	}
+	for i, claim := range declarative {
+		reference := bespoke[i]
+		if claim.ID != reference.ID {
+			t.Fatalf("claim %d: got ID %q, want %q", i, claim.ID, reference.ID)
+		}
+		if len(claim.Observations) != len(reference.Observations) {
+			t.Fatalf("claim %q: got %d observations, want %d",
+				claim.ID, len(claim.Observations), len(reference.Observations))
+		}
+		// Still a true claim when the model is data.
+		if err := cardgen.Verify(claim); err != nil {
+			t.Errorf("claim %q does not hold for the declarative model: %v", claim.ID, err)
+			continue
+		}
+		for k, obs := range claim.Observations {
+			t.Logf("%s / %s: declarative %.4f (bespoke %.4f)",
+				claim.ID, obs.Label, obs.Value, reference.Observations[k].Value)
+		}
+	}
+}

--- a/models/bathing-water-forecaster/behaviour.go
+++ b/models/bathing-water-forecaster/behaviour.go
@@ -28,17 +28,24 @@ func runStub(anomalyVolatility float64, numSteps int, seed uint64) *simulator.St
 	return store
 }
 
+// stubBuilder assembles the model, matching BuildStub's signature. The behaviour
+// helpers take one rather than calling BuildStub directly so that an alternative
+// assembly of the same model — notably the declarative one in declarative.yaml —
+// can be put through this exact claim suite instead of a re-stated copy of it.
+type stubBuilder func(anomalyVolatility float64, numSteps int, seed uint64) *simulator.ConfigGenerator
+
 // runStubOverride runs the stub with an override hook applied to the generated
 // config before the run, so a behaviour can vary any partition's params without
 // bloating BuildStub's signature — BuildStub still exposes only the one headline
 // driver (the anomaly volatility).
 func runStubOverride(
+	build stubBuilder,
 	anomalyVolatility float64,
 	numSteps int,
 	seed uint64,
 	override func(*simulator.ConfigGenerator),
 ) *simulator.StateTimeStorage {
-	gen := BuildStub(anomalyVolatility, numSteps, seed)
+	gen := build(anomalyVolatility, numSteps, seed)
 	if override != nil {
 		override(gen)
 	}
@@ -66,10 +73,15 @@ func meanPExceed(store *simulator.StateTimeStorage, site string) float64 {
 // meanPExceedEnsemble averages meanPExceed over an ensemble of independent
 // realisations (varying the anomaly seed), so each claim is about the distribution
 // rather than one noisy anomaly trajectory.
-func meanPExceedEnsemble(anomalyVolatility float64, numSteps, nMembers int, site string) float64 {
+func meanPExceedEnsemble(
+	build stubBuilder,
+	anomalyVolatility float64,
+	numSteps, nMembers int,
+	site string,
+) float64 {
 	sum := 0.0
 	for m := 0; m < nMembers; m++ {
-		store := runStub(anomalyVolatility, numSteps, uint64(1000+m))
+		store := runStubOverride(build, anomalyVolatility, numSteps, uint64(1000+m), nil)
 		sum += meanPExceed(store, site)
 	}
 	return sum / float64(nMembers)
@@ -78,13 +90,15 @@ func meanPExceedEnsemble(anomalyVolatility float64, numSteps, nMembers int, site
 // meanPExceedOverride is the ensemble-mean exceedance probability for a site under
 // an override, averaged over an ensemble of anomaly seeds.
 func meanPExceedOverride(
+	build stubBuilder,
 	numSteps, nMembers int,
 	site string,
 	override func(*simulator.ConfigGenerator),
 ) float64 {
 	sum := 0.0
 	for m := 0; m < nMembers; m++ {
-		store := runStubOverride(DefaultAnomalyVolatility, numSteps, uint64(3000+m), override)
+		store := runStubOverride(
+			build, DefaultAnomalyVolatility, numSteps, uint64(3000+m), override)
 		sum += meanPExceed(store, site)
 	}
 	return sum / float64(nMembers)
@@ -93,6 +107,7 @@ func meanPExceedOverride(
 // maxPExceedOverride is the ensemble-mean of the per-run peak exceedance
 // probability for a site under an override.
 func maxPExceedOverride(
+	build stubBuilder,
 	anomalyVolatility float64,
 	numSteps, nMembers int,
 	site string,
@@ -100,7 +115,7 @@ func maxPExceedOverride(
 ) float64 {
 	sum := 0.0
 	for m := 0; m < nMembers; m++ {
-		store := runStubOverride(anomalyVolatility, numSteps, uint64(6000+m), override)
+		store := runStubOverride(build, anomalyVolatility, numSteps, uint64(6000+m), override)
 		rows := store.GetValues(site)
 		peak := 0.0
 		for _, r := range rows {
@@ -139,13 +154,15 @@ func corr(a, b []float64) float64 {
 // meanCrossSiteCorrOverride is the ensemble-mean Pearson correlation between two
 // sites' exceedance-probability series under an override.
 func meanCrossSiteCorrOverride(
+	build stubBuilder,
 	numSteps, nMembers int,
 	siteA, siteB string,
 	override func(*simulator.ConfigGenerator),
 ) float64 {
 	sum := 0.0
 	for m := 0; m < nMembers; m++ {
-		store := runStubOverride(DefaultAnomalyVolatility, numSteps, uint64(9000+m), override)
+		store := runStubOverride(
+			build, DefaultAnomalyVolatility, numSteps, uint64(9000+m), override)
 		a := col(store.GetValues(siteA), 1)
 		b := col(store.GetValues(siteB), 1)
 		sum += corr(a, b)
@@ -182,28 +199,35 @@ func setAnomalyParam(gen *simulator.ConfigGenerator, key string, value float64) 
 //
 // The claim IDs match the subtest names under TestBathingWaterExpectedBehaviour.
 func ObservedBehaviour() []cardgen.Claim {
+	return observedBehaviour(BuildStub)
+}
+
+// observedBehaviour computes the claims against a given assembly of the model. The
+// equivalence test runs it against the declarative build so that the data-only model
+// answers the same claims, measured the same way.
+func observedBehaviour(build stubBuilder) []cardgen.Claim {
 	const pExceed = "ensemble-mean exceedance probability"
 
 	// Shared 365-step / 12-member clean baselines, reused across the actionable and
 	// structural claims that perturb one input against them (avoids recomputing the
 	// same base each time).
 	const steps, nMembers = 365, 12
-	baseSite0 := meanPExceedOverride(steps, nMembers, "site_0", nil)
-	baseSite1 := meanPExceedOverride(steps, nMembers, "site_1", nil)
+	baseSite0 := meanPExceedOverride(build, steps, nMembers, "site_0", nil)
+	baseSite1 := meanPExceedOverride(build, steps, nMembers, "site_1", nil)
 
 	// Decision-path: pollution reduction (halving a site's clean-water baseline count).
-	cleaned := meanPExceedOverride(steps, nMembers, "site_1", func(g *simulator.ConfigGenerator) {
+	cleaned := meanPExceedOverride(build, steps, nMembers, "site_1", func(g *simulator.ConfigGenerator) {
 		setSiteParam(g, "site_1", "baseline", math.Log(75.0))
 	})
 
 	// Decision-path: a stricter (lower) statutory threshold.
-	stricter := meanPExceedOverride(steps, nMembers, "site_0", func(g *simulator.ConfigGenerator) {
+	stricter := meanPExceedOverride(build, steps, nMembers, "site_0", func(g *simulator.ConfigGenerator) {
 		setSiteParam(g, "site_0", "log_threshold", math.Log(250.0))
 	})
 
 	// Structural headline: a more volatile shared regional anomaly.
-	calm := meanPExceedEnsemble(0.3, 400, 16, "site_0")
-	stormy := meanPExceedEnsemble(0.8, 400, 16, "site_0")
+	calm := meanPExceedEnsemble(build, 0.3, 400, 16, "site_0")
+	stormy := meanPExceedEnsemble(build, 0.8, 400, 16, "site_0")
 
 	// Structural: stronger regional coupling (larger anomaly loading on both sites),
 	// with the seasonal terms in antiphase so near-zero coupling decorrelates them.
@@ -211,36 +235,36 @@ func ObservedBehaviour() []cardgen.Claim {
 		setSiteParam(g, "site_0", "seasonal_phase", 0.0)
 		setSiteParam(g, "site_1", "seasonal_phase", math.Pi)
 	}
-	weakCorr := meanCrossSiteCorrOverride(600, 10, "site_0", "site_1", func(g *simulator.ConfigGenerator) {
+	weakCorr := meanCrossSiteCorrOverride(build, 600, 10, "site_0", "site_1", func(g *simulator.ConfigGenerator) {
 		antiphase(g)
 		setSiteParam(g, "site_0", "anomaly_loading", 0.05)
 		setSiteParam(g, "site_1", "anomaly_loading", 0.05)
 	})
-	strongCorr := meanCrossSiteCorrOverride(600, 10, "site_0", "site_1", func(g *simulator.ConfigGenerator) {
+	strongCorr := meanCrossSiteCorrOverride(build, 600, 10, "site_0", "site_1", func(g *simulator.ConfigGenerator) {
 		antiphase(g)
 		setSiteParam(g, "site_0", "anomaly_loading", 1.5)
 		setSiteParam(g, "site_1", "anomaly_loading", 1.5)
 	})
 
 	// Structural: faster anomaly mean-reversion (higher theta) shrinks its variance.
-	persistent := meanPExceedOverride(400, 16, "site_0", func(g *simulator.ConfigGenerator) {
+	persistent := meanPExceedOverride(build, 400, 16, "site_0", func(g *simulator.ConfigGenerator) {
 		setAnomalyParam(g, "thetas", 0.15)
 	})
-	fleeting := meanPExceedOverride(400, 16, "site_0", func(g *simulator.ConfigGenerator) {
+	fleeting := meanPExceedOverride(build, 400, 16, "site_0", func(g *simulator.ConfigGenerator) {
 		setAnomalyParam(g, "thetas", 0.6)
 	})
 
 	// Structural: a larger within-site sample scale fattens the tail.
-	noisier := meanPExceedOverride(steps, nMembers, "site_0", func(g *simulator.ConfigGenerator) {
+	noisier := meanPExceedOverride(build, steps, nMembers, "site_0", func(g *simulator.ConfigGenerator) {
 		setSiteParam(g, "site_0", "sample_scale", 1.4)
 	})
 
 	// Structural: a larger seasonal amplitude raises the peak-season exceedance,
 	// measured as the per-run peak with the anomaly volatility damped.
-	flat := maxPExceedOverride(0.1, 365, 8, "site_0", func(g *simulator.ConfigGenerator) {
+	flat := maxPExceedOverride(build, 0.1, 365, 8, "site_0", func(g *simulator.ConfigGenerator) {
 		setSiteParam(g, "site_0", "seasonal_amplitude", 0.2)
 	})
-	swingy := maxPExceedOverride(0.1, 365, 8, "site_0", func(g *simulator.ConfigGenerator) {
+	swingy := maxPExceedOverride(build, 0.1, 365, 8, "site_0", func(g *simulator.ConfigGenerator) {
 		setSiteParam(g, "site_0", "seasonal_amplitude", 1.2)
 	})
 

--- a/models/bathing-water-forecaster/declarative.yaml
+++ b/models/bathing-water-forecaster/declarative.yaml
@@ -1,0 +1,126 @@
+# The bathing-water-forecaster generative core, written entirely as data: no Go, no
+# compilation.
+#
+# This is the same model BuildStub assembles in stub.go, with the same partition names,
+# param keys, state layout and wiring, so the two can be compared directly (see
+# expression_equivalence_test.go, which checks per-step agreement and re-runs the whole
+# behaviour suite against this file). The run knobs BuildStub takes as arguments (seed,
+# horizon, anomaly volatility) are injected by the caller; everything below is the model.
+#
+# No index constant needed replacing by a data mask here, unlike anglersim's tempIndex:
+# every param this model reads is width 1, so the Go [0] subscripts are scalar reads that
+# broadcasting already expresses.
+#
+# The baseline and log_threshold literals are logs of counts in CFU/100ml, written as the
+# shortest decimal that round-trips to the same float64 math.Log returns in stub.go — an
+# approximate transcription would show up as a real disagreement rather than as rounding.
+main:
+  partitions:
+
+  # Shared regional wet-week anomaly z(t): an Ornstein-Uhlenbeck process under the same
+  # Euler-Maruyama discretisation continuous.OrnsteinUhlenbeckIteration applies. sigmas is
+  # the swept headline driver and is injected per run.
+  - name: anomaly
+    params:
+      thetas: [0.3]
+      mus: [0.0]
+      sigmas: [0.5]
+    init_state_values: [0.0]
+    state_history_depth: 1
+    seed: 0
+
+  # The three designated sites, each mapping its latent log-concentration to an exceedance
+  # probability. They are separate partitions rather than one 3-wide partition because that
+  # is the shape BuildStub gives them, and they read the one shared anomaly within-step via
+  # params_from_upstream — the param key is simply the name the expressions then see.
+  # Sites draw no randomness, so their seeds are immaterial (BuildStub also pins them to 0).
+
+  # Clean, moderately coherent.
+  - name: site_0
+    params:
+      baseline: [4.605170185988092]
+      seasonal_amplitude: [0.5]
+      seasonal_phase: [0.0]
+      period: [365.0]
+      anomaly_loading: [0.7]
+      sample_scale: [0.8]
+      log_threshold: [6.214608098422191]
+    params_from_upstream:
+      anomaly:
+        upstream: anomaly
+    init_state_values: [0.0, 0.0]
+    state_history_depth: 1
+    seed: 0
+
+  # More urban, strongly coherent.
+  - name: site_1
+    params:
+      baseline: [5.0106352940962555]
+      seasonal_amplitude: [0.5]
+      seasonal_phase: [0.0]
+      period: [365.0]
+      anomaly_loading: [0.9]
+      sample_scale: [0.8]
+      log_threshold: [6.214608098422191]
+    params_from_upstream:
+      anomaly:
+        upstream: anomaly
+    init_state_values: [0.0, 0.0]
+    state_history_depth: 1
+    seed: 0
+
+  # Clean, weakly coherent (mostly local).
+  - name: site_2
+    params:
+      baseline: [4.499809670330265]
+      seasonal_amplitude: [0.5]
+      seasonal_phase: [0.0]
+      period: [365.0]
+      anomaly_loading: [0.4]
+      sample_scale: [0.8]
+      log_threshold: [6.214608098422191]
+    params_from_upstream:
+      anomaly:
+        upstream: anomaly
+    init_state_values: [0.0, 0.0]
+    state_history_depth: 1
+    seed: 0
+
+  expressions:
+
+  # One normal draw per step, matching the single NormFloat64 the Go loop takes for this
+  # one-dimensional state, which is what keeps the two draw streams in lockstep. Both
+  # params are scalar, so shared() states that the one sample applies to the whole field.
+  - partition: anomaly
+    fields:
+    - {name: z}
+    outputs: ["z + thetas * (mus - z) * dt + shared(normal(0, sigmas * sqrt(dt)))"]
+
+  # The site update is identical across the three; only their params differ. It is written
+  # once and aliased so the three cannot drift apart.
+  #
+  # The step is deterministic: all stochastic, cross-site-correlated variation arrives
+  # through the shared anomaly, while sample_scale is integrated out analytically inside
+  # the Gaussian CDF. That CDF is spelled out as 0.5 * erfc(-x / sqrt(2)) — the same
+  # formula the Go normalCDF uses, term for term, so the two agree to rounding.
+  - partition: site_0
+    fields: &site_fields
+    - {name: mu}
+    - {name: p_exceed}
+    bindings: &site_bindings
+    - {name: season, expr: "seasonal_amplitude * sin(2 * pi * t / period + seasonal_phase)"}
+    - {name: latent, expr: "baseline + season + anomaly_loading * anomaly"}
+    - {name: z_score, expr: "(latent - log_threshold) / sample_scale"}
+    outputs: &site_outputs
+    - "latent"
+    - "0.5 * erfc(-z_score / sqrt(2))"
+
+  - partition: site_1
+    fields: *site_fields
+    bindings: *site_bindings
+    outputs: *site_outputs
+
+  - partition: site_2
+    fields: *site_fields
+    bindings: *site_bindings
+    outputs: *site_outputs

--- a/models/bathing-water-forecaster/expression_equivalence_test.go
+++ b/models/bathing-water-forecaster/expression_equivalence_test.go
@@ -1,0 +1,285 @@
+package bathingwater
+
+// Does declarative.yaml — this model written as data, with no Go — reproduce the model
+// stub.go builds in code?
+//
+// Two independent checks, because they fail in different ways. The step-for-step tests
+// compare single Iterate calls over randomised inputs, which catches a mis-stated formula
+// exactly. The suite test re-runs the model's own claim computations against the
+// declarative build, which catches a model that is subtly different in a way per-step
+// agreement would not: wrong wiring, wrong param values, wrong state layout.
+//
+// The anomaly is the only partition that draws: it takes one normal per step from a stream
+// seeded exactly as the declarative one is (rng.New(seed) and rand.New(rand.NewPCG(seed,
+// seed)) are the same generator), so the two stay in lockstep and equivalence is decidable
+// directly rather than only in distribution. The sites draw nothing at all — every
+// stochastic, cross-site-correlated movement reaches them through the anomaly — so their
+// agreement is a pure question of formula.
+//
+// Agreement is asserted to a tight tolerance rather than bit-for-bit: compiled Go is free
+// to contract a + b*c into a fused multiply-add, which rounds differently from the
+// evaluator's separate operations.
+
+import (
+	"math"
+	"math/rand/v2"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+
+	"github.com/umbralcalc/stochadex/models/cardgen"
+	"github.com/umbralcalc/stochadex/pkg/api"
+	"github.com/umbralcalc/stochadex/pkg/continuous"
+	"github.com/umbralcalc/stochadex/pkg/general"
+	"github.com/umbralcalc/stochadex/pkg/simulator"
+)
+
+// tolerance is well above FMA rounding and well below any difference a real modelling
+// discrepancy would produce.
+const tolerance = 1e-12
+
+// declarativeBuildStub assembles the model from declarative.yaml, matching BuildStub's
+// signature so it can be dropped into the behaviour helpers. The YAML holds the model; the
+// run knobs BuildStub takes as arguments are injected here, exactly as BuildStub injects
+// them into its Go partitions. The sites need no seed injected because BuildStub pins them
+// to 0 and they draw nothing.
+func declarativeBuildStub(
+	anomalyVolatility float64,
+	numSteps int,
+	seed uint64,
+) *simulator.ConfigGenerator {
+	config := api.LoadApiRunConfigFromYaml("declarative.yaml")
+	config.Main.Simulation = simulator.SimulationConfig{
+		OutputCondition: &simulator.EveryStepOutputCondition{},
+		TerminationCondition: &simulator.NumberOfStepsTerminationCondition{
+			MaxNumberOfSteps: numSteps,
+		},
+		TimestepFunction: &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+		InitTimeValue:    0.0,
+	}
+	gen := config.Main.GetConfigGenerator()
+	gen.GetPartition("anomaly").Params.Map["sigmas"] = []float64{anomalyVolatility}
+	gen.GetPartition("anomaly").Seed = seed
+	return gen
+}
+
+// declarativeIteration returns the expression iteration the YAML supplies for a partition,
+// alongside the params it declares.
+func declarativeIteration(
+	t *testing.T,
+	partition string,
+) (*general.ExpressionIteration, map[string][]float64) {
+	t.Helper()
+	config := declarativeBuildStub(DefaultAnomalyVolatility, 10, 0).GetPartition(partition)
+	iteration, ok := config.Iteration.(*general.ExpressionIteration)
+	if !ok {
+		t.Fatalf("%s is not expression-backed: got %T", partition, config.Iteration)
+	}
+	return iteration, config.Params.Map
+}
+
+// assertClose fails when two values differ by more than the FMA-scale tolerance, comparing
+// relatively once the magnitude exceeds 1.
+func assertClose(t *testing.T, got, want float64, context string) float64 {
+	t.Helper()
+	d := math.Abs(got - want)
+	if s := math.Abs(want); s > 1 {
+		d /= s
+	}
+	if d > tolerance {
+		t.Fatalf("%s: declarative=%v bespoke=%v deviation=%g", context, got, want, d)
+	}
+	return d
+}
+
+func TestDeclarativeAnomalyMatchesBespoke(t *testing.T) {
+	bespoke := &continuous.OrnsteinUhlenbeckIteration{}
+	declarative, _ := declarativeIteration(t, "anomaly")
+	settings := &simulator.Settings{
+		Iterations: []simulator.IterationSettings{{Name: "anomaly", Seed: 5}},
+	}
+	bespoke.Configure(0, settings)
+	declarative.Configure(0, settings)
+
+	rng := rand.New(rand.NewPCG(31, 32))
+	// The Euler-Maruyama step is branch-free, so what needs covering is its regimes rather
+	// than any if: the drift must be seen pulling from both sides of the mean (a sign error
+	// in mus - z hides entirely when z is always below it), and the two streams must be
+	// seen staying aligned across a varying volatility.
+	regimes := map[string]int{}
+	maxDev := 0.0
+
+	const cases = 20000
+	for i := 0; i < cases; i++ {
+		z := rng.Float64()*8 - 4
+		mu := rng.Float64()*2 - 1
+		p := simulator.NewParams(map[string][]float64{
+			"thetas": {rng.Float64()},
+			"mus":    {mu},
+			"sigmas": {rng.Float64()},
+		})
+		mk := func() []*simulator.StateHistory {
+			return []*simulator.StateHistory{{
+				Values:            mat.NewDense(1, 1, []float64{z}),
+				StateWidth:        1,
+				StateHistoryDepth: 1,
+			}}
+		}
+		// dt is swept away from 1 even though the model runs at a constant stepsize of 1,
+		// because at dt=1 both the drift's dt factor and the diffusion's sqrt(dt) are
+		// no-ops: a twin that dropped either would agree anyway, and the test would be
+		// asserting less than it appears to.
+		dt := 0.25 + rng.Float64()*1.75
+		ts := &simulator.CumulativeTimestepsHistory{
+			Values:            mat.NewVecDense(1, []float64{float64(i)}),
+			NextIncrement:     dt,
+			CurrentStepNumber: i + 1,
+		}
+		if dt > 1 {
+			regimes["dt_above_1"]++
+		} else {
+			regimes["dt_below_1"]++
+		}
+
+		want := bespoke.Iterate(&p, 0, mk(), ts)
+		got := declarative.Iterate(&p, 0, mk(), ts)
+
+		if z > mu {
+			regimes["reverting_down"]++
+		} else {
+			regimes["reverting_up"]++
+		}
+		maxDev = math.Max(maxDev, assertClose(t, got[0], want[0], "anomaly"))
+	}
+	for _, r := range []string{
+		"reverting_down", "reverting_up", "dt_above_1", "dt_below_1",
+	} {
+		if regimes[r] == 0 {
+			t.Errorf("regime %q never exercised; the comparison is weaker than it looks", r)
+		}
+	}
+	t.Logf("regimes exercised: %v", regimes)
+	t.Logf("max deviation: %g", maxDev)
+}
+
+func TestDeclarativeConcentrationMatchesBespoke(t *testing.T) {
+	bespoke := &BathingConcentrationIteration{}
+	declarative, _ := declarativeIteration(t, "site_0")
+	settings := &simulator.Settings{
+		Iterations: []simulator.IterationSettings{{Name: "site_0", Seed: 5}},
+	}
+	bespoke.Configure(0, settings)
+	declarative.Configure(0, settings)
+
+	rng := rand.New(rand.NewPCG(41, 42))
+	// BathingConcentrationIteration has no if in it, so the branches that must be covered
+	// are the ones inside the transcendental functions the two sides each call: math.Erfc
+	// switches algorithm by magnitude, and saturates to 0 and to 2 in the tails. The
+	// exceedance tails are also where this model is actually read — a site sits below the
+	// threshold nearly always — so agreeing only in the comfortable middle would be a weak
+	// result. The ranges below are deliberately wider than the default scenario (which
+	// pins z_score near -2) to reach both saturated tails.
+	branches := map[string]int{}
+	maxDev := 0.0
+
+	const cases = 20000
+	for i := 0; i < cases; i++ {
+		// A wide sample_scale range is what spreads z_score across roughly [-50, 50]: at
+		// the small end the tails saturate, at the large end the mid-range is dense.
+		sigma := 0.1 + rng.Float64()*2.0
+		p := simulator.NewParams(map[string][]float64{
+			"baseline":           {2 + rng.Float64()*6},
+			"seasonal_amplitude": {rng.Float64() * 2},
+			"seasonal_phase":     {rng.Float64() * 2 * math.Pi},
+			"period":             {30 + rng.Float64()*370},
+			"anomaly_loading":    {rng.Float64()*2 - 0.5},
+			"sample_scale":       {sigma},
+			"log_threshold":      {5 + rng.Float64()*2},
+			"anomaly":            {rng.Float64()*8 - 4},
+		})
+		mk := func() []*simulator.StateHistory {
+			return []*simulator.StateHistory{{
+				Values:            mat.NewDense(1, 2, []float64{0, 0}),
+				StateWidth:        2,
+				StateHistoryDepth: 1,
+			}}
+		}
+		// Cumulative time is swept over many periods and is what drives the seasonal term,
+		// so sin is compared across its whole cycle rather than near one phase.
+		ts := &simulator.CumulativeTimestepsHistory{
+			Values:            mat.NewVecDense(1, []float64{rng.Float64() * 2000}),
+			NextIncrement:     1.0,
+			CurrentStepNumber: i + 1,
+		}
+
+		want := bespoke.Iterate(&p, 0, mk(), ts)
+		got := declarative.Iterate(&p, 0, mk(), ts)
+
+		switch {
+		case want[1] < 1e-6:
+			branches["p_lower_tail"]++
+		case want[1] > 1-1e-6:
+			branches["p_upper_tail"]++
+		default:
+			branches["p_mid_range"]++
+		}
+		// The seasonal term must be seen on both sides of zero, or a sign or phase error in
+		// the sin argument would survive.
+		season := want[0] - p.Map["baseline"][0] -
+			p.Map["anomaly_loading"][0]*p.Map["anomaly"][0]
+		if season > 0 {
+			branches["season_positive"]++
+		} else {
+			branches["season_negative"]++
+		}
+
+		maxDev = math.Max(maxDev, assertClose(t, got[0], want[0], "mu"))
+		maxDev = math.Max(maxDev, assertClose(t, got[1], want[1], "p_exceed"))
+	}
+	for _, b := range []string{
+		"p_lower_tail", "p_upper_tail", "p_mid_range",
+		"season_positive", "season_negative",
+	} {
+		if branches[b] == 0 {
+			t.Errorf("branch %q never exercised; the comparison is weaker than it looks", b)
+		}
+	}
+	t.Logf("branches exercised: %v", branches)
+	t.Logf("max deviation: %g", maxDev)
+}
+
+func TestDeclarativeBathingWaterAnswersTheSameClaims(t *testing.T) {
+	// The oracle is the model's own behaviour suite: every claim recomputed against the
+	// declarative build must still hold, and must hold with the same numbers the card
+	// reports — not merely point the same way.
+	if testing.Short() {
+		t.Skip("runs the full claim ensemble twice")
+	}
+	bespoke := ObservedBehaviour()
+	declarative := observedBehaviour(declarativeBuildStub)
+
+	if len(declarative) != len(bespoke) {
+		t.Fatalf("got %d claims, want %d", len(declarative), len(bespoke))
+	}
+	maxDev := 0.0
+	for i, claim := range declarative {
+		reference := bespoke[i]
+		if claim.ID != reference.ID {
+			t.Fatalf("claim %d: got ID %q, want %q", i, claim.ID, reference.ID)
+		}
+		// Still a true claim when the model is data.
+		if err := cardgen.Verify(claim); err != nil {
+			t.Errorf("claim %q does not hold for the declarative model: %v", claim.ID, err)
+			continue
+		}
+		if len(claim.Observations) != len(reference.Observations) {
+			t.Fatalf("claim %q: got %d observations, want %d",
+				claim.ID, len(claim.Observations), len(reference.Observations))
+		}
+		for k, obs := range claim.Observations {
+			maxDev = math.Max(maxDev, assertClose(t, obs.Value,
+				reference.Observations[k].Value, claim.ID+" / "+obs.Label))
+		}
+	}
+	t.Logf("max deviation across every observation on every claim: %g", maxDev)
+}

--- a/models/bathing-water-forecaster/stub_test.go
+++ b/models/bathing-water-forecaster/stub_test.go
@@ -56,8 +56,8 @@ func TestBathingWaterStub(t *testing.T) {
 	t.Run("more volatile anomaly raises mean exceedance", func(t *testing.T) {
 		const numSteps, nMembers = 400, 16
 
-		calm := meanPExceedEnsemble(0.3, numSteps, nMembers, "site_0")
-		stormy := meanPExceedEnsemble(0.8, numSteps, nMembers, "site_0")
+		calm := meanPExceedEnsemble(BuildStub, 0.3, numSteps, nMembers, "site_0")
+		stormy := meanPExceedEnsemble(BuildStub, 0.8, numSteps, nMembers, "site_0")
 
 		if !(stormy > calm) {
 			t.Fatalf("expected a more volatile anomaly to raise mean exceedance: "+

--- a/models/business-survival/behaviour.go
+++ b/models/business-survival/behaviour.go
@@ -13,17 +13,24 @@ import (
 // computation here — not in a _test.go file — is what lets the card show exactly
 // the numbers the test asserts on, so the two can never disagree.
 
+// stubBuilder assembles the model, matching BuildStub's signature. The behaviour
+// helpers take one rather than calling BuildStub directly so that an alternative
+// assembly of the same model — notably the declarative one in declarative.yaml —
+// can be put through this exact claim suite instead of a re-stated copy of it.
+type stubBuilder func(hazardScale float64, numSteps int, seed uint64) *simulator.ConfigGenerator
+
 // runStubOverride runs the stub with an override hook applied to the generated
 // config before the run, so a behaviour can vary any partition's params (policy
 // multipliers, elasticities, covariates, survival curve) without bloating
 // BuildStub's signature — BuildStub still exposes only the one headline driver.
 func runStubOverride(
+	build stubBuilder,
 	hazardScale float64,
 	numSteps int,
 	seed uint64,
 	override func(*simulator.ConfigGenerator),
 ) *simulator.StateTimeStorage {
-	gen := BuildStub(hazardScale, numSteps, seed)
+	gen := build(hazardScale, numSteps, seed)
 	if override != nil {
 		override(gen)
 	}
@@ -101,10 +108,11 @@ func meanBackHalfSectorStock(rows [][]float64, sec int) float64 {
 // deterministicBackHalfStock runs one deterministic stub and returns the back-half
 // mean register stock. Deterministic mode makes a single run sufficient.
 func deterministicBackHalfStock(
+	build stubBuilder,
 	hazardScale float64,
 	extra func(*simulator.ConfigGenerator),
 ) float64 {
-	store := runStubOverride(hazardScale, DefaultNumSteps, 7001, func(g *simulator.ConfigGenerator) {
+	store := runStubOverride(build, hazardScale, DefaultNumSteps, 7001, func(g *simulator.ConfigGenerator) {
 		deterministic(g)
 		if extra != nil {
 			extra(g)
@@ -130,10 +138,11 @@ func cohortInit() []float64 {
 // deterministic), seeding one cohort at age 0 and returning the fraction still
 // active after 60 months. This is the model's signature decision metric.
 func cohortSurvival(
+	build stubBuilder,
 	hazardScale float64,
 	extra func(*simulator.ConfigGenerator),
 ) float64 {
-	store := runStubOverride(hazardScale, 60, 7001, func(g *simulator.ConfigGenerator) {
+	store := runStubOverride(build, hazardScale, 60, 7001, func(g *simulator.ConfigGenerator) {
 		deterministic(g)
 		setVec(g, "base_birth_rates", make([]float64, numSectors)) // formation off
 		g.GetPartition("population").InitStateValues = cohortInit()
@@ -154,6 +163,13 @@ func cohortSurvival(
 //
 // The claim IDs match the subtest names under TestBusinessSurvivalExpectedBehaviour.
 func ObservedBehaviour() []cardgen.Claim {
+	return observedBehaviour(BuildStub)
+}
+
+// observedBehaviour computes the claims against a given assembly of the model. The
+// equivalence test runs it against the declarative build so that the data-only
+// model answers the same claims, measured the same way.
+func observedBehaviour(build stubBuilder) []cardgen.Claim {
 	const (
 		stock       = "deterministic back-half register stock"
 		sectorStk   = "deterministic back-half sector stock"
@@ -165,32 +181,32 @@ func ObservedBehaviour() []cardgen.Claim {
 
 	// Shared deterministic baselines, reused across the claims that perturb one
 	// input against them (avoids recomputing the same base each time).
-	detBase := deterministicBackHalfStock(DefaultPolicyHazardScale, nil)
-	baseRun := runStubOverride(DefaultPolicyHazardScale, DefaultNumSteps, 7001, deterministic)
+	detBase := deterministicBackHalfStock(build, DefaultPolicyHazardScale, nil)
+	baseRun := runStubOverride(build, DefaultPolicyHazardScale, DefaultNumSteps, 7001, deterministic)
 	baseRows := baseRun.GetValues("population")
 	baseTech := meanBackHalfSectorStock(baseRows, tech)
 	baseHosp := meanBackHalfSectorStock(baseRows, hospitality)
 	baseRetail := meanBackHalfSectorStock(baseRows, retail)
-	calm := cohortSurvival(DefaultPolicyHazardScale, nil)
+	calm := cohortSurvival(build, DefaultPolicyHazardScale, nil)
 
 	// ----- Decision-path responses (actionable support levers) -----
 
-	supported := cohortSurvival(0.85, nil)
-	adverse := cohortSurvival(1.15, nil)
+	supported := cohortSurvival(build, 0.85, nil)
+	adverse := cohortSurvival(build, 1.15, nil)
 
-	boostedFormation := deterministicBackHalfStock(DefaultPolicyHazardScale, func(g *simulator.ConfigGenerator) {
+	boostedFormation := deterministicBackHalfStock(build, DefaultPolicyHazardScale, func(g *simulator.ConfigGenerator) {
 		setParam(g, "policy_birth_scale", 1.2)
 	})
 
-	infantHelped := cohortSurvival(DefaultPolicyHazardScale, func(g *simulator.ConfigGenerator) {
+	infantHelped := cohortSurvival(build, DefaultPolicyHazardScale, func(g *simulator.ConfigGenerator) {
 		setParam(g, "policy_infant_hazard_scale", 0.3)
 	})
-	infantHurt := cohortSurvival(DefaultPolicyHazardScale, func(g *simulator.ConfigGenerator) {
+	infantHurt := cohortSurvival(build, DefaultPolicyHazardScale, func(g *simulator.ConfigGenerator) {
 		setParam(g, "policy_infant_hazard_scale", 1.7)
 	})
 
 	targetedTech := meanBackHalfSectorStock(
-		runStubOverride(DefaultPolicyHazardScale, DefaultNumSteps, 7001, func(g *simulator.ConfigGenerator) {
+		runStubOverride(build, DefaultPolicyHazardScale, DefaultNumSteps, 7001, func(g *simulator.ConfigGenerator) {
 			deterministic(g)
 			scale := make([]float64, numSectors)
 			for i := range scale {
@@ -201,7 +217,7 @@ func ObservedBehaviour() []cardgen.Claim {
 		}).GetValues("population"), tech)
 
 	relievedHosp := meanBackHalfSectorStock(
-		runStubOverride(DefaultPolicyHazardScale, DefaultNumSteps, 7001, func(g *simulator.ConfigGenerator) {
+		runStubOverride(build, DefaultPolicyHazardScale, DefaultNumSteps, 7001, func(g *simulator.ConfigGenerator) {
 			deterministic(g)
 			scale := make([]float64, numSectors)
 			for i := range scale {
@@ -213,7 +229,7 @@ func ObservedBehaviour() []cardgen.Claim {
 
 	// ----- Structural-driver responses (non-actionable; out-of-sample credibility) -----
 
-	worseCurve := deterministicBackHalfStock(DefaultPolicyHazardScale, func(g *simulator.ConfigGenerator) {
+	worseCurve := deterministicBackHalfStock(build, DefaultPolicyHazardScale, func(g *simulator.ConfigGenerator) {
 		scaled := make([]float64, len(DefaultSurvivalFracs))
 		for i, v := range DefaultSurvivalFracs {
 			scaled[i] = v * 0.9 // uniformly worse survival at every horizon
@@ -221,39 +237,39 @@ func ObservedBehaviour() []cardgen.Claim {
 		setVec(g, "survival_fracs", scaled)
 	})
 
-	lowRate := deterministicBackHalfStock(DefaultPolicyHazardScale, func(g *simulator.ConfigGenerator) {
+	lowRate := deterministicBackHalfStock(build, DefaultPolicyHazardScale, func(g *simulator.ConfigGenerator) {
 		setParam(g, "birth_elasticity_rate", -0.5)
 		setVec(g, "covariate_bank_rates", []float64{0.5}) // = reference → neutral
 	})
-	highRate := deterministicBackHalfStock(DefaultPolicyHazardScale, func(g *simulator.ConfigGenerator) {
+	highRate := deterministicBackHalfStock(build, DefaultPolicyHazardScale, func(g *simulator.ConfigGenerator) {
 		setParam(g, "birth_elasticity_rate", -0.5)
 		setVec(g, "covariate_bank_rates", []float64{3.0}) // tighter → fewer births
 	})
 
-	lowClaimant := deterministicBackHalfStock(DefaultPolicyHazardScale, func(g *simulator.ConfigGenerator) {
+	lowClaimant := deterministicBackHalfStock(build, DefaultPolicyHazardScale, func(g *simulator.ConfigGenerator) {
 		setParam(g, "birth_elasticity_claimant", -0.4)
 		setVec(g, "covariate_claimants", []float64{12000.0}) // = reference → neutral
 	})
-	highClaimant := deterministicBackHalfStock(DefaultPolicyHazardScale, func(g *simulator.ConfigGenerator) {
+	highClaimant := deterministicBackHalfStock(build, DefaultPolicyHazardScale, func(g *simulator.ConfigGenerator) {
 		setParam(g, "birth_elasticity_claimant", -0.4)
 		setVec(g, "covariate_claimants", []float64{24000.0}) // weaker economy
 	})
 
-	lowDeathRate := cohortSurvival(DefaultPolicyHazardScale, func(g *simulator.ConfigGenerator) {
+	lowDeathRate := cohortSurvival(build, DefaultPolicyHazardScale, func(g *simulator.ConfigGenerator) {
 		setParam(g, "death_elasticity_rate", 0.5)
 		setVec(g, "covariate_bank_rates", []float64{0.5}) // = reference → neutral
 	})
-	highDeathRate := cohortSurvival(DefaultPolicyHazardScale, func(g *simulator.ConfigGenerator) {
+	highDeathRate := cohortSurvival(build, DefaultPolicyHazardScale, func(g *simulator.ConfigGenerator) {
 		setParam(g, "death_elasticity_rate", 0.5)
 		setVec(g, "covariate_bank_rates", []float64{3.0}) // tighter → higher hazard
 	})
 
-	distressed := cohortSurvival(DefaultPolicyHazardScale, func(g *simulator.ConfigGenerator) {
+	distressed := cohortSurvival(build, DefaultPolicyHazardScale, func(g *simulator.ConfigGenerator) {
 		setVec(g, "distress_hazard_boost", []float64{0.3}) // +30% hazard
 	})
 
 	burdenedRetail := meanBackHalfSectorStock(
-		runStubOverride(DefaultPolicyHazardScale, DefaultNumSteps, 7001, func(g *simulator.ConfigGenerator) {
+		runStubOverride(build, DefaultPolicyHazardScale, DefaultNumSteps, 7001, func(g *simulator.ConfigGenerator) {
 			deterministic(g)
 			scale := append([]float64(nil), DefaultSectorHazardScales...)
 			scale[retail] = 1.5

--- a/models/business-survival/declarative.yaml
+++ b/models/business-survival/declarative.yaml
@@ -1,0 +1,242 @@
+# The business-survival generative core, written entirely as data: no Go, no compilation.
+#
+# This is the same model BuildStub assembles in stub.go — same partition name, same param
+# keys, same state layout — so the two can be compared directly (see
+# expression_equivalence_test.go, which checks per-step agreement and re-runs the whole
+# behaviour suite against this file). The run knobs BuildStub takes as arguments (the
+# support-policy hazard scale, the horizon, the seed) are injected by the caller; everything
+# below is the model.
+#
+# This is the entry that had no twin until each/slice/concat existed. The register is a
+# flattened sector × age grid, element i of the next state reads element i-1 (a business ages
+# one month), age 0 takes formation, and the top bucket is absorbing — an index shift, which
+# an elementwise evaluator cannot say. each(360, k, ...) says it: the lane index carries both
+# coordinates (sec = floor(k/60), age = k%60, exactly SingleLAPopulationIteration's
+# offset(sec, age) = sec*60 + age), the lane reads register[k-1], and everything inside a lane
+# is scalar so the boundary guards are lazy and register[-1] is never evaluated.
+#
+# Three params-as-data notes:
+#
+#  - The Go derives its 60 monthly hazards in Configure, from survival_fracs and
+#    sector_hazard_scales. Here they are derived per step from the same params, in bindings —
+#    same arithmetic, no cached table. That is a strictly more faithful statement of the model:
+#    the Go's cache means a mid-run change to survival_fracs is silently ignored, which is a
+#    property of the implementation and not of the demography.
+#  - Same for deterministic, which the Go also snapshots in Configure and this reads live.
+#    Every assembly sets it before Configure, so the two agree everywhere it is used.
+#  - The Go treats several params as optional, defaulting when absent (GetOk). A declarative
+#    partition has no notion of an absent name, so each optional param is stated here at its
+#    no-effect value, which is exactly what the Go's absent branch computes. The *validity*
+#    guards on those params (a negative scalar or a non-positive per-sector multiplier falls
+#    back to the default) are real branches and are stated below.
+main:
+  partitions:
+
+  # The monthly sector × age Leslie register for one local authority: 6 sectors × 60 age
+  # buckets, flattened, sec-major.
+  - name: population
+    params:
+      survival_fracs: [0.946, 0.747, 0.559, 0.45, 0.384]
+      sector_hazard_scales: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+      base_birth_rates: [5.0, 4.0, 6.0, 4.0, 5.0, 3.0]
+      covariate_bank_rates: [0.5]
+      covariate_claimants: [12000.0]
+      rate_ref: [0.5]
+      claimant_ref: [12000.0]
+      birth_elasticity_rate: [0.0]
+      birth_elasticity_claimant: [0.0]
+      death_elasticity_rate: [0.0]
+      # The one swept driver: support-policy hazard multiplier.
+      policy_death_hazard_scale: [1.0]
+      # Optional in the Go, stated here at the value its absent branch computes.
+      deterministic: [0.0]
+      policy_birth_scale: [1.0]
+      policy_infant_hazard_scale: [1.0]
+      policy_sector_birth_scale: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+      policy_sector_hazard_scale: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+      distress_hazard_boost: [0.0]
+      covariate_gdp_growth: [0.0]
+      gdp_ref: [0.0]
+      birth_elasticity_gdp: [0.0]
+    # The register starts empty and fills from formation. 360 = 6 sectors × 60 age buckets;
+    # this is what sets the partition's state width.
+    init_state_values:
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    state_history_depth: 1
+    seed: 0
+
+  expressions:
+
+  - partition: population
+    fields:
+    # One flat block, sec-major: element sec*60 + age, matching offset(sec, age) in the Go.
+    - {name: register, width: 360}
+
+    bindings:
+
+    # ---- the ONS survival curve, turned into 60 monthly hazards ----
+    #
+    # Within each year of life the hazard is piecewise constant, chosen so that twelve months
+    # of survival compound to that year's conditional survival ratio surv[y]/surv[y-1] (with
+    # surv[-1] = 1). concat supplies the shifted denominator, which is the whole of what the
+    # Go's running prev variable does.
+    - {name: surv5, expr: "slice(survival_fracs, 0, 5)"}
+    - {name: prev_surv, expr: "concat(1.0, slice(survival_fracs, 0, 4))"}
+    - {name: raw_ratio, expr: "surv5 / prev_surv"}
+    # A ratio outside (0, 1] is a non-monotone or non-positive survival curve: clamped, exactly
+    # as the Go clamps it. The guard is vector-valued, so both branches evaluate — harmless,
+    # since neither draws.
+    - name: year_ratio
+      expr: >-
+        where(raw_ratio > 0 && raw_ratio <= 1, raw_ratio,
+        clamp(raw_ratio, 1e-12, 1.0))
+    - {name: year_monthly_surv, expr: "pow(year_ratio, 1.0 / 12.0)"}
+    - {name: base_hazard, expr: "each(60, m, 1 - year_monthly_surv[floor(m / 12)])"}
+
+    # ---- macroeconomic covariates ----
+    #
+    # The Go indexes each covariate series by floor(current_time), clamped into the series, and
+    # repeats the last value past its end. The DSL has no len(), so a vector's width has to be
+    # recovered: a vector-valued condition makes where select elementwise, so where(x == x, 1, 1)
+    # is a vector of ones exactly as wide as x, and summing it counts them. Keeping the twin
+    # general in the series length beats freezing today's into a param.
+    #
+    # The arithmetic spelling of the same trick, sum(0 * x + 1), is WRONG and was caught by the
+    # equivalence test: 0 * NaN is NaN, so one NaN covariate poisons the count, and a NaN index
+    # does not panic — a float-to-int conversion of NaN is undefined in Go and silently read
+    # element 0 here. x == x is false for NaN and 1 either way, so this form is NaN-safe. The
+    # model reaches that case: it guards its multipliers against NaN explicitly.
+    - {name: n_rates, expr: "sum(where(covariate_bank_rates == covariate_bank_rates, 1, 1))"}
+    - {name: t_index, expr: "clamp(floor(t), 0, n_rates - 1)"}
+    - {name: rate, expr: "covariate_bank_rates[t_index]"}
+    # Each series is re-clamped to its own length, so a shorter claimant or GDP series holds at
+    # its last value while the rate series keeps advancing.
+    - name: claimant
+      expr: >-
+        covariate_claimants[min(t_index, sum(where(covariate_claimants == covariate_claimants, 1, 1)) - 1)]
+    - name: gdp
+      expr: >-
+        covariate_gdp_growth[min(t_index, sum(where(covariate_gdp_growth == covariate_gdp_growth, 1, 1)) - 1)]
+    - {name: gdp_term, expr: "birth_elasticity_gdp * (gdp - gdp_ref)"}
+
+    # ---- log-linear economic multipliers on formation and exit ----
+    #
+    # where(m >= 0, m, 1) is the Go's "if m < 0 || IsNaN(m) { m = 1 }": exp is never negative,
+    # so the guard only ever fires on a NaN, and a NaN fails >= 0.
+    - name: birth_mult_raw
+      expr: >-
+        exp(birth_elasticity_rate * (rate - rate_ref)
+        + birth_elasticity_claimant * (log(claimant / claimant_ref))
+        + gdp_term)
+    - {name: birth_mult, expr: "where(birth_mult_raw >= 0, birth_mult_raw, 1)"}
+    - {name: death_mult_raw, expr: "exp(death_elasticity_rate * (rate - rate_ref))"}
+    - {name: death_mult_econ, expr: "where(death_mult_raw >= 0, death_mult_raw, 1)"}
+    # The distress / leading-indicator channel, applied after the NaN guard, as in the Go.
+    - name: boost
+      expr: >-
+        distress_hazard_boost[min(t_index, sum(where(distress_hazard_boost == distress_hazard_boost, 1, 1)) - 1)]
+    - {name: death_mult, expr: "death_mult_econ * where(boost > 0, 1 + boost, 1)"}
+
+    # ---- support-policy multipliers, with the Go's validity fallbacks ----
+    #
+    # A scalar policy param falls back to its default when negative or NaN (zero is a
+    # legitimate switch-everything-off); a per-sector one falls back when non-positive or NaN.
+    # The two thresholds differ in the Go and differ here.
+    - {name: policy_birth, expr: "where(policy_birth_scale >= 0, policy_birth_scale, 1)"}
+    - name: policy_death
+      expr: >-
+        where(policy_death_hazard_scale >= 0, policy_death_hazard_scale, 1)
+    - name: infant
+      expr: >-
+        where(policy_infant_hazard_scale >= 0, policy_infant_hazard_scale, 1)
+    - name: sec_birth
+      expr: >-
+        where(policy_sector_birth_scale > 0, policy_sector_birth_scale, 1)
+    - name: sec_haz
+      expr: >-
+        where(policy_sector_hazard_scale > 0, policy_sector_hazard_scale, 1)
+
+    # ---- per-sector formation rate ----
+    - {name: lam, expr: "base_birth_rates * birth_mult * policy_birth * sec_birth"}
+
+    # ---- the effective monthly exit hazard, over the whole sector × age grid ----
+    #
+    # haz is the Go's cached monthlyHazard table, flattened: element sec*60 + m. eff applies
+    # the economic, policy and sector multipliers; eff_infant is the same with the first-year
+    # relief folded in, which only the age 0 -> 1 transition reads. Both clamps are kept
+    # separate because the Go clamps twice (once building the table, once after the
+    # multipliers), and the inner clamp is observable whenever a sector scale alone pushes the
+    # hazard past 1.
+    - name: haz
+      expr: >-
+        each(360, k, clamp(base_hazard[k % 60]
+        * sector_hazard_scales[floor(k / 60)], 0, 1))
+    - name: eff
+      expr: >-
+        each(360, k, clamp(haz[k] * death_mult * policy_death
+        * sec_haz[floor(k / 60)], 0, 1))
+    - name: eff_infant
+      expr: >-
+        each(360, k, clamp(haz[k] * death_mult * policy_death
+        * sec_haz[floor(k / 60)] * infant, 0, 1))
+
+    # ---- survival probabilities, per lane ----
+    #
+    # p_in[k] is the probability a business in the bucket below survives into lane k, so it
+    # reads the hazard at k-1 — the index shift itself. Age 1 takes the infant-relief hazard.
+    # Age 0 has no bucket below; its entry is unused (formation fills that lane) and is only
+    # here to keep the vector 360 wide, so the guard also keeps register[-1] out of reach.
+    # p_stay[k] is the probability a business already in lane k survives another month, which
+    # only the absorbing top bucket uses.
+    - name: p_in
+      expr: >-
+        each(360, k, where(k % 60 == 0, 0,
+        1 - where(k % 60 == 1, eff_infant[k - 1], eff[k - 1])))
+    - {name: p_stay, expr: "1 - eff"}
+
+    outputs:
+    # One lane per sector × age bucket, in the Go's own loop order, so a lane's draws are taken
+    # before the next lane starts exactly as the Go's nested loop takes them: a sector's
+    # formation Poisson, then its 58 ageing binomials, then the two feeding the top bucket.
+    #
+    #   age 0        formation: Poisson(lambda), or lambda itself in deterministic mean-field
+    #   age 1..58    the bucket below, thinned by survival
+    #   age 59       absorbing: the bucket below plus its own survivors
+    #
+    # The binomial is the Go's binomialSample: round the count, and return early — drawing
+    # nothing — for an empty bucket or a certain outcome. Those guards are scalar inside a
+    # lane, so where is lazy and the early returns are reproduced rather than approximated.
+    - >-
+      each(360, k,
+      where(k % 60 == 0,
+      where(deterministic >= 0.5, lam[floor(k / 60)],
+      where(lam[floor(k / 60)] > 0, poisson(lam[floor(k / 60)]), 0)),
+      where(deterministic >= 0.5, register[k - 1] * p_in[k],
+      where(floor(register[k - 1] + 0.5) <= 0, 0,
+      where(p_in[k] <= 0, 0,
+      where(p_in[k] >= 1, floor(register[k - 1] + 0.5),
+      binomial(floor(register[k - 1] + 0.5), p_in[k])))))
+      + where(k % 60 == 59,
+      where(deterministic >= 0.5, register[k] * p_stay[k],
+      where(floor(register[k] + 0.5) <= 0, 0,
+      where(p_stay[k] <= 0, 0,
+      where(p_stay[k] >= 1, floor(register[k] + 0.5),
+      binomial(floor(register[k] + 0.5), p_stay[k]))))),
+      0)))

--- a/models/business-survival/doc.go
+++ b/models/business-survival/doc.go
@@ -6,11 +6,31 @@
 // The generative core is a single bespoke iteration,
 // SingleLAPopulationIteration ([single_la_population.go]), with its survival →
 // hazard helper ([hazard.go]). Both are lifted verbatim from the downstream
-// business-survival repo. They live here — beside the stub rather than in engine
-// core — because the catalogue is the staging ground for the "should this be
-// promoted into core?" question: a generic aged-cohort / Leslie primitive
-// recurring across other models would be the signal to promote, but that waits
-// for the recurrence. The downstream repo's data ingestion (ONS / Companies
+// business-survival repo. The downstream repo's data ingestion (ONS / Companies
 // House / NOMIS / Bank of England), panel calibration, and SMC inference
 // helpers are inference / ingestion concerns and were left downstream.
+//
+// # No declarative twin: a category 2 capability gap
+//
+// Every other catalogue entry ships a declarative.yaml stating its model as data
+// (see models/CONVENTIONS.md §5). This one cannot, and the absence is the
+// finding: it is the catalogue's worked example of a missing structure rather
+// than a missing vocabulary, and one model is enough to prove it.
+//
+// general.ExpressionIteration is elementwise over a partition's current row:
+// element i of an output is computed from element i of its inputs. A cohort flow
+// is precisely the update that breaks that. Element i of the next register reads
+// element i-1 of the current one (a business ages one month), the top bucket is
+// absorbing (it takes both the inflow from below and its own survivors), and the
+// state is a flattened sector × age grid whose per-sector blocks the evaluator
+// has no way to address. No set of functions rescues this, because the alignment
+// is built into what the evaluator is. Closing it means either an operator that
+// enlarges the DSL (a shift, a slice, a reshape) or a core aged-cohort Iteration
+// — a real design decision, and deliberately not taken on one instance.
+//
+// A second, smaller signal sits alongside it, and is a category 1 finding rather
+// than a gap in core: this iteration hand-rolls poissonSample and binomialSample
+// beside the samplers pkg/rng now ships. That is standardisation debt in the
+// model, to be paid on its own merits and never as a side effect of making an
+// equivalence test agree.
 package bizsurvival

--- a/models/business-survival/doc.go
+++ b/models/business-survival/doc.go
@@ -10,27 +10,53 @@
 // House / NOMIS / Bank of England), panel calibration, and SMC inference
 // helpers are inference / ingestion concerns and were left downstream.
 //
-// # No declarative twin: a category 2 capability gap
+// # The declarative twin, and the gap that used to be here
 //
-// Every other catalogue entry ships a declarative.yaml stating its model as data
-// (see models/CONVENTIONS.md §5). This one cannot, and the absence is the
-// finding: it is the catalogue's worked example of a missing structure rather
-// than a missing vocabulary, and one model is enough to prove it.
+// This entry was the catalogue's one worked example of a category 2 capability
+// gap: the model that could not be stated as data. That gap is closed, and
+// [declarative.yaml] is the twin.
 //
-// general.ExpressionIteration is elementwise over a partition's current row:
-// element i of an output is computed from element i of its inputs. A cohort flow
-// is precisely the update that breaks that. Element i of the next register reads
+// What was missing was structure, not vocabulary — general.ExpressionIteration
+// was elementwise over a partition's current row, and a cohort flow is precisely
+// the update that breaks that alignment. Element i of the next register reads
 // element i-1 of the current one (a business ages one month), the top bucket is
-// absorbing (it takes both the inflow from below and its own survivors), and the
-// state is a flattened sector × age grid whose per-sector blocks the evaluator
-// has no way to address. No set of functions rescues this, because the alignment
-// is built into what the evaluator is. Closing it means either an operator that
-// enlarges the DSL (a shift, a slice, a reshape) or a core aged-cohort Iteration
-// — a real design decision, and deliberately not taken on one instance.
+// absorbing, and the state is a flattened sector × age grid whose per-sector
+// blocks the evaluator had no way to address. The diagnosis held: no set of
+// functions rescued it, and what closed it was an operator that enlarges the
+// DSL. That operator is each(n, i, expr), which builds a width-n value whose
+// element i is expr with the lane index i bound. It answers all three parts at
+// once. The lane index carries both grid coordinates, so sec = floor(k/60) and
+// age = k%60 reproduce offset(sec, age) exactly and the per-sector blocks become
+// addressable. A lane may read element k-1, which is the index shift itself. And
+// everything inside a lane is a scalar, so where is lazy there: the age 0 lane
+// never evaluates register[-1], and a guarded draw is genuinely skipped rather
+// than merely discarded. concat and slice supply the shifted denominator that
+// turns the ONS survival curve into monthly hazards, which is the other place the
+// old evaluator had to reach past the current element.
 //
-// A second, smaller signal sits alongside it, and is a category 1 finding rather
-// than a gap in core: this iteration hand-rolls poissonSample and binomialSample
-// beside the samplers pkg/rng now ships. That is standardisation debt in the
-// model, to be paid on its own merits and never as a side effect of making an
-// equivalence test agree.
+// # The sampler note, which is still a category 1 finding
+//
+// This iteration hand-rolls poissonSample and binomialSample beside the samplers
+// pkg/rng now ships. That remains standardisation debt in the model, to be paid
+// on its own merits and never as a side effect of making an equivalence test
+// agree.
+//
+// It is worth recording precisely what it did NOT cost, because the natural
+// reading is wrong and the twin's oracle turns on it. In
+// antimicrobial-resistance a hand-rolled sampler is what forces a weaker,
+// distributional oracle: its Knuth loop is a genuinely different algorithm from
+// the engine's, consuming a different number of draws, so the streams cannot be
+// aligned. Not so here. These two methods are thin wrappers that set Lambda /
+// N / P on a distuv distribution and call its Rand, and pkg/rng is a deliberate
+// bit-identical reimplementation of distuv's own algorithms. Same generator,
+// same algorithm, same draw order — so the twin is checked EXACTLY, on the
+// stochastic path as well as the mean-field one, and the debt is cosmetic rather
+// than semantic. See expression_equivalence_test.go.
+//
+// One real difference between the two is recorded rather than patched: the Go
+// caches its monthly hazard table, and its deterministic flag, in Configure,
+// where the twin derives both per step from the same params. Every assembly sets
+// those params before Configure, so the two agree everywhere either is used, but
+// a mid-run change to survival_fracs would be ignored by the Go and honoured by
+// the twin. That is a property of the implementation and not of the demography.
 package bizsurvival

--- a/models/business-survival/expression_equivalence_test.go
+++ b/models/business-survival/expression_equivalence_test.go
@@ -1,0 +1,648 @@
+package bizsurvival
+
+// Does declarative.yaml — this model written as data, with no Go — reproduce the model
+// stub.go builds in code?
+//
+// This is the entry that had no twin at all until the DSL grew each, slice and concat. The
+// register is a flattened sector × age grid whose next row reads the row below it, which is
+// exactly what an elementwise evaluator cannot say. So the first question this file answers
+// is not "is the twin right" but "is there one", and the branch counts below are the
+// evidence: the index shift, the absorbing top bucket and the per-sector blocks are all
+// reached, on both sides, and agree.
+//
+// # Which oracle, and why this one
+//
+// The strongest available: EXACT, value-by-value, on both the mean-field path and the
+// stochastic one. That was not the expected outcome and it is worth saying why it holds,
+// because the reasoning that says it should not is nearly right.
+//
+// SingleLAPopulationIteration has its own poissonSample and binomialSample, which reads like
+// antimicrobial-resistance's blocker — a hand-rolled sampler the engine implements
+// differently, whose stream cannot be aligned. It is not the same situation. Those two
+// methods are thin wrappers: they set Lambda / N / P on a distuv distribution and call its
+// Rand, and the guards around them (lambda <= 0, n <= 0, p <= 0, p >= 1) return early
+// without drawing. pkg/rng is a deliberate bit-identical reimplementation of distuv's own
+// algorithms — see its package doc, which is explicit that a Sampler consumes the source in
+// the same order as the distuv distribution it replaces — and both sides seed the same
+// generator, since rng.New(seed) is rand.New(rand.NewPCG(seed, seed)) and Configure builds
+// exactly that. The DSL's binomial() goes further and calls distuv.Binomial itself.
+//
+// So the two sides share one stream, and the twin holds it in step by reproducing each early
+// return as a scalar guard inside each's lane, where where is lazy and a guarded branch
+// draws nothing. That is what makes lambda = 0 and an empty bucket cost zero draws on both
+// sides rather than one on one side, and it is the whole reason the streams stay aligned
+// past the first guard. TestDeclarativeStochasticMatchesBespokeExactly is what proves it,
+// over ten compounding steps per case and across every sampler branch.
+//
+// Two layers, because they fail in different ways. The step tests compare single Iterate
+// calls over randomised inputs, which catches a mis-stated formula exactly. The suite test
+// re-runs the model's own claim computations against the declarative build, which catches
+// what per-step agreement cannot: wrong wiring, wrong param values, wrong state layout.
+//
+// Agreement is asserted to a tight tolerance rather than bit-for-bit: compiled Go is free to
+// contract a + b*c into a fused multiply-add, which rounds differently from the evaluator's
+// separate operations. That residue is the FMA, not the model.
+//
+// # The one difference that is real, and is not a defect
+//
+// The Go caches its 60 monthly hazards, and its deterministic flag, in Configure; the twin
+// derives both per step from the same params. Every assembly sets those params before
+// Configure, so the two agree everywhere either is used — but a mid-run change to
+// survival_fracs would be ignored by the Go and honoured by the twin. That is a property of
+// the implementation, not of the demography, and the twin states the demography. Recorded,
+// not patched: changing the model to make a twin agree is forbidden, and here it is the
+// model that is the odd one out.
+
+import (
+	"fmt"
+	"math"
+	"math/rand/v2"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+
+	"github.com/umbralcalc/stochadex/models/cardgen"
+	"github.com/umbralcalc/stochadex/pkg/api"
+	"github.com/umbralcalc/stochadex/pkg/general"
+	"github.com/umbralcalc/stochadex/pkg/simulator"
+)
+
+// tolerance is well above FMA rounding and well below any difference a real modelling
+// discrepancy would produce.
+const tolerance = 1e-12
+
+// stateWidth is the register's flattened size: 6 sectors × 60 monthly age buckets.
+const stateWidth = 360
+
+// declarativeBuildStub assembles the model from declarative.yaml, matching BuildStub's
+// signature so it can be dropped into the behaviour helpers. The YAML holds the model; the
+// run knobs BuildStub takes as arguments are injected here, exactly as BuildStub injects
+// them into its Go partition.
+func declarativeBuildStub(
+	hazardScale float64,
+	numSteps int,
+	seed uint64,
+) *simulator.ConfigGenerator {
+	config := api.LoadApiRunConfigFromYaml("declarative.yaml")
+	config.Main.Simulation = simulator.SimulationConfig{
+		OutputCondition: &simulator.EveryStepOutputCondition{},
+		TerminationCondition: &simulator.NumberOfStepsTerminationCondition{
+			MaxNumberOfSteps: numSteps,
+		},
+		TimestepFunction: &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+		InitTimeValue:    0.0,
+	}
+	gen := config.Main.GetConfigGenerator()
+	gen.GetPartition("population").Params.Map["policy_death_hazard_scale"] =
+		[]float64{hazardScale}
+	gen.GetPartition("population").Seed = seed
+	return gen
+}
+
+// declarativeParams returns the params declarative.yaml declares for the population
+// partition, copied so a caller may vary them.
+func declarativeParams(t *testing.T) map[string][]float64 {
+	t.Helper()
+	config := declarativeBuildStub(DefaultPolicyHazardScale, 10, 0).GetPartition("population")
+	if _, ok := config.Iteration.(*general.ExpressionIteration); !ok {
+		t.Fatalf("population is not expression-backed: got %T", config.Iteration)
+	}
+	out := map[string][]float64{}
+	for k, v := range config.Params.Map {
+		out[k] = append([]float64{}, v...)
+	}
+	return out
+}
+
+// declarativeIteration returns the expression iteration the YAML supplies for the population
+// partition. Configure is what parses and seeds it, so a fresh one per configuration is not
+// needed — the caller reconfigures it.
+func declarativeIteration(t *testing.T) *general.ExpressionIteration {
+	t.Helper()
+	config := declarativeBuildStub(DefaultPolicyHazardScale, 10, 0).GetPartition("population")
+	iteration, ok := config.Iteration.(*general.ExpressionIteration)
+	if !ok {
+		t.Fatalf("population is not expression-backed: got %T", config.Iteration)
+	}
+	return iteration
+}
+
+// settingsFor builds the partition settings both sides configure from. The bespoke reads
+// survival_fracs, sector_hazard_scales and deterministic here, in Configure, and checks the
+// state width, so the settings must carry the case's params and a full-width init state.
+func settingsFor(params map[string][]float64, seed uint64) *simulator.Settings {
+	return &simulator.Settings{
+		Iterations: []simulator.IterationSettings{{
+			Name:              "population",
+			Seed:              seed,
+			Params:            simulator.NewParams(params),
+			StateWidth:        stateWidth,
+			InitStateValues:   make([]float64, stateWidth),
+			StateHistoryDepth: 1,
+		}},
+	}
+}
+
+// history wraps a single state row as a depth-1 history. Both sides get their own copy, so
+// neither can be affected by the other's writes.
+func history(values []float64) []*simulator.StateHistory {
+	return []*simulator.StateHistory{{
+		Values:            mat.NewDense(1, len(values), append([]float64{}, values...)),
+		StateWidth:        len(values),
+		StateHistoryDepth: 1,
+	}}
+}
+
+// timesteps builds a one-step timesteps history at cumulative time t with increment dt.
+func timesteps(t float64, step int, dt float64) *simulator.CumulativeTimestepsHistory {
+	return &simulator.CumulativeTimestepsHistory{
+		Values:            mat.NewVecDense(1, []float64{t}),
+		NextIncrement:     dt,
+		CurrentStepNumber: step + 1,
+	}
+}
+
+// assertClose fails when two values differ by more than the FMA-scale tolerance, comparing
+// relatively once the magnitude exceeds 1. Two NaNs count as agreement: a NaN covariate is a
+// case both sides are expected to carry identically, and NaN != NaN would report it as a
+// difference.
+//
+// The context is taken as a format string and its arguments rather than a formatted string,
+// so that locating a failure costs nothing on the millions of comparisons that pass.
+func assertClose(t *testing.T, got, want float64, format string, args ...any) float64 {
+	t.Helper()
+	if math.IsNaN(got) && math.IsNaN(want) {
+		return 0
+	}
+	d := math.Abs(got - want)
+	if s := math.Abs(want); s > 1 {
+		d /= s
+	}
+	if d > tolerance {
+		t.Fatalf("%s: declarative=%v bespoke=%v deviation=%g",
+			fmt.Sprintf(format, args...), got, want, d)
+	}
+	return d
+}
+
+// offsetOf mirrors the Go's offset(sec, age) = sec*60 + age, which is the layout the twin's
+// each(360, k, ...) lane index has to reproduce.
+func offsetOf(sec, age int) int { return sec*NumAges + age }
+
+func TestDeclarativeMeanFieldMatchesBespokeExactly(t *testing.T) {
+	// The mean-field oracle. With deterministic set, births = lambda and moved = prev*pSurv
+	// and neither side draws at all, so the streams stop mattering and the whole cohort
+	// structure is decidable value by value: the index shift, the absorbing top bucket, the
+	// hazard lookup, the survival-curve clamps, the covariate indexing, the economic
+	// multipliers and every policy fallback. This is where nearly all the risk lives.
+	bespoke := &SingleLAPopulationIteration{}
+	declarative := declarativeIteration(t)
+	base := declarativeParams(t)
+
+	rng := rand.New(rand.NewPCG(41, 42))
+	branches := map[string]int{}
+	maxDev := 0.0
+
+	const cases = 6000
+	for i := 0; i < cases; i++ {
+		params := map[string][]float64{}
+		for k, v := range base {
+			params[k] = append([]float64{}, v...)
+		}
+		params["deterministic"] = []float64{1.0}
+
+		// The survival curve, ranged well outside the physical (0,1] so the year-ratio clamps
+		// fire often rather than never: a non-monotone curve gives a ratio above 1, a negative
+		// one gives a ratio at or below 0. Kept away from exactly zero so no ratio is 0/0.
+		surv := make([]float64, 5)
+		for k := range surv {
+			switch i % 7 {
+			case 0: // rising: ratio > 1
+				surv[k] = 0.3 + float64(k)*0.2
+			case 1: // negative entries: ratio <= 0
+				surv[k] = -0.05 - rng.Float64()*0.2
+			case 2: // flat: ratio == 1, so the hazard is exactly 0
+				surv[k] = 0.8
+			default:
+				surv[k] = 0.95 - float64(k)*0.15 - rng.Float64()*0.02
+			}
+		}
+		params["survival_fracs"] = surv
+
+		// Sector hazard scales large enough that the table clamp at 1 bites, and sometimes
+		// zero so the hazard vanishes entirely.
+		scales := make([]float64, numSectors)
+		for k := range scales {
+			if i%11 == 0 {
+				scales[k] = 0
+			} else {
+				scales[k] = rng.Float64() * 3
+			}
+		}
+		params["sector_hazard_scales"] = scales
+
+		births := make([]float64, numSectors)
+		for k := range births {
+			births[k] = rng.Float64() * 8
+		}
+		params["base_birth_rates"] = births
+
+		// Covariate series of varying length, with the claimant and GDP series often shorter
+		// than the rate series so each one's own end-of-series clamp is exercised separately.
+		nRates := 1 + rng.IntN(5)
+		rates := make([]float64, nRates)
+		for k := range rates {
+			rates[k] = rng.Float64() * 4
+		}
+		if i%13 == 0 {
+			rates[nRates-1] = math.NaN() // NaN rate: both multipliers must fall back to 1
+		}
+		params["covariate_bank_rates"] = rates
+
+		claimants := make([]float64, 1+rng.IntN(3))
+		for k := range claimants {
+			claimants[k] = 8000 + rng.Float64()*20000
+		}
+		if i%17 == 0 {
+			claimants[0] = -5000 // log of a negative: birthMult is NaN and must fall back
+		}
+		params["covariate_claimants"] = claimants
+
+		gdp := make([]float64, 1+rng.IntN(3))
+		for k := range gdp {
+			gdp[k] = rng.Float64()*6 - 3
+		}
+		params["covariate_gdp_growth"] = gdp
+		params["gdp_ref"] = []float64{rng.Float64()*2 - 1}
+		params["birth_elasticity_gdp"] = []float64{0}
+		if i%3 == 0 {
+			params["birth_elasticity_gdp"] = []float64{rng.Float64()*0.4 - 0.2}
+		}
+
+		distress := make([]float64, 1+rng.IntN(3))
+		for k := range distress {
+			distress[k] = rng.Float64()*0.8 - 0.4 // straddles zero: active vs inactive
+		}
+		params["distress_hazard_boost"] = distress
+
+		params["rate_ref"] = []float64{rng.Float64() * 2}
+		params["claimant_ref"] = []float64{8000 + rng.Float64()*10000}
+		params["birth_elasticity_rate"] = []float64{rng.Float64()*0.6 - 0.3}
+		params["birth_elasticity_claimant"] = []float64{rng.Float64()*0.6 - 0.3}
+		params["death_elasticity_rate"] = []float64{rng.Float64()*0.6 - 0.3}
+
+		// Policy scalars ranged below zero, which is the Go's "invalid, use the default"
+		// branch — a range a real scenario would never visit, and so the only way to reach it.
+		policyScalar := func(key string, hi float64) {
+			v := rng.Float64() * hi
+			if rng.IntN(6) == 0 {
+				v = -rng.Float64()
+			}
+			params[key] = []float64{v}
+		}
+		policyScalar("policy_birth_scale", 2)
+		policyScalar("policy_death_hazard_scale", 3)
+		policyScalar("policy_infant_hazard_scale", 2)
+		if i%11 == 5 {
+			// Drive the effective hazard past 1 outright rather than waiting for a random draw
+			// to do it. The Go clamps twice — once building the hazard table, once after the
+			// multipliers — and the outer clamp is only reachable from a range like this.
+			params["policy_death_hazard_scale"] = []float64{50}
+		}
+
+		// Per-sector multipliers use a different fallback threshold in the Go (non-positive,
+		// not negative), so zero must appear as well as negatives.
+		perSector := func(key string) {
+			v := make([]float64, numSectors)
+			for k := range v {
+				switch rng.IntN(8) {
+				case 0:
+					v[k] = 0
+				case 1:
+					v[k] = -rng.Float64()
+				default:
+					v[k] = rng.Float64() * 2
+				}
+			}
+			params[key] = v
+		}
+		perSector("policy_sector_birth_scale")
+		perSector("policy_sector_hazard_scale")
+
+		// Cumulative time below zero, inside the rate series, and past its end, so all three
+		// covariate-index branches are reached.
+		var tv float64
+		switch i % 4 {
+		case 0:
+			tv = -1 - rng.Float64()*3
+		case 1:
+			tv = rng.Float64() * float64(nRates)
+		default:
+			tv = float64(nRates) + rng.Float64()*6
+		}
+		// dt is varied below, at and above 1 even though neither side should read it: at the
+		// stepsize of 1 every assembly actually runs at, a stray dt or sqrt(dt) factor in the
+		// twin would be invisible.
+		dt := []float64{0.5, 1.0, 2.0, 3.5}[i%4]
+
+		state := make([]float64, stateWidth)
+		for k := range state {
+			state[k] = rng.Float64() * 500
+		}
+
+		settings := settingsFor(params, uint64(i%97))
+		bespoke.Configure(0, settings)
+		declarative.Configure(0, settings)
+
+		p := simulator.NewParams(params)
+		ts := timesteps(tv, i, dt)
+		want := append([]float64{}, bespoke.Iterate(&p, 0, history(state), ts)...)
+		got := append([]float64{}, declarative.Iterate(&p, 0, history(state), ts)...)
+
+		// ---- branch accounting, derived from the inputs rather than declared ----
+
+		switch i % 7 {
+		case 0:
+			branches["year_ratio_clamped_above_one"]++
+		case 1:
+			branches["year_ratio_clamped_at_zero"]++
+		case 2:
+			branches["year_hazard_exactly_zero"]++
+		default:
+			branches["year_ratio_valid"]++
+		}
+		if tv < 0 {
+			branches["covariate_index_clamped_low"]++
+		} else if int(tv) >= nRates {
+			branches["covariate_index_clamped_high"]++
+		} else {
+			branches["covariate_index_inside_series"]++
+		}
+		if len(claimants) < nRates {
+			branches["claimant_series_shorter_than_rates"]++
+		}
+		if params["birth_elasticity_gdp"][0] != 0 {
+			branches["gdp_channel_active"]++
+		} else {
+			branches["gdp_channel_neutral"]++
+		}
+		tIdx := int(math.Max(0, math.Min(float64(nRates-1), math.Floor(tv))))
+		if b := distress[int(math.Min(float64(tIdx), float64(len(distress)-1)))]; b > 0 {
+			branches["distress_boost_active"]++
+		} else {
+			branches["distress_boost_inactive"]++
+		}
+		if math.IsNaN(pickSeries(rates, tIdx)) {
+			branches["death_mult_nan_fallback"]++
+		}
+		if pickSeries(claimants, tIdx) < 0 {
+			branches["birth_mult_nan_fallback"]++
+		}
+		for _, key := range []string{
+			"policy_birth_scale", "policy_death_hazard_scale", "policy_infant_hazard_scale",
+		} {
+			if params[key][0] < 0 {
+				branches[key+"_fallback"]++
+			} else {
+				branches[key+"_used"]++
+			}
+		}
+		for _, key := range []string{"policy_sector_birth_scale", "policy_sector_hazard_scale"} {
+			for _, v := range params[key] {
+				if v <= 0 {
+					branches[key+"_fallback"]++
+				} else {
+					branches[key+"_used"]++
+				}
+			}
+		}
+		if params["policy_infant_hazard_scale"][0] != 1 {
+			branches["infant_relief_differs_from_baseline"]++
+		}
+		// The structural lanes: every case evaluates all 360 of them, and the top bucket is
+		// genuinely absorbing whenever both it and the bucket below hold businesses.
+		branches["lane_age_0_formation"]++
+		branches["lane_age_1_infant_hazard"]++
+		branches["lane_age_2_to_58_shift"]++
+		branches["lane_age_59_absorbing"]++
+		for sec := 0; sec < numSectors; sec++ {
+			if state[offsetOf(sec, 58)] > 0 && state[offsetOf(sec, 59)] > 0 {
+				branches["top_bucket_takes_inflow_and_survivors"]++
+			}
+		}
+		// The two clamps on the effective hazard, read off the outputs: a lane whose survivors
+		// are exactly zero had its hazard clamped to 1, and one that keeps its whole bucket
+		// had a hazard of exactly 0.
+		for sec := 0; sec < numSectors; sec++ {
+			k := offsetOf(sec, 30)
+			if want[k] == 0 && state[k-1] > 0 {
+				branches["effective_hazard_clamped_at_one"]++
+			}
+			if want[k] == state[k-1] && state[k-1] > 0 {
+				branches["effective_hazard_exactly_zero"]++
+			}
+		}
+
+		for k := range want {
+			maxDev = math.Max(maxDev, assertClose(t, got[k], want[k],
+				"case %d, bucket %d (sector %d, age %d), t=%v, dt=%v",
+				i, k, k/NumAges, k%NumAges, tv, dt))
+		}
+	}
+
+	for _, b := range []string{
+		"year_ratio_valid", "year_ratio_clamped_above_one", "year_ratio_clamped_at_zero",
+		"year_hazard_exactly_zero",
+		"covariate_index_clamped_low", "covariate_index_clamped_high",
+		"covariate_index_inside_series", "claimant_series_shorter_than_rates",
+		"gdp_channel_active", "gdp_channel_neutral",
+		"distress_boost_active", "distress_boost_inactive",
+		"death_mult_nan_fallback", "birth_mult_nan_fallback",
+		"policy_birth_scale_fallback", "policy_birth_scale_used",
+		"policy_death_hazard_scale_fallback", "policy_death_hazard_scale_used",
+		"policy_infant_hazard_scale_fallback", "policy_infant_hazard_scale_used",
+		"policy_sector_birth_scale_fallback", "policy_sector_birth_scale_used",
+		"policy_sector_hazard_scale_fallback", "policy_sector_hazard_scale_used",
+		"infant_relief_differs_from_baseline",
+		"lane_age_0_formation", "lane_age_1_infant_hazard", "lane_age_2_to_58_shift",
+		"lane_age_59_absorbing", "top_bucket_takes_inflow_and_survivors",
+		"effective_hazard_clamped_at_one", "effective_hazard_exactly_zero",
+	} {
+		if branches[b] == 0 {
+			t.Errorf("branch %q never exercised; the comparison is weaker than it looks", b)
+		}
+	}
+	t.Logf("branches exercised: %v", branches)
+	t.Logf("max deviation: %g", maxDev)
+}
+
+func TestDeclarativeStochasticMatchesBespokeExactly(t *testing.T) {
+	// The stochastic path, on the same stream. Every sampler branch has to line up for this
+	// to hold — a guard that draws on one side and returns early on the other desynchronises
+	// the stream and every later lane diverges, which is why this runs ten compounding steps
+	// per case rather than one.
+	bespoke := &SingleLAPopulationIteration{}
+	declarative := declarativeIteration(t)
+	base := declarativeParams(t)
+
+	rng := rand.New(rand.NewPCG(51, 52))
+	branches := map[string]int{}
+	maxDev := 0.0
+
+	const (
+		cases = 400
+		steps = 10
+	)
+	for i := 0; i < cases; i++ {
+		params := map[string][]float64{}
+		for k, v := range base {
+			params[k] = append([]float64{}, v...)
+		}
+		params["deterministic"] = []float64{0.0}
+
+		// Formation rates swept across rng.Poisson's own lambda = 10 switch from the direct
+		// exponential-interarrival method to Hoermann's PTRS, and down to zero, which is
+		// poissonSample's early return: it draws nothing there, and the twin must not either.
+		lambdas := make([]float64, numSectors)
+		for k := range lambdas {
+			switch (i + k) % 3 {
+			case 0:
+				lambdas[k] = rng.Float64() * 9
+			case 1:
+				lambdas[k] = 10 + rng.Float64()*90
+			default:
+				lambdas[k] = 0
+			}
+		}
+		params["base_birth_rates"] = lambdas
+
+		// The survival probability is driven to both certainties as well as the interior,
+		// because those are binomialSample's other two early returns.
+		var regime string
+		switch i % 4 {
+		case 0:
+			regime = "certain_survival" // zero hazard: p >= 1, return n, draw nothing
+			params["sector_hazard_scales"] = make([]float64, numSectors)
+		case 1:
+			regime = "certain_death" // hazard clamped to 1: p <= 0, return 0, draw nothing
+			params["policy_death_hazard_scale"] = []float64{500}
+			scales := make([]float64, numSectors)
+			for k := range scales {
+				scales[k] = 50
+			}
+			params["sector_hazard_scales"] = scales
+		default:
+			regime = "interior"
+			scales := make([]float64, numSectors)
+			for k := range scales {
+				scales[k] = 0.5 + rng.Float64()*1.5
+			}
+			params["sector_hazard_scales"] = scales
+			params["policy_death_hazard_scale"] = []float64{rng.Float64() * 2}
+		}
+		params["policy_infant_hazard_scale"] = []float64{rng.Float64() * 2}
+
+		// Half the buckets start empty, which is binomialSample's n <= 0 early return.
+		state := make([]float64, stateWidth)
+		for k := range state {
+			if rng.IntN(2) == 0 {
+				state[k] = 0
+			} else {
+				state[k] = math.Floor(rng.Float64() * 300)
+			}
+		}
+
+		settings := settingsFor(params, uint64(1000+i))
+		bespoke.Configure(0, settings)
+		declarative.Configure(0, settings)
+
+		for _, lambda := range lambdas {
+			switch {
+			case lambda <= 0:
+				branches["poisson_zero_lambda_no_draw"]++
+			case lambda < 10:
+				branches["poisson_direct_method"]++
+			default:
+				branches["poisson_ptrs"]++
+			}
+		}
+		branches["binomial_"+regime]++
+		for _, v := range state {
+			if v == 0 {
+				branches["binomial_empty_bucket_no_draw"]++
+			}
+		}
+
+		p := simulator.NewParams(params)
+		wantState := append([]float64{}, state...)
+		gotState := append([]float64{}, state...)
+		for step := 0; step < steps; step++ {
+			ts := timesteps(float64(step), step, []float64{0.5, 1.0, 2.0}[step%3])
+			want := append([]float64{},
+				bespoke.Iterate(&p, 0, history(wantState), ts)...)
+			got := append([]float64{},
+				declarative.Iterate(&p, 0, history(gotState), ts)...)
+			for k := range want {
+				maxDev = math.Max(maxDev, assertClose(t, got[k], want[k],
+					"case %d, step %d, bucket %d (sector %d, age %d)",
+					i, step, k, k/NumAges, k%NumAges))
+			}
+			// Advance each side on its OWN output, so a divergence cannot be masked by
+			// feeding both the same state back in.
+			wantState, gotState = want, got
+		}
+	}
+
+	for _, b := range []string{
+		"poisson_zero_lambda_no_draw", "poisson_direct_method", "poisson_ptrs",
+		"binomial_interior", "binomial_certain_survival", "binomial_certain_death",
+		"binomial_empty_bucket_no_draw",
+	} {
+		if branches[b] == 0 {
+			t.Errorf("branch %q never exercised; the comparison is weaker than it looks", b)
+		}
+	}
+	t.Logf("branches exercised: %v", branches)
+	t.Logf("max deviation over %d cases × %d compounding steps: %g", cases, steps, maxDev)
+}
+
+func TestDeclarativeBusinessSurvivalAnswersTheSameClaims(t *testing.T) {
+	// The oracle is the model's own behaviour suite: every claim recomputed against the
+	// declarative build must still hold, and must hold with the same numbers the card
+	// reports — not merely point the same way.
+	//
+	// Asserting the numbers is available here, and so is required: every claim in this suite
+	// runs in deterministic mean-field mode, where neither side takes a draw, so the two
+	// builds are comparable value-by-value over the full 120-step run and a tolerance wide
+	// enough to hide a real difference would be a choice, not a necessity.
+	if testing.Short() {
+		t.Skip("runs the full claim suite twice")
+	}
+	bespoke := ObservedBehaviour()
+	declarative := observedBehaviour(declarativeBuildStub)
+
+	if len(declarative) != len(bespoke) {
+		t.Fatalf("got %d claims, want %d", len(declarative), len(bespoke))
+	}
+	maxDev := 0.0
+	for i, claim := range declarative {
+		reference := bespoke[i]
+		if claim.ID != reference.ID {
+			t.Fatalf("claim %d: got ID %q, want %q", i, claim.ID, reference.ID)
+		}
+		// Still a true claim when the model is data.
+		if err := cardgen.Verify(claim); err != nil {
+			t.Errorf("claim %q does not hold for the declarative model: %v", claim.ID, err)
+			continue
+		}
+		if len(claim.Observations) != len(reference.Observations) {
+			t.Fatalf("claim %q: got %d observations, want %d",
+				claim.ID, len(claim.Observations), len(reference.Observations))
+		}
+		for k, obs := range claim.Observations {
+			maxDev = math.Max(maxDev, assertClose(t, obs.Value,
+				reference.Observations[k].Value, "%s / %s", claim.ID, obs.Label))
+		}
+	}
+	t.Logf("max deviation across every observation on every claim: %g", maxDev)
+}

--- a/models/energy-balancer/behaviour.go
+++ b/models/energy-balancer/behaviour.go
@@ -26,16 +26,23 @@ func runStub(renewablePenetration float64, numSteps int, seed uint64) *simulator
 	return store
 }
 
+// stubBuilder assembles the model, matching BuildStub's signature. The behaviour
+// helpers take one rather than calling BuildStub directly so that an alternative
+// assembly of the same model — notably the declarative one in declarative.yaml —
+// can be put through this exact claim suite instead of a re-stated copy of it.
+type stubBuilder func(renewablePenetration float64, numSteps int, seed uint64) *simulator.ConfigGenerator
+
 // runStubOverride runs the stub with an override hook applied to the generated
 // config before the run, so a behaviour can vary any partition's params without
 // bloating BuildStub's signature.
 func runStubOverride(
+	build stubBuilder,
 	renewablePenetration float64,
 	numSteps int,
 	seed uint64,
 	override func(*simulator.ConfigGenerator),
 ) *simulator.StateTimeStorage {
-	gen := BuildStub(renewablePenetration, numSteps, seed)
+	gen := build(renewablePenetration, numSteps, seed)
 	if override != nil {
 		override(gen)
 	}
@@ -75,6 +82,7 @@ func meanFinalEFC(policy string, renewablePenetration float64, numSteps, nMember
 // meanFinalValue ensemble-averages finalValue over nMembers seeds under a fixed
 // penetration and override, damping single-run noise.
 func meanFinalValue(
+	build stubBuilder,
 	renewablePenetration float64,
 	numSteps, nMembers int,
 	partition string,
@@ -83,7 +91,7 @@ func meanFinalValue(
 ) float64 {
 	var sum float64
 	for m := 0; m < nMembers; m++ {
-		store := runStubOverride(renewablePenetration, numSteps, uint64(3000+m), override)
+		store := runStubOverride(build, renewablePenetration, numSteps, uint64(3000+m), override)
 		sum += finalValue(store, partition, idx)
 	}
 	return sum / float64(nMembers)
@@ -103,45 +111,52 @@ func setParam(gen *simulator.ConfigGenerator, partition, key string, value float
 //
 // Claim IDs match the subtest names under TestEnergyBalancerExpectedBehaviour.
 func ObservedBehaviour() []cardgen.Claim {
+	return observedBehaviour(BuildStub)
+}
+
+// observedBehaviour computes the claims against a given assembly of the model. The
+// equivalence test runs it against the declarative build so that the data-only model
+// answers the same claims, measured the same way.
+func observedBehaviour(build stubBuilder) []cardgen.Claim {
 	const steps, nMembers, pen = 168, 8, 0.6
 	const efcUnit = "ensemble-mean cumulative EFC"
 
-	baseEFC := meanFinalValue(pen, steps, nMembers, "price_efc", 0, nil)
-	baseRevenue := meanFinalValue(pen, steps, nMembers, "price_revenue", 0, nil)
-	baseCarbonEFC := meanFinalValue(pen, steps, nMembers, "carbon_efc", 0, nil)
+	baseEFC := meanFinalValue(build, pen, steps, nMembers, "price_efc", 0, nil)
+	baseRevenue := meanFinalValue(build, pen, steps, nMembers, "price_revenue", 0, nil)
+	baseCarbonEFC := meanFinalValue(build, pen, steps, nMembers, "carbon_efc", 0, nil)
 
 	// Headline: storage value grows with intermittency — more renewable penetration
 	// raises price-policy cycling.
-	pen00 := meanFinalValue(0.0, steps, nMembers, "price_efc", 0, nil)
-	pen05 := meanFinalValue(0.5, steps, nMembers, "price_efc", 0, nil)
-	pen10 := meanFinalValue(1.0, steps, nMembers, "price_efc", 0, nil)
+	pen00 := meanFinalValue(build, 0.0, steps, nMembers, "price_efc", 0, nil)
+	pen05 := meanFinalValue(build, 0.5, steps, nMembers, "price_efc", 0, nil)
+	pen10 := meanFinalValue(build, 1.0, steps, nMembers, "price_efc", 0, nil)
 
-	strict := meanFinalValue(pen, steps, nMembers, "price_efc", 0, func(g *simulator.ConfigGenerator) {
+	strict := meanFinalValue(build, pen, steps, nMembers, "price_efc", 0, func(g *simulator.ConfigGenerator) {
 		setParam(g, "price_dispatch", "price_high", 60.0)
 	})
-	big := meanFinalValue(pen, steps, nMembers, "price_efc", 0, func(g *simulator.ConfigGenerator) {
+	big := meanFinalValue(build, pen, steps, nMembers, "price_efc", 0, func(g *simulator.ConfigGenerator) {
 		setParam(g, "price_battery", "energy_capacity_mwh", 400.0)
 		setParam(g, "price_efc", "energy_capacity_mwh", 400.0)
 	})
-	leaky := meanFinalValue(pen, steps, nMembers, "price_revenue", 0, func(g *simulator.ConfigGenerator) {
+	leaky := meanFinalValue(build, pen, steps, nMembers, "price_revenue", 0, func(g *simulator.ConfigGenerator) {
 		setParam(g, "price_battery", "charge_efficiency", 0.75)
 		setParam(g, "price_battery", "discharge_efficiency", 0.75)
 	})
-	noisy := meanFinalValue(pen, steps, nMembers, "price_efc", 0, func(g *simulator.ConfigGenerator) {
+	noisy := meanFinalValue(build, pen, steps, nMembers, "price_efc", 0, func(g *simulator.ConfigGenerator) {
 		setParam(g, "price_noise", "sigmas", 15.0)
 	})
-	steep := meanFinalValue(pen, steps, nMembers, "price_efc", 0, func(g *simulator.ConfigGenerator) {
+	steep := meanFinalValue(build, pen, steps, nMembers, "price_efc", 0, func(g *simulator.ConfigGenerator) {
 		setParam(g, "price", "demand_slope", 0.004)
 		setParam(g, "price", "demand_intercept", 35.0-0.004*DefaultResidualMeanMW)
 	})
-	carbonSteep := meanFinalValue(pen, steps, nMembers, "carbon_efc", 0, func(g *simulator.ConfigGenerator) {
+	carbonSteep := meanFinalValue(build, pen, steps, nMembers, "carbon_efc", 0, func(g *simulator.ConfigGenerator) {
 		setParam(g, "carbon_intensity", "carbon_slope", 0.020)
 		setParam(g, "carbon_intensity", "carbon_intercept", 175.0-0.020*DefaultResidualMeanMW)
 	})
 
 	// (state, action) → outcome sign claims — single seeded runs driven hard into
 	// the branch (expensive vs cheap market), asserting the trade's sign.
-	expensive := runStubOverride(pen, steps, 42, func(g *simulator.ConfigGenerator) {
+	expensive := runStubOverride(build, pen, steps, 42, func(g *simulator.ConfigGenerator) {
 		setParam(g, "residual_demand", "mus", 30000.0) // price ≈ £50 > £45 sell bar
 		setParam(g, "residual_demand", "sigmas", 50.0)
 		setParam(g, "price_noise", "sigmas", 0.5)
@@ -149,7 +164,7 @@ func ObservedBehaviour() []cardgen.Claim {
 	sellSoC := finalValue(expensive, "price_battery", 0)
 	sellRevenue := finalValue(expensive, "price_revenue", 0)
 
-	cheap := runStubOverride(pen, steps, 42, func(g *simulator.ConfigGenerator) {
+	cheap := runStubOverride(build, pen, steps, 42, func(g *simulator.ConfigGenerator) {
 		setParam(g, "residual_demand", "mus", 15000.0) // price ≈ £20 < £25 buy bar
 		setParam(g, "residual_demand", "sigmas", 50.0)
 		setParam(g, "price_noise", "sigmas", 0.5)

--- a/models/energy-balancer/declarative.yaml
+++ b/models/energy-balancer/declarative.yaml
@@ -1,0 +1,341 @@
+# The energy-balancer generative core, written entirely as data: no Go, no compilation.
+#
+# This is the same model BuildStub assembles in stub.go, with the same partition names,
+# param keys, state layout and wiring, so the two can be compared directly (see
+# expression_equivalence_test.go, which checks per-step agreement and re-runs the whole
+# behaviour suite against this file). The run knobs BuildStub takes as arguments (renewable
+# penetration, horizon, seed) are injected by the caller; everything below is the model.
+#
+# Read semantics, which the two channels below do NOT share:
+#   - upstreams: is a lag-1 read of another partition's state history, and is what every
+#     bespoke iteration here does when it resolves a *_partition index and reads
+#     stateHistories[idx] (price, carbon_intensity, both dispatches, and all six
+#     accumulators). Their Go doc comments say so explicitly: "one-step lag".
+#   - params_from_upstream: is a within-step read, and is used for exactly one edge — the
+#     battery's dispatch_mw — matching BuildStub, where the battery applies this step's
+#     dispatch to the current SoC.
+# Mixing the two is also what keeps dispatch -> battery -> dispatch from deadlocking.
+#
+# One mask appears here with no counterpart in the params of stub.go, because the Go code
+# carries it as a hardcoded index instead: actual_dispatch_mask selects the battery's
+# actual_dispatch_mw, which the Go reads as the bare constant state index 1 (the accumulator
+# comments literally say "state index 1 of the battery partition"). Stating it as data is
+# what removes the index constant.
+main:
+  partitions:
+
+  # ---- Shared signals -----------------------------------------------------------------
+  # Residual demand (net load): the data-free stand-in for NESO half-hourly replay. sigmas
+  # is the headline driver — the caller injects baseline + penetration * per-penetration MW,
+  # exactly as BuildStub translates its renewablePenetration argument.
+  - name: residual_demand
+    params:
+      thetas: [0.5]
+      mus: [22500.0]
+      sigmas: [1000.0]
+    init_state_values: [22500.0]
+    state_history_depth: 1
+    seed: 0
+
+  # Mean-reverting price noise (mu = 0).
+  - name: price_noise
+    params:
+      thetas: [2.0]
+      mus: [0.0]
+      sigmas: [5.0]
+    init_state_values: [0.0]
+    state_history_depth: 1
+    seed: 0
+
+  # Mean-reverting carbon-intensity noise (mu = 0).
+  - name: carbon_noise
+    params:
+      thetas: [2.0]
+      mus: [0.0]
+      sigmas: [20.0]
+    init_state_values: [0.0]
+    state_history_depth: 1
+    seed: 0
+
+  # Structural imbalance price. init = 0.002 * 22500 - 10.
+  - name: price
+    params:
+      demand_slope: [0.002]
+      demand_intercept: [-10.0]
+    init_state_values: [35.0]
+    state_history_depth: 1
+    seed: 0
+
+  # Structural carbon intensity, driven off the same residual demand as the price, which is
+  # what reproduces their real co-movement. init = 0.012 * 22500 - 95.
+  - name: carbon_intensity
+    params:
+      carbon_slope: [0.012]
+      carbon_intercept: [-95.0]
+    init_state_values: [175.0]
+    state_history_depth: 1
+    seed: 0
+
+  # ---- Price-threshold policy chain ---------------------------------------------------
+  - name: price_dispatch
+    params:
+      price_high: [45.0]
+      price_low: [25.0]
+      power_rating_mw: [100.0]
+    init_state_values: [0.0]
+    state_history_depth: 1
+    seed: 0
+
+  - name: price_battery
+    params:
+      energy_capacity_mwh: [200.0]
+      power_rating_mw: [100.0]
+      charge_efficiency: [0.92]
+      discharge_efficiency: [0.92]
+      min_soc_fraction: [0.1]
+      max_soc_fraction: [0.9]
+    params_from_upstream:
+      dispatch_mw:
+        upstream: price_dispatch
+        indices: [0]
+    init_state_values: [100.0, 0.0]
+    state_history_depth: 1
+    seed: 0
+
+  - name: price_efc
+    params:
+      energy_capacity_mwh: [200.0]
+      actual_dispatch_mask: [0.0, 1.0]
+    init_state_values: [0.0]
+    state_history_depth: 1
+    seed: 0
+
+  - name: price_revenue
+    params:
+      actual_dispatch_mask: [0.0, 1.0]
+    init_state_values: [0.0]
+    state_history_depth: 1
+    seed: 0
+
+  - name: price_co2_saved
+    params:
+      actual_dispatch_mask: [0.0, 1.0]
+    init_state_values: [0.0]
+    state_history_depth: 1
+    seed: 0
+
+  # ---- Carbon-threshold policy chain --------------------------------------------------
+  # Physically identical battery to the price chain, arbitraging the same market against a
+  # different signal, so the two policies' cycling can be compared under identical conditions.
+  - name: carbon_dispatch
+    params:
+      carbon_high: [250.0]
+      carbon_low: [100.0]
+      power_rating_mw: [100.0]
+    init_state_values: [0.0]
+    state_history_depth: 1
+    seed: 0
+
+  - name: carbon_battery
+    params:
+      energy_capacity_mwh: [200.0]
+      power_rating_mw: [100.0]
+      charge_efficiency: [0.92]
+      discharge_efficiency: [0.92]
+      min_soc_fraction: [0.1]
+      max_soc_fraction: [0.9]
+    params_from_upstream:
+      dispatch_mw:
+        upstream: carbon_dispatch
+        indices: [0]
+    init_state_values: [100.0, 0.0]
+    state_history_depth: 1
+    seed: 0
+
+  - name: carbon_efc
+    params:
+      energy_capacity_mwh: [200.0]
+      actual_dispatch_mask: [0.0, 1.0]
+    init_state_values: [0.0]
+    state_history_depth: 1
+    seed: 0
+
+  - name: carbon_revenue
+    params:
+      actual_dispatch_mask: [0.0, 1.0]
+    init_state_values: [0.0]
+    state_history_depth: 1
+    seed: 0
+
+  - name: carbon_co2_saved
+    params:
+      actual_dispatch_mask: [0.0, 1.0]
+    init_state_values: [0.0]
+    state_history_depth: 1
+    seed: 0
+
+  expressions:
+
+  # The exact conditional-Gaussian OU transition, shared by all three noise processes: the
+  # three differ only in their params, so the anchor states the process once. X_{t+dt} | X_t
+  # is Gaussian with mean mu + (X_t - mu) exp(-theta dt) and variance
+  # (sigma^2 / 2theta)(1 - exp(-2 theta dt)); at theta = 0 it degenerates to Brownian motion,
+  # which the scalar where guards lazily so the 1/theta is never evaluated there.
+  #
+  # shared() is what makes this exactly one draw per step, matching the bespoke iteration's
+  # single NormFloat64 call. That holds because each of these fields is one element wide; a
+  # wider field would need iid(width, ...) to stay in lockstep.
+  - partition: residual_demand
+    fields:
+    - {name: x}
+    bindings: &ou_transition
+    - {name: decay, expr: "exp(-thetas * dt)"}
+    - {name: mean, expr: "where(thetas > 0, mus + (x - mus) * decay, x)"}
+    - {name: cond_var, expr: "where(thetas > 0,
+        sigmas * sigmas / (2 * thetas) * (1 - exp(-2 * thetas * dt)),
+        sigmas * sigmas * dt)"}
+    - {name: sd, expr: "sqrt(max(cond_var, 0))"}
+    outputs: ["shared(normal(mean, sd))"]
+
+  - partition: price_noise
+    fields:
+    - {name: x}
+    bindings: *ou_transition
+    outputs: ["shared(normal(mean, sd))"]
+
+  - partition: carbon_noise
+    fields:
+    - {name: x}
+    bindings: *ou_transition
+    outputs: ["shared(normal(mean, sd))"]
+
+  # Both structural signals are the same reduced form — a linear response to residual demand
+  # plus its own mean-reverting noise — which is why they co-move.
+  - partition: price
+    fields:
+    - {name: price_gbp_per_mwh}
+    upstreams:
+      demand: residual_demand
+      noise: price_noise
+    outputs: ["demand_slope * demand + demand_intercept + noise"]
+
+  - partition: carbon_intensity
+    fields:
+    - {name: carbon_gco2_kwh}
+    upstreams:
+      demand: residual_demand
+      noise: carbon_noise
+    outputs: ["carbon_slope * demand + carbon_intercept + noise"]
+
+  # Buy cheap, sell dear: full power across a threshold, nothing between.
+  - partition: price_dispatch
+    fields:
+    - {name: dispatch}
+    upstreams:
+      signal: price
+    outputs:
+    - "where(signal > price_high, power_rating_mw,
+        where(signal < price_low, -power_rating_mw, 0))"
+
+  # Discharge when the grid is dirty (displace gas), charge when it is clean (absorb surplus
+  # renewables): the same shape as the price policy against a different signal.
+  - partition: carbon_dispatch
+    fields:
+    - {name: dispatch}
+    upstreams:
+      signal: carbon_intensity
+    outputs:
+    - "where(signal > carbon_high, power_rating_mw,
+        where(signal < carbon_low, -power_rating_mw, 0))"
+
+  # The battery: clip the dispatch to the power rating, apply it to SoC through the one-way
+  # efficiency for its direction, then enforce the SoC limits and back-calculate the dispatch
+  # actually achieved. actual is the back-calculation: at a limit the battery only moved the
+  # energy it had room for, so the achieved dispatch is that energy converted back through
+  # the same efficiency.
+  - partition: price_battery
+    fields:
+    - {name: soc}
+    - {name: actual_dispatch}
+    bindings: &battery_dynamics
+    - {name: min_soc, expr: "min_soc_fraction * energy_capacity_mwh"}
+    - {name: max_soc, expr: "max_soc_fraction * energy_capacity_mwh"}
+    - {name: dispatch, expr: "clamp(dispatch_mw, -power_rating_mw, power_rating_mw)"}
+    - {name: energy_delta, expr: "where(dispatch >= 0,
+        -dispatch * dt / discharge_efficiency,
+        -dispatch * dt * charge_efficiency)"}
+    - {name: soc_raw, expr: "soc + energy_delta"}
+    - {name: new_soc, expr: "clamp(soc_raw, min_soc, max_soc)"}
+    - {name: actual, expr: "where(soc_raw < min_soc,
+        (soc - min_soc) * discharge_efficiency / dt,
+        where(soc_raw > max_soc,
+        -(max_soc - soc) / (charge_efficiency * dt), dispatch))"}
+    outputs: ["new_soc", "actual"]
+
+  - partition: carbon_battery
+    fields:
+    - {name: soc}
+    - {name: actual_dispatch}
+    bindings: *battery_dynamics
+    outputs: ["new_soc", "actual"]
+
+  # Equivalent full cycles: energy moved per step over twice the capacity (a full cycle is a
+  # charge and a discharge), accumulated.
+  - partition: price_efc
+    fields:
+    - {name: cumulative_efc}
+    upstreams:
+      battery: price_battery
+    bindings: &efc_accumulation
+    - {name: actual_dispatch, expr: "dot(actual_dispatch_mask, battery)"}
+    outputs: ["cumulative_efc + abs(actual_dispatch * dt) / (2 * energy_capacity_mwh)"]
+
+  - partition: carbon_efc
+    fields:
+    - {name: cumulative_efc}
+    upstreams:
+      battery: carbon_battery
+    bindings: *efc_accumulation
+    outputs: ["cumulative_efc + abs(actual_dispatch * dt) / (2 * energy_capacity_mwh)"]
+
+  # Revenue: positive when discharging (selling), negative when charging (buying).
+  - partition: price_revenue
+    fields:
+    - {name: cumulative_revenue}
+    upstreams:
+      battery: price_battery
+      market_price: price
+    bindings: &revenue_accumulation
+    - {name: actual_dispatch, expr: "dot(actual_dispatch_mask, battery)"}
+    outputs: ["cumulative_revenue + actual_dispatch * market_price * dt"]
+
+  - partition: carbon_revenue
+    fields:
+    - {name: cumulative_revenue}
+    upstreams:
+      battery: carbon_battery
+      market_price: price
+    bindings: *revenue_accumulation
+    outputs: ["cumulative_revenue + actual_dispatch * market_price * dt"]
+
+  # Carbon displaced by discharging only: charging does not save carbon, hence the max at 0.
+  # MWh * gCO2/kWh / 1000 = tCO2.
+  - partition: price_co2_saved
+    fields:
+    - {name: cumulative_carbon_tco2}
+    upstreams:
+      battery: price_battery
+      carbon: carbon_intensity
+    bindings: &carbon_savings_accumulation
+    - {name: actual_dispatch, expr: "dot(actual_dispatch_mask, battery)"}
+    - {name: discharge_mwh, expr: "max(actual_dispatch, 0) * dt"}
+    outputs: ["cumulative_carbon_tco2 + discharge_mwh * carbon / 1000"]
+
+  - partition: carbon_co2_saved
+    fields:
+    - {name: cumulative_carbon_tco2}
+    upstreams:
+      battery: carbon_battery
+      carbon: carbon_intensity
+    bindings: *carbon_savings_accumulation
+    outputs: ["cumulative_carbon_tco2 + discharge_mwh * carbon / 1000"]

--- a/models/energy-balancer/expression_equivalence_test.go
+++ b/models/energy-balancer/expression_equivalence_test.go
@@ -1,0 +1,136 @@
+package energybalancer
+
+// Corpus validation for general.ExpressionIteration: can a real bespoke catalogue iteration
+// be re-expressed declaratively, as data, with no Go?
+//
+// BatteryIteration is the hardest control flow in this catalogue (a power clip, a sign
+// branch, and a three-way state-of-charge switch that back-calculates the dispatch actually
+// achieved) but it is deterministic, so equivalence is decidable by direct comparison rather
+// than by distribution matching.
+//
+// Note this asserts a tight relative tolerance rather than bit-identity: the compiled Go is
+// free to contract `soc + (-dispatch*dt*eff)` into a fused multiply-add, which rounds
+// differently from the evaluator's separate operations. Deviation at that scale is the FMA,
+// not the model, and moves no card claim.
+
+import (
+	"math"
+	"math/rand/v2"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+
+	"github.com/umbralcalc/stochadex/pkg/general"
+	"github.com/umbralcalc/stochadex/pkg/simulator"
+)
+
+// declarativeBattery is BatteryIteration expressed entirely as data.
+func declarativeBattery() *general.ExpressionIteration {
+	return &general.ExpressionIteration{
+		Fields: []general.ExpressionField{{Name: "soc"}, {Name: "actual_dispatch"}},
+		Bindings: []general.ExpressionBinding{
+			{Name: "min_soc", Expr: "min_soc_fraction * energy_capacity_mwh"},
+			{Name: "max_soc", Expr: "max_soc_fraction * energy_capacity_mwh"},
+			{Name: "dispatch", Expr: "clamp(dispatch_mw, -power_rating_mw, power_rating_mw)"},
+			{Name: "energy_delta", Expr: "where(dispatch >= 0, " +
+				"-dispatch * dt / discharge_efficiency, " +
+				"-dispatch * dt * charge_efficiency)"},
+			{Name: "soc_raw", Expr: "soc + energy_delta"},
+			{Name: "new_soc", Expr: "clamp(soc_raw, min_soc, max_soc)"},
+			{Name: "actual", Expr: "where(soc_raw < min_soc, " +
+				"(soc - min_soc) * discharge_efficiency / dt, " +
+				"where(soc_raw > max_soc, " +
+				"-(max_soc - soc) / (charge_efficiency * dt), dispatch))"},
+		},
+		Outputs: []string{"new_soc", "actual"},
+	}
+}
+
+func TestDeclarativeBatteryMatchesBespoke(t *testing.T) {
+	bespoke := &BatteryIteration{}
+	declarative := declarativeBattery()
+	settings := &simulator.Settings{
+		Iterations: []simulator.IterationSettings{{Name: "battery", Seed: 0}},
+	}
+	bespoke.Configure(0, settings)
+	declarative.Configure(0, settings)
+
+	rng := rand.New(rand.NewPCG(1, 2))
+	capacity := DefaultEnergyCapacityMWh
+	branches := map[string]int{}
+	maxDev, ulpDiffs := 0.0, 0
+
+	const cases = 20000
+	for i := 0; i < cases; i++ {
+		soc := rng.Float64() * capacity
+		// Deliberately over-range so the power clip and both SoC limits all trigger.
+		dispatch := (rng.Float64()*4 - 2) * DefaultPowerRatingMW
+		dt := 0.25 + rng.Float64()
+
+		params := simulator.NewParams(map[string][]float64{
+			"dispatch_mw":          {dispatch},
+			"energy_capacity_mwh":  {capacity},
+			"power_rating_mw":      {DefaultPowerRatingMW},
+			"charge_efficiency":    {DefaultChargeEfficiency},
+			"discharge_efficiency": {DefaultDischargeEfficiency},
+			"min_soc_fraction":     {DefaultMinSoCFraction},
+			"max_soc_fraction":     {DefaultMaxSoCFraction},
+		})
+		mk := func() []*simulator.StateHistory {
+			return []*simulator.StateHistory{{
+				Values:            mat.NewDense(1, 2, []float64{soc, 0}),
+				StateWidth:        2,
+				StateHistoryDepth: 1,
+			}}
+		}
+		ts := &simulator.CumulativeTimestepsHistory{
+			Values:            mat.NewVecDense(1, []float64{float64(i) * dt}),
+			NextIncrement:     dt,
+			CurrentStepNumber: i + 1,
+		}
+
+		want := bespoke.Iterate(&params, 0, mk(), ts)
+		got := declarative.Iterate(&params, 0, mk(), ts)
+
+		if math.Abs(dispatch) > DefaultPowerRatingMW {
+			branches["power_clip"]++
+		}
+		switch {
+		case want[0] <= DefaultMinSoCFraction*capacity+1e-12:
+			branches["soc_floor"]++
+		case want[0] >= DefaultMaxSoCFraction*capacity-1e-12:
+			branches["soc_ceiling"]++
+		default:
+			branches["normal"]++
+		}
+
+		if len(got) != len(want) {
+			t.Fatalf("case %d: width %d, want %d", i, len(got), len(want))
+		}
+		for k := range want {
+			d := math.Abs(got[k] - want[k])
+			if s := math.Abs(want[k]); s > 1 {
+				d /= s
+			}
+			if d > maxDev {
+				maxDev = d
+			}
+			if d > 1e-12 {
+				t.Fatalf("case %d field %d: declarative=%v bespoke=%v rel-dev=%g "+
+					"(soc=%v dispatch=%v dt=%v)",
+					i, k, got[k], want[k], d, soc, dispatch, dt)
+			}
+			if got[k] != want[k] {
+				ulpDiffs++
+			}
+		}
+	}
+	for _, b := range []string{"normal", "power_clip", "soc_floor", "soc_ceiling"} {
+		if branches[b] == 0 {
+			t.Errorf("branch %q never exercised; the comparison is weaker than it looks", b)
+		}
+	}
+	t.Logf("branches exercised: %v", branches)
+	t.Logf("max relative deviation: %g over %d comparisons", maxDev, cases*2)
+	t.Logf("outputs differing only at ULP scale (FMA contraction): %d", ulpDiffs)
+}

--- a/models/energy-balancer/expression_equivalence_test.go
+++ b/models/energy-balancer/expression_equivalence_test.go
@@ -1,17 +1,27 @@
 package energybalancer
 
-// Corpus validation for general.ExpressionIteration: can a real bespoke catalogue iteration
-// be re-expressed declaratively, as data, with no Go?
+// Does declarative.yaml — this model written as data, with no Go — reproduce the model
+// stub.go builds in code?
 //
-// BatteryIteration is the hardest control flow in this catalogue (a power clip, a sign
-// branch, and a three-way state-of-charge switch that back-calculates the dispatch actually
-// achieved) but it is deterministic, so equivalence is decidable by direct comparison rather
-// than by distribution matching.
+// Two independent kinds of check, because they fail in different ways. The step-for-step
+// tests compare single Iterate calls over randomised inputs, one per bespoke iteration
+// type, which catches a mis-stated formula exactly. The suite test re-runs the model's own
+// claim computations against the declarative build, which catches a model that is subtly
+// different in a way per-step agreement would not: wrong wiring, wrong param values, wrong
+// state layout.
 //
-// Note this asserts a tight relative tolerance rather than bit-identity: the compiled Go is
-// free to contract `soc + (-dispatch*dt*eff)` into a fused multiply-add, which rounds
-// differently from the evaluator's separate operations. Deviation at that scale is the FMA,
-// not the model, and moves no card claim.
+// Every draw in this model is taken by OrnsteinUhlenbeckExactGaussianIteration, which
+// samples from rng.New(seed) — the same generator the expression evaluator uses, since
+// rng.New(seed) is rand.New(rand.NewPCG(seed, seed)) — and takes exactly one NormFloat64
+// per dimension per step. The declarative OU takes exactly one shared(normal(...)) over a
+// one-wide field, and sampler.Normal(mu, sigma) is NormFloat64()*sigma + mu, so the two
+// streams stay in lockstep and equivalence is decidable directly rather than only in
+// distribution. Every other iteration here is deterministic.
+//
+// Agreement is asserted to a tight tolerance rather than bit-for-bit: compiled Go is free
+// to contract a + b*c into a fused multiply-add, which rounds differently from the
+// evaluator's separate operations. Deviation at that scale is the FMA, not the model, and
+// moves no card claim.
 
 import (
 	"math"
@@ -20,40 +30,419 @@ import (
 
 	"gonum.org/v1/gonum/mat"
 
+	"github.com/umbralcalc/stochadex/models/cardgen"
+	"github.com/umbralcalc/stochadex/pkg/api"
 	"github.com/umbralcalc/stochadex/pkg/general"
 	"github.com/umbralcalc/stochadex/pkg/simulator"
 )
 
-// declarativeBattery is BatteryIteration expressed entirely as data.
-func declarativeBattery() *general.ExpressionIteration {
-	return &general.ExpressionIteration{
-		Fields: []general.ExpressionField{{Name: "soc"}, {Name: "actual_dispatch"}},
-		Bindings: []general.ExpressionBinding{
-			{Name: "min_soc", Expr: "min_soc_fraction * energy_capacity_mwh"},
-			{Name: "max_soc", Expr: "max_soc_fraction * energy_capacity_mwh"},
-			{Name: "dispatch", Expr: "clamp(dispatch_mw, -power_rating_mw, power_rating_mw)"},
-			{Name: "energy_delta", Expr: "where(dispatch >= 0, " +
-				"-dispatch * dt / discharge_efficiency, " +
-				"-dispatch * dt * charge_efficiency)"},
-			{Name: "soc_raw", Expr: "soc + energy_delta"},
-			{Name: "new_soc", Expr: "clamp(soc_raw, min_soc, max_soc)"},
-			{Name: "actual", Expr: "where(soc_raw < min_soc, " +
-				"(soc - min_soc) * discharge_efficiency / dt, " +
-				"where(soc_raw > max_soc, " +
-				"-(max_soc - soc) / (charge_efficiency * dt), dispatch))"},
+// tolerance is well above FMA rounding and well below any difference a real modelling
+// discrepancy would produce.
+const tolerance = 1e-12
+
+// declarativeBuildStub assembles the model from declarative.yaml, matching BuildStub's
+// signature so it can be dropped into the behaviour helpers. The YAML holds the model; the
+// run knobs BuildStub takes as arguments are injected here, exactly as BuildStub injects
+// them into its Go partitions.
+//
+// The penetration-to-volatility map is BuildStub's own translation of its argument into a
+// param — the knob, not the generative core — so it is restated here rather than in the
+// YAML. Keeping sigmas the param it acts on is also what lets the behaviour suite's
+// volatility overrides reach the declarative model unchanged.
+func declarativeBuildStub(
+	renewablePenetration float64,
+	numSteps int,
+	seed uint64,
+) *simulator.ConfigGenerator {
+	config := api.LoadApiRunConfigFromYaml("declarative.yaml")
+	config.Main.Simulation = simulator.SimulationConfig{
+		OutputCondition: &simulator.EveryStepOutputCondition{},
+		TerminationCondition: &simulator.NumberOfStepsTerminationCondition{
+			MaxNumberOfSteps: numSteps,
 		},
-		Outputs: []string{"new_soc", "actual"},
+		TimestepFunction: &simulator.ConstantTimestepFunction{Stepsize: stepSizeHours},
+		InitTimeValue:    0.0,
+	}
+	gen := config.Main.GetConfigGenerator()
+	gen.GetPartition("residual_demand").Params.Map["sigmas"] = []float64{
+		DefaultBaselineVolatilityMW +
+			renewablePenetration*DefaultVolatilityPerPenetrationMW,
+	}
+	gen.GetPartition("residual_demand").Seed = seed
+	gen.GetPartition("price_noise").Seed = seed + 1
+	gen.GetPartition("carbon_noise").Seed = seed + 2
+	return gen
+}
+
+// assembly is one generated build of the model, kept whole so that a step-for-step test can
+// reach an iteration together with the params and partition indices the generator resolved
+// for it.
+type assembly struct {
+	settings        *simulator.Settings
+	implementations *simulator.Implementations
+}
+
+// assemble generates configs from a builder. GenerateConfigs configures every iteration, so
+// the samplers here are already seeded from the partition seeds.
+func assemble(t *testing.T, build stubBuilder, penetration float64, seed uint64) *assembly {
+	t.Helper()
+	settings, implementations := build(penetration, DefaultNumSteps, seed).GenerateConfigs()
+	return &assembly{settings: settings, implementations: implementations}
+}
+
+func (a *assembly) index(t *testing.T, name string) int {
+	t.Helper()
+	for i, iteration := range a.settings.Iterations {
+		if iteration.Name == name {
+			return i
+		}
+	}
+	t.Fatalf("no partition named %q", name)
+	return -1
+}
+
+func (a *assembly) iteration(t *testing.T, name string) simulator.Iteration {
+	t.Helper()
+	return a.implementations.Iterations[a.index(t, name)]
+}
+
+// params returns the params the generator resolved for a partition, which for the bespoke
+// build is where params_as_partitions has become concrete partition indices.
+func (a *assembly) params(t *testing.T, name string) map[string][]float64 {
+	t.Helper()
+	return a.settings.Iterations[a.index(t, name)].Params.Map
+}
+
+// histories builds a fresh, correctly-shaped lag-1 state history for every partition in the
+// model, with the named rows filled in. Fresh per call because iterations return slices that
+// alias their own history buffers.
+func (a *assembly) histories(rows map[string][]float64) []*simulator.StateHistory {
+	out := make([]*simulator.StateHistory, len(a.settings.Iterations))
+	for i, iteration := range a.settings.Iterations {
+		row := make([]float64, iteration.StateWidth)
+		if values, ok := rows[iteration.Name]; ok {
+			copy(row, values)
+		}
+		out[i] = &simulator.StateHistory{
+			Values:            mat.NewDense(1, iteration.StateWidth, row),
+			StateWidth:        iteration.StateWidth,
+			StateHistoryDepth: 1,
+		}
+	}
+	return out
+}
+
+// timesteps returns a history whose increment is dt, which is what every dt-sensitive
+// iteration here reads.
+func timesteps(step int, dt float64) *simulator.CumulativeTimestepsHistory {
+	return &simulator.CumulativeTimestepsHistory{
+		Values:            mat.NewVecDense(1, []float64{float64(step) * dt}),
+		NextIncrement:     dt,
+		CurrentStepNumber: step + 1,
 	}
 }
 
-func TestDeclarativeBatteryMatchesBespoke(t *testing.T) {
-	bespoke := &BatteryIteration{}
-	declarative := declarativeBattery()
-	settings := &simulator.Settings{
-		Iterations: []simulator.IterationSettings{{Name: "battery", Seed: 0}},
+// declarativeIteration asserts a partition is expression-backed and returns it, so a test
+// that means to exercise the DSL cannot silently be handed a Go iteration.
+func declarativeIteration(
+	t *testing.T,
+	a *assembly,
+	partition string,
+) *general.ExpressionIteration {
+	t.Helper()
+	iteration, ok := a.iteration(t, partition).(*general.ExpressionIteration)
+	if !ok {
+		t.Fatalf("%s is not expression-backed: got %T", partition, a.iteration(t, partition))
 	}
-	bespoke.Configure(0, settings)
-	declarative.Configure(0, settings)
+	return iteration
+}
+
+// assertClose fails when two values differ by more than the FMA-scale tolerance, comparing
+// relatively once the magnitude exceeds 1.
+func assertClose(t *testing.T, got, want float64, context string) float64 {
+	t.Helper()
+	d := math.Abs(got - want)
+	if s := math.Abs(want); s > 1 {
+		d /= s
+	}
+	if d > tolerance {
+		t.Fatalf("%s: declarative=%v bespoke=%v deviation=%g", context, got, want, d)
+	}
+	return d
+}
+
+// assertBranchesExercised fails when a named branch was never reached, since a comparison
+// that never entered a branch says nothing about it.
+func assertBranchesExercised(t *testing.T, branches map[string]int, names ...string) {
+	t.Helper()
+	for _, name := range names {
+		if branches[name] == 0 {
+			t.Errorf("branch %q never exercised; the comparison is weaker than it looks", name)
+		}
+	}
+	t.Logf("branches exercised: %v", branches)
+}
+
+// TestDeclarativeConfigMatchesBespoke checks the two builds are the same model before any
+// per-step comparison: same partitions in the same order, same state layout, same seeds. A
+// step-for-step test drives one iteration and so cannot see a partition that is missing,
+// misordered or wrongly initialised.
+//
+// Params are deliberately NOT compared: the declarative build carries no resolved
+// *_partition indices (it names its upstreams instead) and carries an actual_dispatch_mask
+// the Go build hardcodes as an index. That difference is the point of the exercise.
+func TestDeclarativeConfigMatchesBespoke(t *testing.T) {
+	bespoke := assemble(t, BuildStub, 0.6, 7)
+	declarative := assemble(t, declarativeBuildStub, 0.6, 7)
+
+	if len(declarative.settings.Iterations) != len(bespoke.settings.Iterations) {
+		t.Fatalf("got %d partitions, want %d",
+			len(declarative.settings.Iterations), len(bespoke.settings.Iterations))
+	}
+	for i, want := range bespoke.settings.Iterations {
+		got := declarative.settings.Iterations[i]
+		if got.Name != want.Name {
+			t.Fatalf("partition %d: got name %q, want %q", i, got.Name, want.Name)
+		}
+		if got.StateWidth != want.StateWidth {
+			t.Errorf("%s: got state width %d, want %d", want.Name, got.StateWidth, want.StateWidth)
+		}
+		if got.Seed != want.Seed {
+			t.Errorf("%s: got seed %d, want %d", want.Name, got.Seed, want.Seed)
+		}
+		if len(got.InitStateValues) != len(want.InitStateValues) {
+			t.Fatalf("%s: got %d init values, want %d",
+				want.Name, len(got.InitStateValues), len(want.InitStateValues))
+		}
+		for k := range want.InitStateValues {
+			assertClose(t, got.InitStateValues[k], want.InitStateValues[k],
+				want.Name+" init state")
+		}
+	}
+	// The one within-step edge in the model. Everything else is a lag-1 history read, which
+	// the declarative build spells as an upstreams alias rather than a resolved index.
+	for _, battery := range []string{"price_battery", "carbon_battery"} {
+		got := declarative.settings.Iterations[declarative.index(t, battery)].ParamsFromUpstream
+		want := bespoke.settings.Iterations[bespoke.index(t, battery)].ParamsFromUpstream
+		if len(got) != len(want) {
+			t.Fatalf("%s: got %d upstream params, want %d", battery, len(got), len(want))
+		}
+		if got["dispatch_mw"].Upstream != want["dispatch_mw"].Upstream {
+			t.Errorf("%s: dispatch_mw comes from partition %d, want %d",
+				battery, got["dispatch_mw"].Upstream, want["dispatch_mw"].Upstream)
+		}
+	}
+}
+
+// TestDeclarativeOrnsteinUhlenbeckMatchesBespoke drives residual_demand, the OU partition
+// the headline driver acts on. The other two OU partitions share this expression by YAML
+// anchor and this Go type, so they are the same comparison with different params; the config
+// and suite tests cover their wiring.
+//
+// The theta=0 degenerate case (Brownian motion) is swept even though this model never
+// configures it, because the bespoke iteration branches on it and the declarative guard has
+// to agree. The conditional-variance clamp at zero is not swept: for theta>0 the variance is
+// positive by construction, so the clamp is defensive and unreachable from any params here.
+func TestDeclarativeOrnsteinUhlenbeckMatchesBespoke(t *testing.T) {
+	const partition = "residual_demand"
+	bespokeBuild := assemble(t, BuildStub, 0.6, 3)
+	declarativeBuild := assemble(t, declarativeBuildStub, 0.6, 3)
+
+	bespoke := bespokeBuild.iteration(t, partition)
+	declarative := declarativeIteration(t, declarativeBuild, partition)
+	index := bespokeBuild.index(t, partition)
+
+	rng := rand.New(rand.NewPCG(31, 32))
+	branches := map[string]int{}
+	maxDev := 0.0
+
+	const cases = 20000
+	for i := 0; i < cases; i++ {
+		// theta=0 on a sweep of the cases so the Brownian branch is compared too, and both
+		// sides still take exactly one draw, keeping the streams in lockstep.
+		theta := 0.0
+		if i%4 != 0 {
+			theta = rng.Float64() * 3
+		}
+		mu := rng.Float64() * 30000
+		sigma := rng.Float64() * 4000
+		x := rng.Float64() * 40000
+		dt := 0.1 + rng.Float64()
+
+		values := map[string][]float64{
+			"thetas": {theta},
+			"mus":    {mu},
+			"sigmas": {sigma},
+		}
+		bespokeParams := simulator.NewParams(values)
+		declarativeParams := simulator.NewParams(values)
+		rows := map[string][]float64{partition: {x}}
+		ts := timesteps(i, dt)
+
+		want := append([]float64{}, bespoke.Iterate(
+			&bespokeParams, index, bespokeBuild.histories(rows), ts)...)
+		got := declarative.Iterate(
+			&declarativeParams, index, declarativeBuild.histories(rows), ts)
+
+		if theta > 0 {
+			branches["mean_reverting"]++
+		} else {
+			branches["brownian"]++
+		}
+		if len(got) != len(want) {
+			t.Fatalf("case %d: width %d, want %d", i, len(got), len(want))
+		}
+		maxDev = math.Max(maxDev, assertClose(t, got[0], want[0], "residual demand"))
+	}
+	assertBranchesExercised(t, branches, "mean_reverting", "brownian")
+	t.Logf("max deviation: %g", maxDev)
+}
+
+// TestDeclarativeStructuralSignalsMatchBespoke drives the price and carbon-intensity
+// reduced forms. Both are straight-line, so there are no branches to sweep; what is being
+// checked is that each reads the right upstream, since both read residual demand but must
+// take their noise from different partitions.
+func TestDeclarativeStructuralSignalsMatchBespoke(t *testing.T) {
+	bespokeBuild := assemble(t, BuildStub, 0.6, 11)
+	declarativeBuild := assemble(t, declarativeBuildStub, 0.6, 11)
+
+	for _, signal := range []struct {
+		partition    string
+		noise        string
+		slopeKey     string
+		interceptKey string
+	}{
+		{"price", "price_noise", "demand_slope", "demand_intercept"},
+		{"carbon_intensity", "carbon_noise", "carbon_slope", "carbon_intercept"},
+	} {
+		t.Run(signal.partition, func(t *testing.T) {
+			bespoke := bespokeBuild.iteration(t, signal.partition)
+			declarative := declarativeIteration(t, declarativeBuild, signal.partition)
+			index := bespokeBuild.index(t, signal.partition)
+			resolved := bespokeBuild.params(t, signal.partition)
+
+			rng := rand.New(rand.NewPCG(41, 42))
+			maxDev := 0.0
+
+			const cases = 20000
+			for i := 0; i < cases; i++ {
+				slope := rng.Float64() * 0.03
+				intercept := rng.Float64()*200 - 100
+				demand := rng.Float64() * 45000
+				// Both noise partitions are given a value, so a signal reading the wrong one
+				// diverges rather than silently agreeing on a shared number.
+				priceNoise := rng.Float64()*20 - 10
+				carbonNoise := rng.Float64()*80 - 40
+
+				bespokeParams := simulator.NewParams(map[string][]float64{
+					signal.slopeKey:     {slope},
+					signal.interceptKey: {intercept},
+					"demand_partition":  resolved["demand_partition"],
+					"noise_partition":   resolved["noise_partition"],
+				})
+				declarativeParams := simulator.NewParams(map[string][]float64{
+					signal.slopeKey:     {slope},
+					signal.interceptKey: {intercept},
+				})
+				rows := map[string][]float64{
+					"residual_demand": {demand},
+					"price_noise":     {priceNoise},
+					"carbon_noise":    {carbonNoise},
+				}
+				ts := timesteps(i, stepSizeHours)
+
+				want := bespoke.Iterate(
+					&bespokeParams, index, bespokeBuild.histories(rows), ts)
+				got := declarative.Iterate(
+					&declarativeParams, index, declarativeBuild.histories(rows), ts)
+
+				maxDev = math.Max(maxDev, assertClose(t, got[0], want[0], signal.partition))
+			}
+			t.Logf("cases: %d, max deviation: %g", cases, maxDev)
+		})
+	}
+}
+
+// TestDeclarativeDispatchMatchesBespoke drives both threshold policies over a signal range
+// wide enough that all three arms — discharge, charge and hold — are compared.
+func TestDeclarativeDispatchMatchesBespoke(t *testing.T) {
+	bespokeBuild := assemble(t, BuildStub, 0.6, 13)
+	declarativeBuild := assemble(t, declarativeBuildStub, 0.6, 13)
+
+	for _, policy := range []struct {
+		partition   string
+		signal      string
+		signalParam string
+		highKey     string
+		lowKey      string
+		low, span   float64
+	}{
+		{"price_dispatch", "price", "price_partition", "price_high", "price_low", 0, 80},
+		{"carbon_dispatch", "carbon_intensity", "carbon_partition",
+			"carbon_high", "carbon_low", 0, 400},
+	} {
+		t.Run(policy.partition, func(t *testing.T) {
+			bespoke := bespokeBuild.iteration(t, policy.partition)
+			declarative := declarativeIteration(t, declarativeBuild, policy.partition)
+			index := bespokeBuild.index(t, policy.partition)
+			resolved := bespokeBuild.params(t, policy.partition)
+			defaults := declarativeBuild.params(t, policy.partition)
+			high, low := defaults[policy.highKey][0], defaults[policy.lowKey][0]
+
+			rng := rand.New(rand.NewPCG(51, 52))
+			branches := map[string]int{}
+			maxDev := 0.0
+
+			const cases = 20000
+			for i := 0; i < cases; i++ {
+				signal := policy.low + rng.Float64()*policy.span
+
+				bespokeParams := simulator.NewParams(map[string][]float64{
+					policy.highKey:     {high},
+					policy.lowKey:      {low},
+					"power_rating_mw":  {DefaultPowerRatingMW},
+					policy.signalParam: resolved[policy.signalParam],
+				})
+				declarativeParams := simulator.NewParams(map[string][]float64{
+					policy.highKey:    {high},
+					policy.lowKey:     {low},
+					"power_rating_mw": {DefaultPowerRatingMW},
+				})
+				rows := map[string][]float64{policy.signal: {signal}}
+				ts := timesteps(i, stepSizeHours)
+
+				want := bespoke.Iterate(
+					&bespokeParams, index, bespokeBuild.histories(rows), ts)
+				got := declarative.Iterate(
+					&declarativeParams, index, declarativeBuild.histories(rows), ts)
+
+				switch {
+				case signal > high:
+					branches["discharge"]++
+				case signal < low:
+					branches["charge"]++
+				default:
+					branches["hold"]++
+				}
+				maxDev = math.Max(maxDev, assertClose(t, got[0], want[0], policy.partition))
+			}
+			assertBranchesExercised(t, branches, "discharge", "charge", "hold")
+			t.Logf("max deviation: %g", maxDev)
+		})
+	}
+}
+
+// TestDeclarativeBatteryMatchesBespoke drives the hardest control flow in the model: a power
+// clip, a sign branch on the dispatch direction, and a three-way state-of-charge switch that
+// back-calculates the dispatch actually achieved.
+func TestDeclarativeBatteryMatchesBespoke(t *testing.T) {
+	const partition = "price_battery"
+	bespokeBuild := assemble(t, BuildStub, 0.6, 17)
+	declarativeBuild := assemble(t, declarativeBuildStub, 0.6, 17)
+
+	bespoke := bespokeBuild.iteration(t, partition)
+	declarative := declarativeIteration(t, declarativeBuild, partition)
+	index := bespokeBuild.index(t, partition)
 
 	rng := rand.New(rand.NewPCG(1, 2))
 	capacity := DefaultEnergyCapacityMWh
@@ -67,7 +456,7 @@ func TestDeclarativeBatteryMatchesBespoke(t *testing.T) {
 		dispatch := (rng.Float64()*4 - 2) * DefaultPowerRatingMW
 		dt := 0.25 + rng.Float64()
 
-		params := simulator.NewParams(map[string][]float64{
+		values := map[string][]float64{
 			"dispatch_mw":          {dispatch},
 			"energy_capacity_mwh":  {capacity},
 			"power_rating_mw":      {DefaultPowerRatingMW},
@@ -75,25 +464,22 @@ func TestDeclarativeBatteryMatchesBespoke(t *testing.T) {
 			"discharge_efficiency": {DefaultDischargeEfficiency},
 			"min_soc_fraction":     {DefaultMinSoCFraction},
 			"max_soc_fraction":     {DefaultMaxSoCFraction},
-		})
-		mk := func() []*simulator.StateHistory {
-			return []*simulator.StateHistory{{
-				Values:            mat.NewDense(1, 2, []float64{soc, 0}),
-				StateWidth:        2,
-				StateHistoryDepth: 1,
-			}}
 		}
-		ts := &simulator.CumulativeTimestepsHistory{
-			Values:            mat.NewVecDense(1, []float64{float64(i) * dt}),
-			NextIncrement:     dt,
-			CurrentStepNumber: i + 1,
-		}
+		bespokeParams := simulator.NewParams(values)
+		declarativeParams := simulator.NewParams(values)
+		rows := map[string][]float64{partition: {soc, 0}}
+		ts := timesteps(i, dt)
 
-		want := bespoke.Iterate(&params, 0, mk(), ts)
-		got := declarative.Iterate(&params, 0, mk(), ts)
+		want := bespoke.Iterate(&bespokeParams, index, bespokeBuild.histories(rows), ts)
+		got := declarative.Iterate(&declarativeParams, index, declarativeBuild.histories(rows), ts)
 
 		if math.Abs(dispatch) > DefaultPowerRatingMW {
 			branches["power_clip"]++
+		}
+		if dispatch >= 0 {
+			branches["discharging"]++
+		} else {
+			branches["charging"]++
 		}
 		switch {
 		case want[0] <= DefaultMinSoCFraction*capacity+1e-12:
@@ -108,29 +494,131 @@ func TestDeclarativeBatteryMatchesBespoke(t *testing.T) {
 			t.Fatalf("case %d: width %d, want %d", i, len(got), len(want))
 		}
 		for k := range want {
-			d := math.Abs(got[k] - want[k])
-			if s := math.Abs(want[k]); s > 1 {
-				d /= s
-			}
-			if d > maxDev {
-				maxDev = d
-			}
-			if d > 1e-12 {
-				t.Fatalf("case %d field %d: declarative=%v bespoke=%v rel-dev=%g "+
-					"(soc=%v dispatch=%v dt=%v)",
-					i, k, got[k], want[k], d, soc, dispatch, dt)
-			}
+			maxDev = math.Max(maxDev, assertClose(t, got[k], want[k], "battery"))
 			if got[k] != want[k] {
 				ulpDiffs++
 			}
 		}
 	}
-	for _, b := range []string{"normal", "power_clip", "soc_floor", "soc_ceiling"} {
-		if branches[b] == 0 {
-			t.Errorf("branch %q never exercised; the comparison is weaker than it looks", b)
+	assertBranchesExercised(t, branches,
+		"normal", "power_clip", "soc_floor", "soc_ceiling", "charging", "discharging")
+	t.Logf("max deviation: %g over %d comparisons", maxDev, cases*2)
+	t.Logf("outputs differing only at ULP scale (FMA contraction): %d", ulpDiffs)
+}
+
+// TestDeclarativeAccumulatorsMatchBespoke drives the three accumulators that read the
+// battery's achieved dispatch out of its state. All three are where the Go hardcodes the
+// battery's state index 1, and the declarative build states it as actual_dispatch_mask, so
+// this is the test that mask has to earn.
+func TestDeclarativeAccumulatorsMatchBespoke(t *testing.T) {
+	bespokeBuild := assemble(t, BuildStub, 0.6, 19)
+	declarativeBuild := assemble(t, declarativeBuildStub, 0.6, 19)
+
+	for _, accumulator := range []struct {
+		partition string
+		extra     []string
+	}{
+		{"price_efc", []string{"energy_capacity_mwh"}},
+		{"price_revenue", nil},
+		{"price_co2_saved", nil},
+	} {
+		t.Run(accumulator.partition, func(t *testing.T) {
+			bespoke := bespokeBuild.iteration(t, accumulator.partition)
+			declarative := declarativeIteration(t, declarativeBuild, accumulator.partition)
+			index := bespokeBuild.index(t, accumulator.partition)
+			resolved := bespokeBuild.params(t, accumulator.partition)
+			defaults := declarativeBuild.params(t, accumulator.partition)
+
+			rng := rand.New(rand.NewPCG(61, 62))
+			branches := map[string]int{}
+			maxDev := 0.0
+
+			const cases = 20000
+			for i := 0; i < cases; i++ {
+				// Straddles zero so the discharge-only carbon credit and the revenue sign
+				// are both exercised on either side.
+				actualDispatch := rng.Float64()*2*DefaultPowerRatingMW - DefaultPowerRatingMW
+				soc := rng.Float64() * DefaultEnergyCapacityMWh
+				price := rng.Float64()*100 - 20
+				carbon := rng.Float64() * 400
+				previous := rng.Float64() * 100
+				dt := 0.25 + rng.Float64()
+
+				bespokeValues := map[string][]float64{}
+				declarativeValues := map[string][]float64{}
+				for _, key := range accumulator.extra {
+					bespokeValues[key] = resolved[key]
+					declarativeValues[key] = defaults[key]
+				}
+				for _, key := range []string{
+					"battery_partition", "price_partition", "carbon_partition",
+				} {
+					if value, ok := resolved[key]; ok {
+						bespokeValues[key] = value
+					}
+				}
+				declarativeValues["actual_dispatch_mask"] = defaults["actual_dispatch_mask"]
+
+				bespokeParams := simulator.NewParams(bespokeValues)
+				declarativeParams := simulator.NewParams(declarativeValues)
+				rows := map[string][]float64{
+					"price_battery":       {soc, actualDispatch},
+					"price":               {price},
+					"carbon_intensity":    {carbon},
+					accumulator.partition: {previous},
+				}
+				ts := timesteps(i, dt)
+
+				want := bespoke.Iterate(
+					&bespokeParams, index, bespokeBuild.histories(rows), ts)
+				got := declarative.Iterate(
+					&declarativeParams, index, declarativeBuild.histories(rows), ts)
+
+				if actualDispatch >= 0 {
+					branches["discharging"]++
+				} else {
+					branches["charging"]++
+				}
+				maxDev = math.Max(maxDev, assertClose(t, got[0], want[0], accumulator.partition))
+			}
+			assertBranchesExercised(t, branches, "discharging", "charging")
+			t.Logf("max deviation: %g", maxDev)
+		})
+	}
+}
+
+func TestDeclarativeEnergyBalancerAnswersTheSameClaims(t *testing.T) {
+	// The oracle is the model's own behaviour suite: every claim recomputed against the
+	// declarative build must still hold, and must hold with the same numbers the card
+	// reports — not merely point the same way.
+	if testing.Short() {
+		t.Skip("runs the full claim ensemble twice")
+	}
+	bespoke := ObservedBehaviour()
+	declarative := observedBehaviour(declarativeBuildStub)
+
+	if len(declarative) != len(bespoke) {
+		t.Fatalf("got %d claims, want %d", len(declarative), len(bespoke))
+	}
+	maxDev := 0.0
+	for i, claim := range declarative {
+		reference := bespoke[i]
+		if claim.ID != reference.ID {
+			t.Fatalf("claim %d: got ID %q, want %q", i, claim.ID, reference.ID)
+		}
+		// Still a true claim when the model is data.
+		if err := cardgen.Verify(claim); err != nil {
+			t.Errorf("claim %q does not hold for the declarative model: %v", claim.ID, err)
+			continue
+		}
+		if len(claim.Observations) != len(reference.Observations) {
+			t.Fatalf("claim %q: got %d observations, want %d",
+				claim.ID, len(claim.Observations), len(reference.Observations))
+		}
+		for k, obs := range claim.Observations {
+			maxDev = math.Max(maxDev, assertClose(t, obs.Value,
+				reference.Observations[k].Value, claim.ID+" / "+obs.Label))
 		}
 	}
-	t.Logf("branches exercised: %v", branches)
-	t.Logf("max relative deviation: %g over %d comparisons", maxDev, cases*2)
-	t.Logf("outputs differing only at ULP scale (FMA contraction): %d", ulpDiffs)
+	t.Logf("max deviation across every observation on every claim: %g", maxDev)
 }

--- a/models/floodrisk/behaviour.go
+++ b/models/floodrisk/behaviour.go
@@ -26,16 +26,23 @@ func runStub(rainfallMultiplier float64, numSteps int, seed uint64) *simulator.S
 	return store
 }
 
+// stubBuilder assembles the model, matching BuildStub's signature. The behaviour
+// helpers take one rather than calling BuildStub directly so that an alternative
+// assembly of the same model — notably the declarative one in declarative.yaml —
+// can be put through this exact claim suite instead of a re-stated copy of it.
+type stubBuilder func(rainfallMultiplier float64, numSteps int, seed uint64) *simulator.ConfigGenerator
+
 // runStubOverride runs the stub with an override hook applied to the generated
 // config before the run, so a behaviour can vary any partition's params without
 // bloating BuildStub's signature (which exposes only the rainfall multiplier).
 func runStubOverride(
+	build stubBuilder,
 	rainfallMultiplier float64,
 	numSteps int,
 	seed uint64,
 	override func(*simulator.ConfigGenerator),
 ) *simulator.StateTimeStorage {
-	gen := BuildStub(rainfallMultiplier, numSteps, seed)
+	gen := build(rainfallMultiplier, numSteps, seed)
 	if override != nil {
 		override(gen)
 	}
@@ -76,13 +83,14 @@ func meanPeakFlow(rainfallMultiplier float64, numSteps, nMembers, spinUp int) fl
 // meanPeakFlowOverride averages peak flow across an ensemble under a fixed
 // override, damping the sampling noise in a single run.
 func meanPeakFlowOverride(
+	build stubBuilder,
 	rainfallMultiplier float64,
 	numSteps, nMembers, spinUp int,
 	override func(*simulator.ConfigGenerator),
 ) float64 {
 	var sum float64
 	for m := 0; m < nMembers; m++ {
-		store := runStubOverride(rainfallMultiplier, numSteps, uint64(5000+m), override)
+		store := runStubOverride(build, rainfallMultiplier, numSteps, uint64(5000+m), override)
 		sum += peakFlow(store.GetValues("runoff"), spinUp)
 	}
 	return sum / float64(nMembers)
@@ -104,23 +112,30 @@ func setRainfallParam(gen *simulator.ConfigGenerator, key string, value float64)
 //
 // Claim IDs match the subtest names under TestFloodRiskExpectedBehaviour.
 func ObservedBehaviour() []cardgen.Claim {
+	return observedBehaviour(BuildStub)
+}
+
+// observedBehaviour computes the claims against a given assembly of the model. The
+// equivalence test runs it against the declarative build so that the data-only model
+// answers the same claims, measured the same way.
+func observedBehaviour(build stubBuilder) []cardgen.Claim {
 	const steps, nMembers, spinUp = 730, 8, 60
 	const peak = "ensemble-mean peak flow (m³/s)"
 
-	base := meanPeakFlowOverride(1.0, steps, nMembers, spinUp, nil)
+	base := meanPeakFlowOverride(build, 1.0, steps, nMembers, spinUp, nil)
 
-	rain115 := meanPeakFlowOverride(1.15, steps, nMembers, spinUp, nil)
-	rain130 := meanPeakFlowOverride(1.3, steps, nMembers, spinUp, nil)
-	persistent := meanPeakFlowOverride(1.0, steps, nMembers, spinUp, func(g *simulator.ConfigGenerator) {
+	rain115 := meanPeakFlowOverride(build, 1.15, steps, nMembers, spinUp, nil)
+	rain130 := meanPeakFlowOverride(build, 1.3, steps, nMembers, spinUp, nil)
+	persistent := meanPeakFlowOverride(build, 1.0, steps, nMembers, spinUp, func(g *simulator.ConfigGenerator) {
 		setRainfallParam(g, "p_wet_given_wet", 0.95)
 	})
-	thirsty := meanPeakFlowOverride(1.0, steps, nMembers, spinUp, func(g *simulator.ConfigGenerator) {
+	thirsty := meanPeakFlowOverride(build, 1.0, steps, nMembers, spinUp, func(g *simulator.ConfigGenerator) {
 		setRunoffParam(g, "et_rate", 5.0)
 	})
-	bigger := meanPeakFlowOverride(1.0, steps, nMembers, spinUp, func(g *simulator.ConfigGenerator) {
+	bigger := meanPeakFlowOverride(build, 1.0, steps, nMembers, spinUp, func(g *simulator.ConfigGenerator) {
 		setRunoffParam(g, "catchment_area_km2", 2.0*DefaultCatchmentAreaKm2)
 	})
-	spongy := meanPeakFlowOverride(1.0, steps, nMembers, spinUp, func(g *simulator.ConfigGenerator) {
+	spongy := meanPeakFlowOverride(build, 1.0, steps, nMembers, spinUp, func(g *simulator.ConfigGenerator) {
 		setRunoffParam(g, "field_capacity", 700.0)
 	})
 

--- a/models/floodrisk/declarative.yaml
+++ b/models/floodrisk/declarative.yaml
@@ -1,0 +1,98 @@
+# The floodrisk generative core, written entirely as data: no Go, no compilation.
+#
+# This is the same model BuildStub assembles in stub.go, with the same partition names,
+# param keys, state layout and wiring, so the two can be compared directly (see
+# expression_equivalence_test.go, which checks per-step agreement and re-runs the whole
+# behaviour suite against this file). The run knobs BuildStub takes as arguments (seed,
+# horizon, rainfall multiplier) are injected by the caller; everything below is the model.
+#
+# Wiring note: runoff reads rainfall through upstreams, not params_from_upstream. The Go
+# runoff resolves a partition *index* (params_as_partitions: upstream_partition) and then
+# reads stateHistories at that index, which is a lag-1 read of the previous step's committed
+# rainfall. upstreams is the same lag-1 state-history read, so it is the faithful
+# translation; params_from_upstream would be a within-step read and hence a different model.
+# The upstream_partition param disappears because it only ever carried the index that
+# upstreams now resolves by name.
+main:
+  partitions:
+
+  # Two-state Markov (wet/dry) chain with Gamma-distributed wet-day amounts.
+  - name: rainfall
+    params:
+      wet_day_shape: [0.609]
+      wet_day_scale: [7.944]
+      p_wet_given_dry: [0.40]
+      p_wet_given_wet: [0.83]
+      rainfall_multiplier: [1.0]
+      wet_threshold: [0.1]
+    init_state_values: [0.0]
+    state_width: 1
+    state_history_depth: 1
+    seed: 0
+
+  # PDM-style nonlinear runoff generation feeding parallel fast/slow flow stores.
+  - name: runoff
+    params:
+      field_capacity: [330.0]
+      drainage_rate: [0.03]
+      et_rate: [1.1]
+      runoff_shape: [2.7]
+      fast_recession_rate: [0.40]
+      slow_recession_rate: [0.32]
+      catchment_area_km2: [297.0]
+    init_state_values: [100.0, 0.0, 0.0, 0.0]
+    state_width: 4
+    state_history_depth: 1
+    seed: 0
+
+  expressions:
+
+  - partition: rainfall
+    fields:
+    - {name: rainfall_mm}
+    bindings:
+    # Yesterday's committed rainfall classifies yesterday as wet or dry, which selects
+    # today's transition probability.
+    - {name: p_wet, expr: "where(rainfall_mm > wet_threshold, p_wet_given_wet, p_wet_given_dry)"}
+    - {name: today_wet, expr: "shared(uniform(0, 1)) < p_wet"}
+    # The Gamma draw stays inside the output's where rather than becoming a binding:
+    # bindings are eager, and a dry day must take exactly one draw (the uniform above), as
+    # the Go code's early return does. The scalar where is lazy, so it does.
+    # The shape/scale floors at 0.01 keep the draw well-defined for degenerate params.
+    outputs:
+    - "where(today_wet,
+            max(shared(gamma(max(wet_day_shape, 0.01), 1 / max(wet_day_scale, 0.01)))
+                * rainfall_multiplier, wet_threshold),
+            0)"
+
+  - partition: runoff
+    fields:
+    - {name: soil_moisture}
+    - {name: total_flow}
+    - {name: fast_flow}
+    - {name: slow_flow}
+    upstreams:
+      rainfall_mm: rainfall
+    bindings:
+    - {name: net_rainfall, expr: "max(rainfall_mm - et_rate, 0) * dt"}
+    - {name: saturation, expr: "clamp(soil_moisture / field_capacity, 0, 1)"}
+    - {name: runoff_fraction, expr: "1 - pow(1 - saturation, runoff_shape)"}
+    - {name: direct_runoff, expr: "net_rainfall * runoff_fraction"}
+    - {name: wetted_soil, expr: "soil_moisture + (net_rainfall - direct_runoff)"}
+    # Anything the soil store cannot hold spills straight into direct runoff.
+    - {name: excess, expr: "max(wetted_soil - field_capacity, 0)"}
+    - {name: capped_soil, expr: "wetted_soil - excess"}
+    - {name: total_direct_runoff, expr: "direct_runoff + excess"}
+    # Drainage is charged against the capped store and is *not* reduced when the store is
+    # subsequently floored at zero — matching the Go order of operations.
+    - {name: drainage, expr: "drainage_rate * capped_soil * dt"}
+    - {name: mm_to_m3s, expr: "catchment_area_km2 * 1000 / (86400 * dt)"}
+    - {name: next_fast_flow, expr: "fast_recession_rate * (total_direct_runoff * mm_to_m3s)
+                                    + (1 - fast_recession_rate) * fast_flow"}
+    - {name: next_slow_flow, expr: "slow_recession_rate * (drainage * mm_to_m3s)
+                                    + (1 - slow_recession_rate) * slow_flow"}
+    outputs:
+    - "max(capped_soil - drainage, 0)"
+    - "next_fast_flow + next_slow_flow"
+    - "next_fast_flow"
+    - "next_slow_flow"

--- a/models/floodrisk/declarative.yaml
+++ b/models/floodrisk/declarative.yaml
@@ -26,7 +26,6 @@ main:
       rainfall_multiplier: [1.0]
       wet_threshold: [0.1]
     init_state_values: [0.0]
-    state_width: 1
     state_history_depth: 1
     seed: 0
 
@@ -41,7 +40,6 @@ main:
       slow_recession_rate: [0.32]
       catchment_area_km2: [297.0]
     init_state_values: [100.0, 0.0, 0.0, 0.0]
-    state_width: 4
     state_history_depth: 1
     seed: 0
 

--- a/models/floodrisk/expression_equivalence_test.go
+++ b/models/floodrisk/expression_equivalence_test.go
@@ -1,0 +1,326 @@
+package floodrisk
+
+// Does declarative.yaml — this model written as data, with no Go — reproduce the model
+// stub.go builds in code?
+//
+// Two independent checks, because they fail in different ways. The step-for-step tests
+// compare single Iterate calls over randomised inputs, which catches a mis-stated formula
+// exactly. The suite test re-runs the model's own claim computations against the
+// declarative build, which catches a model that is subtly different in a way per-step
+// agreement would not: wrong wiring, wrong param values, wrong state layout.
+//
+// The rainfall partition draws from a stream seeded exactly as the declarative one is
+// (rng.New(seed) and rand.New(rand.NewPCG(seed, seed)) are the same generator, and
+// rng.Gamma reproduces distuv.Gamma's branch structure and draw order), and both take the
+// same number of draws per step — one uniform always, one Gamma only on a wet day — so the
+// two stay in lockstep and equivalence is decidable directly rather than only in
+// distribution. Agreement is asserted to a tight tolerance rather than bit-for-bit:
+// compiled Go is free to contract a + b*c into a fused multiply-add, which rounds
+// differently from the evaluator's separate operations.
+
+import (
+	"math"
+	"math/rand/v2"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+
+	"github.com/umbralcalc/stochadex/models/cardgen"
+	"github.com/umbralcalc/stochadex/pkg/api"
+	"github.com/umbralcalc/stochadex/pkg/general"
+	"github.com/umbralcalc/stochadex/pkg/simulator"
+)
+
+// tolerance is well above FMA rounding and well below any difference a real modelling
+// discrepancy would produce.
+const tolerance = 1e-12
+
+// declarativeBuildStub assembles the model from declarative.yaml, matching BuildStub's
+// signature so it can be dropped into the behaviour helpers. The YAML holds the model; the
+// run knobs BuildStub takes as arguments are injected here, exactly as BuildStub injects
+// them into its Go partitions.
+func declarativeBuildStub(
+	rainfallMultiplier float64,
+	numSteps int,
+	seed uint64,
+) *simulator.ConfigGenerator {
+	config := api.LoadApiRunConfigFromYaml("declarative.yaml")
+	config.Main.Simulation = simulator.SimulationConfig{
+		OutputCondition: &simulator.EveryStepOutputCondition{},
+		TerminationCondition: &simulator.NumberOfStepsTerminationCondition{
+			MaxNumberOfSteps: numSteps,
+		},
+		TimestepFunction: &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+		InitTimeValue:    0.0,
+	}
+	gen := config.Main.GetConfigGenerator()
+	gen.GetPartition("rainfall").Params.Map["rainfall_multiplier"] =
+		[]float64{rainfallMultiplier}
+	gen.GetPartition("rainfall").Seed = seed
+	// runoff is deterministic, so its seed is fixed at zero exactly as BuildStub fixes it.
+	gen.GetPartition("runoff").Seed = 0
+	return gen
+}
+
+// declarativeIteration returns the expression iteration the YAML supplies for a partition,
+// alongside the params it declares.
+func declarativeIteration(
+	t *testing.T,
+	partition string,
+) (*general.ExpressionIteration, map[string][]float64) {
+	t.Helper()
+	config := declarativeBuildStub(1.0, 10, 0).GetPartition(partition)
+	iteration, ok := config.Iteration.(*general.ExpressionIteration)
+	if !ok {
+		t.Fatalf("%s is not expression-backed: got %T", partition, config.Iteration)
+	}
+	return iteration, config.Params.Map
+}
+
+// assertClose fails when two values differ by more than the FMA-scale tolerance, comparing
+// relatively once the magnitude exceeds 1.
+func assertClose(t *testing.T, got, want float64, context string) float64 {
+	t.Helper()
+	d := math.Abs(got - want)
+	if s := math.Abs(want); s > 1 {
+		d /= s
+	}
+	if d > tolerance {
+		t.Fatalf("%s: declarative=%v bespoke=%v deviation=%g", context, got, want, d)
+	}
+	return d
+}
+
+func TestDeclarativeRainfallMatchesBespoke(t *testing.T) {
+	bespoke := &StochasticRainfallIteration{}
+	declarative, _ := declarativeIteration(t, "rainfall")
+	settings := &simulator.Settings{
+		Iterations: []simulator.IterationSettings{{Name: "rainfall", Seed: 5}},
+	}
+	bespoke.Configure(0, settings)
+	declarative.Configure(0, settings)
+
+	rng := rand.New(rand.NewPCG(31, 32))
+	branches := map[string]int{}
+	maxDev := 0.0
+
+	const cases = 20000
+	for i := 0; i < cases; i++ {
+		// Previous rainfall straddles the threshold so both Markov transition rows are used,
+		// and the shape/scale floors are swept periodically so the degenerate-param clamps
+		// are compared rather than assumed. A tiny scale drives wet-day amounts under the
+		// threshold, which is what exercises the floor.
+		prevRainfall := rng.Float64() * 2.0
+		shape := 0.05 + rng.Float64()*2.0
+		if i%7 == 0 {
+			shape = rng.Float64() * 0.005
+		}
+		scale := 1.0 + rng.Float64()*11.0
+		if i%11 == 0 {
+			scale = rng.Float64() * 0.005
+		}
+		threshold := 0.05 + rng.Float64()*1.5
+		p := simulator.NewParams(map[string][]float64{
+			"wet_day_shape":       {shape},
+			"wet_day_scale":       {scale},
+			"p_wet_given_dry":     {rng.Float64()},
+			"p_wet_given_wet":     {rng.Float64()},
+			"rainfall_multiplier": {0.5 + rng.Float64()*1.5},
+			"wet_threshold":       {threshold},
+		})
+		mk := func() []*simulator.StateHistory {
+			return []*simulator.StateHistory{{
+				Values:            mat.NewDense(1, 1, []float64{prevRainfall}),
+				StateWidth:        1,
+				StateHistoryDepth: 1,
+			}}
+		}
+		ts := &simulator.CumulativeTimestepsHistory{
+			Values:            mat.NewVecDense(1, []float64{float64(i)}),
+			NextIncrement:     1.0,
+			CurrentStepNumber: i + 1,
+		}
+
+		want := bespoke.Iterate(&p, 0, mk(), ts)
+		got := declarative.Iterate(&p, 0, mk(), ts)
+
+		if prevRainfall > threshold {
+			branches["prev_wet"]++
+		} else {
+			branches["prev_dry"]++
+		}
+		if want[0] > 0 {
+			branches["today_wet"]++
+			if want[0] == threshold {
+				branches["amount_floored"]++
+			}
+		} else {
+			branches["today_dry"]++
+		}
+		if shape < 0.01 {
+			branches["shape_floored"]++
+		}
+		if scale < 0.01 {
+			branches["scale_floored"]++
+		}
+		maxDev = math.Max(maxDev, assertClose(t, got[0], want[0], "rainfall"))
+	}
+	for _, b := range []string{
+		"prev_wet", "prev_dry", "today_wet", "today_dry",
+		"amount_floored", "shape_floored", "scale_floored",
+	} {
+		if branches[b] == 0 {
+			t.Errorf("branch %q never exercised; the comparison is weaker than it looks", b)
+		}
+	}
+	t.Logf("branches exercised: %v", branches)
+	t.Logf("max deviation: %g", maxDev)
+}
+
+func TestDeclarativeRunoffMatchesBespoke(t *testing.T) {
+	bespoke := &RainfallRunoffIteration{}
+	declarative, _ := declarativeIteration(t, "runoff")
+	// runoff sits at index 1 and reads rainfall at index 0. The bespoke iteration resolves
+	// that index from its settings param; the declarative one resolves it from the partition
+	// name in the YAML's upstreams block — the two must land on the same partition.
+	settings := &simulator.Settings{
+		Iterations: []simulator.IterationSettings{
+			{Name: "rainfall", Seed: 5},
+			{
+				Name: "runoff",
+				Seed: 0,
+				Params: simulator.NewParams(map[string][]float64{
+					"upstream_partition": {0},
+				}),
+			},
+		},
+	}
+	bespoke.Configure(1, settings)
+	declarative.Configure(1, settings)
+
+	rng := rand.New(rand.NewPCG(41, 42))
+	branches := map[string]int{}
+	maxDev := 0.0
+
+	const cases = 20000
+	for i := 0; i < cases; i++ {
+		// Soil moisture ranges below zero and well past any field capacity drawn here, so
+		// both ends of the saturation clamp, the spill over field capacity, and the
+		// zero-floor on the drained store all trigger. Evapotranspiration overlaps the
+		// rainfall range so the net-rainfall clip triggers too.
+		fieldCapacity := 200.0 + rng.Float64()*300.0
+		soilMoisture := rng.Float64()*600.0 - 60.0
+		rainfall := rng.Float64() * 40.0
+		etRate := rng.Float64() * 10.0
+		dt := 0.5 + rng.Float64()
+		p := simulator.NewParams(map[string][]float64{
+			"field_capacity":      {fieldCapacity},
+			"drainage_rate":       {rng.Float64() * 0.1},
+			"et_rate":             {etRate},
+			"runoff_shape":        {0.5 + rng.Float64()*4.0},
+			"fast_recession_rate": {rng.Float64()},
+			"slow_recession_rate": {rng.Float64()},
+			"catchment_area_km2":  {50.0 + rng.Float64()*500.0},
+		})
+		state := []float64{
+			soilMoisture,
+			0.0,
+			rng.Float64() * 50.0,
+			rng.Float64() * 50.0,
+		}
+		mk := func() []*simulator.StateHistory {
+			return []*simulator.StateHistory{
+				{
+					Values:            mat.NewDense(1, 1, []float64{rainfall}),
+					StateWidth:        1,
+					StateHistoryDepth: 1,
+				},
+				{
+					Values:            mat.NewDense(1, 4, append([]float64{}, state...)),
+					StateWidth:        4,
+					StateHistoryDepth: 1,
+				},
+			}
+		}
+		ts := &simulator.CumulativeTimestepsHistory{
+			Values:            mat.NewVecDense(1, []float64{float64(i)}),
+			NextIncrement:     dt,
+			CurrentStepNumber: i + 1,
+		}
+
+		want := bespoke.Iterate(&p, 1, mk(), ts)
+		got := declarative.Iterate(&p, 1, mk(), ts)
+
+		if rainfall > etRate {
+			branches["net_rain_positive"]++
+		} else {
+			branches["net_rain_clipped"]++
+		}
+		switch {
+		case soilMoisture < 0:
+			branches["saturation_clamped_low"]++
+		case soilMoisture > fieldCapacity:
+			branches["saturation_clamped_high"]++
+		default:
+			branches["saturation_interior"]++
+		}
+		if soilMoisture+math.Max(rainfall-etRate, 0.0)*dt > fieldCapacity {
+			branches["spilled_excess"]++
+		} else {
+			branches["no_excess"]++
+		}
+		if want[0] == 0 && soilMoisture < 0 {
+			branches["soil_floored_at_zero"]++
+		}
+		for k := range want {
+			maxDev = math.Max(maxDev, assertClose(t, got[k], want[k], "runoff state"))
+		}
+	}
+	for _, b := range []string{
+		"net_rain_positive", "net_rain_clipped",
+		"saturation_clamped_low", "saturation_clamped_high", "saturation_interior",
+		"spilled_excess", "no_excess", "soil_floored_at_zero",
+	} {
+		if branches[b] == 0 {
+			t.Errorf("branch %q never exercised; the comparison is weaker than it looks", b)
+		}
+	}
+	t.Logf("branches exercised: %v", branches)
+	t.Logf("max deviation: %g", maxDev)
+}
+
+func TestDeclarativeFloodRiskAnswersTheSameClaims(t *testing.T) {
+	// The oracle is the model's own behaviour suite: every claim recomputed against the
+	// declarative build must still hold, and must hold with the same numbers the card
+	// reports — not merely point the same way.
+	if testing.Short() {
+		t.Skip("runs the full claim ensemble twice")
+	}
+	bespoke := ObservedBehaviour()
+	declarative := observedBehaviour(declarativeBuildStub)
+
+	if len(declarative) != len(bespoke) {
+		t.Fatalf("got %d claims, want %d", len(declarative), len(bespoke))
+	}
+	maxDev := 0.0
+	for i, claim := range declarative {
+		reference := bespoke[i]
+		if claim.ID != reference.ID {
+			t.Fatalf("claim %d: got ID %q, want %q", i, claim.ID, reference.ID)
+		}
+		// Still a true claim when the model is data.
+		if err := cardgen.Verify(claim); err != nil {
+			t.Errorf("claim %q does not hold for the declarative model: %v", claim.ID, err)
+			continue
+		}
+		if len(claim.Observations) != len(reference.Observations) {
+			t.Fatalf("claim %q: got %d observations, want %d",
+				claim.ID, len(claim.Observations), len(reference.Observations))
+		}
+		for k, obs := range claim.Observations {
+			maxDev = math.Max(maxDev, assertClose(t, obs.Value,
+				reference.Observations[k].Value, claim.ID+" / "+obs.Label))
+		}
+	}
+	t.Logf("max deviation across every observation on every claim: %g", maxDev)
+}

--- a/models/homark/behaviour.go
+++ b/models/homark/behaviour.go
@@ -13,17 +13,24 @@ import (
 // computation here — not in a _test.go file — is what lets the card show exactly
 // the numbers the test checks, so the two can never disagree.
 
+// stubBuilder assembles the model, matching BuildStub's signature. The behaviour
+// helpers take one rather than calling BuildStub directly so that an alternative
+// assembly of the same model — notably the declarative one in declarative.yaml —
+// can be put through this exact claim suite instead of a re-stated copy of it.
+type stubBuilder func(approvalRate float64, numSteps int, seed uint64) *simulator.ConfigGenerator
+
 // runStubOverride runs the stub with an override hook applied to the generated
 // config before the run, so a behaviour can vary any partition's params
 // (approvals, thresholds, coefficients, rates) without bloating BuildStub's
 // signature — BuildStub still exposes only the one headline driver.
 func runStubOverride(
+	build stubBuilder,
 	approvalRate float64,
 	numSteps int,
 	seed uint64,
 	override func(*simulator.ConfigGenerator),
 ) *simulator.StateTimeStorage {
-	gen := BuildStub(approvalRate, numSteps, seed)
+	gen := build(approvalRate, numSteps, seed)
 	if override != nil {
 		override(gen)
 	}
@@ -52,13 +59,14 @@ func finalAffordability(store *simulator.StateTimeStorage) float64 {
 // meanFinalAff ensemble-averages the final price-to-earnings ratio over nMembers
 // seeds under a fixed approval rate and override, damping single-run noise.
 func meanFinalAff(
+	build stubBuilder,
 	approvalRate float64,
 	numSteps, nMembers int,
 	override func(*simulator.ConfigGenerator),
 ) float64 {
 	var sum float64
 	for m := 0; m < nMembers; m++ {
-		store := runStubOverride(approvalRate, numSteps, uint64(3000+m), override)
+		store := runStubOverride(build, approvalRate, numSteps, uint64(3000+m), override)
 		sum += finalAffordability(store)
 	}
 	return sum / float64(nMembers)
@@ -67,6 +75,7 @@ func meanFinalAff(
 // meanPipelineStock ensemble-averages the pipeline stock over every step and
 // nMembers seeds — the cleanest summary of how full the supply pipeline runs.
 func meanPipelineStock(
+	build stubBuilder,
 	approvalRate float64,
 	numSteps, nMembers int,
 	override func(*simulator.ConfigGenerator),
@@ -74,7 +83,7 @@ func meanPipelineStock(
 	var sum float64
 	var count int
 	for m := 0; m < nMembers; m++ {
-		store := runStubOverride(approvalRate, numSteps, uint64(3000+m), override)
+		store := runStubOverride(build, approvalRate, numSteps, uint64(3000+m), override)
 		for _, row := range store.GetValues("pipeline") {
 			sum += row[0]
 			count++
@@ -92,39 +101,46 @@ func meanPipelineStock(
 //
 // The claim IDs match the subtest names under TestHomarkExpectedBehaviour.
 func ObservedBehaviour() []cardgen.Claim {
+	return observedBehaviour(BuildStub)
+}
+
+// observedBehaviour computes the claims against a given assembly of the model. The
+// equivalence test runs it against the declarative build so that the data-only model
+// answers the same claims, measured the same way.
+func observedBehaviour(build stubBuilder) []cardgen.Claim {
 	const steps, nMembers = DefaultNumSteps, 8
 	const pe = "ensemble-mean final price-to-earnings ratio"
 
 	// Shared baseline at the default approval rate, reused across the structural
 	// claims that perturb one input against it (avoids recomputing the same base).
-	base := meanFinalAff(DefaultApprovalRate, steps, nMembers, nil)
+	base := meanFinalAff(build, DefaultApprovalRate, steps, nMembers, nil)
 
 	// Actionable supply lever: raising planning approvals from 60 to 240 units/month.
-	lowApprovals := meanFinalAff(60.0, steps, nMembers, nil)
-	highApprovals := meanFinalAff(240.0, steps, nMembers, nil)
+	lowApprovals := meanFinalAff(build, 60.0, steps, nMembers, nil)
+	highApprovals := meanFinalAff(build, 240.0, steps, nMembers, nil)
 
 	// Actionable tenure lever: cutting the market-facing delivery fraction.
-	fullMarket := meanFinalAff(DefaultApprovalRate, steps, nMembers, func(g *simulator.ConfigGenerator) {
+	fullMarket := meanFinalAff(build, DefaultApprovalRate, steps, nMembers, func(g *simulator.ConfigGenerator) {
 		setParam(g, "price_drift", "market_fraction", 1.0)
 	})
-	reducedMarket := meanFinalAff(DefaultApprovalRate, steps, nMembers, func(g *simulator.ConfigGenerator) {
+	reducedMarket := meanFinalAff(build, DefaultApprovalRate, steps, nMembers, func(g *simulator.ConfigGenerator) {
 		setParam(g, "price_drift", "market_fraction", 0.3)
 	})
 
 	// Structural drivers.
-	hikedRate := meanFinalAff(DefaultApprovalRate, steps, nMembers, func(g *simulator.ConfigGenerator) {
+	hikedRate := meanFinalAff(build, DefaultApprovalRate, steps, nMembers, func(g *simulator.ConfigGenerator) {
 		setParam(g, "bank_rate", "mus", 6.0)
 	})
-	coupledDemand := meanFinalAff(DefaultApprovalRate, steps, nMembers, func(g *simulator.ConfigGenerator) {
+	coupledDemand := meanFinalAff(build, DefaultApprovalRate, steps, nMembers, func(g *simulator.ConfigGenerator) {
 		setParam(g, "price_drift", "demand_beta", 0.03)
 	})
-	fastEarnings := meanFinalAff(DefaultApprovalRate, steps, nMembers, func(g *simulator.ConfigGenerator) {
+	fastEarnings := meanFinalAff(build, DefaultApprovalRate, steps, nMembers, func(g *simulator.ConfigGenerator) {
 		setParam(g, "log_earnings", "drift_coefficients", 0.006)
 	})
 
 	// Pipeline throughput invariant (mean standing stock, not affordability).
-	basePipeline := meanPipelineStock(DefaultApprovalRate, steps, nMembers, nil)
-	fasterPipeline := meanPipelineStock(DefaultApprovalRate, steps, nMembers, func(g *simulator.ConfigGenerator) {
+	basePipeline := meanPipelineStock(build, DefaultApprovalRate, steps, nMembers, nil)
+	fasterPipeline := meanPipelineStock(build, DefaultApprovalRate, steps, nMembers, func(g *simulator.ConfigGenerator) {
 		setParam(g, "pipeline", "completion_rate", 0.30)
 	})
 

--- a/models/homark/declarative.yaml
+++ b/models/homark/declarative.yaml
@@ -1,0 +1,147 @@
+# The homark generative core, written entirely as data: no Go, no compilation.
+#
+# This is the same model BuildStub assembles in stub.go, with the same partition names,
+# param keys and wiring, so the two can be compared directly (see
+# expression_equivalence_test.go, which checks per-step agreement and re-runs the whole
+# behaviour suite against this file). The run knobs BuildStub takes as arguments (approval
+# rate, horizon, seed) are injected by the caller; everything below is the model.
+#
+# Partitions are declared in BuildStub's order, because the Go price_drift partition reads
+# its inputs by hardcoded index (bankRatePartition, pipelinePartition, logEarningsPartition)
+# and the two builds must agree on what those indices name.
+#
+# Two things the Go code carries as constants appear here as data instead. The partition
+# index constants above become named upstream aliases, which is what an expression reads a
+# state history by. And init_log_earnings — baked into the HousingPriceDriftFunction closure
+# in Go — becomes a param on price_drift, since the demand channel measures earnings against
+# it; it is log(DefaultInitEarnings), the same value BuildStub passes to the closure.
+main:
+  partitions:
+
+  # Mean-reverting policy rate (data-free stand-in for a BoE bank-rate replay), stepped by
+  # the same Euler-Maruyama update as continuous.OrnsteinUhlenbeckIteration.
+  - name: bank_rate
+    params:
+      thetas: [0.1]
+      mus: [3.0]
+      sigmas: [0.3]
+    init_state_values: [3.0]
+    state_width: 1
+    state_history_depth: 1
+    seed: 0
+
+  # Planning-supply stock: per-unit binomial completions, then binomial attrition on what
+  # survives them, then the approval inflow.
+  - name: pipeline
+    params:
+      completion_rate: [0.15]
+      attrition_rate: [0.02]
+      approval_rate: [100.0]
+    init_state_values: [400.0]
+    state_width: 1
+    state_history_depth: 1
+    seed: 1
+
+  # Reduced-form log-price drift: baseline + mortgage-cost + supply (+ demand) channels.
+  # Its three inputs are lag-1 state-history reads in the Go model too, so upstreams — which
+  # is exactly that read — is the faithful wiring here, not params_from_upstream.
+  - name: price_drift
+    params:
+      drift_base: [0.004]
+      bank_beta: [-0.02]
+      pipeline_beta: [0.002]
+      pipeline_ref: [1000.0]
+      market_fraction: [1.0]
+      demand_beta: [0.0]
+      init_log_earnings: [10.308952660644293]
+    init_state_values: [0.0025999999999999999]
+    state_width: 1
+    state_history_depth: 1
+    seed: 0
+
+  - name: log_earnings
+    params:
+      drift_coefficients: [0.0025]
+      diffusion_coefficients: [0.003]
+    init_state_values: [10.308952660644293]
+    state_width: 1
+    state_history_depth: 1
+    seed: 2
+
+  # Drift is supplied within-step by price_drift, so this is params_from_upstream and not an
+  # upstream alias: the drift must be this step's, not the previous step's.
+  - name: log_price
+    params:
+      diffusion_coefficients: [0.010]
+    params_from_upstream:
+      drift_coefficients:
+        upstream: price_drift
+    init_state_values: [12.388394202324129]
+    state_width: 1
+    state_history_depth: 1
+    seed: 3
+
+  - name: affordability
+    params: {}
+    init_state_values: [8.0000000000000018]
+    state_width: 1
+    state_history_depth: 1
+    seed: 0
+
+  expressions:
+
+  - partition: bank_rate
+    fields:
+    - {name: rate}
+    outputs:
+    - "rate + (thetas * (mus - rate) * dt + sigmas * sqrt(dt) * shared(normal(0, 1)))"
+
+  - partition: pipeline
+    fields:
+    - {name: pipeline_stock}
+    bindings:
+    # Only whole units can complete or lapse, and a negative stock offers none.
+    - {name: n, expr: "max(floor(pipeline_stock), 0)"}
+    # Both guards are scalar, so the untaken branch draws nothing and the two builds stay in
+    # step on the same stream.
+    - {name: completions,
+       expr: "where(n > 0 && completion_rate > 0, shared(binomial(n, completion_rate)), 0)"}
+    - {name: remaining, expr: "n - completions"}
+    - {name: attritions,
+       expr: "where(remaining > 0 && attrition_rate > 0, shared(binomial(remaining, attrition_rate)), 0)"}
+    outputs: ["max(pipeline_stock - completions - attritions + approval_rate, 0)"]
+
+  - partition: price_drift
+    fields:
+    - {name: drift}
+    upstreams:
+      bank: bank_rate
+      pipe: pipeline
+      earnings: log_earnings
+    bindings:
+    # A non-positive reference stock would divide the supply channel by zero, so it falls
+    # back to one — the pipeline stock then reads as an absolute unit count.
+    - {name: ref, expr: "where(pipeline_ref <= 0, 1, pipeline_ref)"}
+    - {name: cost, expr: "drift_base + bank_beta * (bank / 100.0)"}
+    - {name: supply, expr: "cost - pipeline_beta * (market_fraction * pipe / ref)"}
+    outputs: ["supply + demand_beta * (earnings - init_log_earnings)"]
+
+  - partition: log_earnings
+    fields:
+    - {name: log_earnings}
+    outputs:
+    - "log_earnings + (drift_coefficients * dt + diffusion_coefficients * sqrt(dt) * shared(normal(0, 1)))"
+
+  - partition: log_price
+    fields:
+    - {name: log_price}
+    outputs:
+    - "log_price + (drift_coefficients * dt + diffusion_coefficients * sqrt(dt) * shared(normal(0, 1)))"
+
+  - partition: affordability
+    fields:
+    - {name: ratio}
+    upstreams:
+      log_price: log_price
+      log_earnings: log_earnings
+    outputs: ["exp(log_price - log_earnings)"]

--- a/models/homark/declarative.yaml
+++ b/models/homark/declarative.yaml
@@ -26,7 +26,6 @@ main:
       mus: [3.0]
       sigmas: [0.3]
     init_state_values: [3.0]
-    state_width: 1
     state_history_depth: 1
     seed: 0
 
@@ -38,7 +37,6 @@ main:
       attrition_rate: [0.02]
       approval_rate: [100.0]
     init_state_values: [400.0]
-    state_width: 1
     state_history_depth: 1
     seed: 1
 
@@ -55,7 +53,6 @@ main:
       demand_beta: [0.0]
       init_log_earnings: [10.308952660644293]
     init_state_values: [0.0025999999999999999]
-    state_width: 1
     state_history_depth: 1
     seed: 0
 
@@ -64,7 +61,6 @@ main:
       drift_coefficients: [0.0025]
       diffusion_coefficients: [0.003]
     init_state_values: [10.308952660644293]
-    state_width: 1
     state_history_depth: 1
     seed: 2
 
@@ -77,14 +73,12 @@ main:
       drift_coefficients:
         upstream: price_drift
     init_state_values: [12.388394202324129]
-    state_width: 1
     state_history_depth: 1
     seed: 3
 
   - name: affordability
     params: {}
     init_state_values: [8.0000000000000018]
-    state_width: 1
     state_history_depth: 1
     seed: 0
 

--- a/models/homark/expression_equivalence_test.go
+++ b/models/homark/expression_equivalence_test.go
@@ -116,10 +116,17 @@ func singleHistory(values []float64) []*simulator.StateHistory {
 	return histories
 }
 
+// stepTimesteps varies the increment rather than pinning it at the model's own
+// stepSizeMonths of 1. At dt = 1 every dt and sqrt(dt) factor is a no-op, so a twin that
+// dropped one would agree anyway and this comparison would assert less than it looks like it
+// does — verified by mutation: deleting dt from the bank-rate update passes at a fixed dt of
+// 1 and fails here. The cycle covers dt below, at and above 1, since sqrt(dt) moves the
+// opposite way either side of it.
 func stepTimesteps(i int) *simulator.CumulativeTimestepsHistory {
+	dt := []float64{stepSizeMonths, 0.25, 2.5, 0.75}[i%4]
 	return &simulator.CumulativeTimestepsHistory{
-		Values:            mat.NewVecDense(1, []float64{float64(i) * stepSizeMonths}),
-		NextIncrement:     stepSizeMonths,
+		Values:            mat.NewVecDense(1, []float64{float64(i) * dt}),
+		NextIncrement:     dt,
 		CurrentStepNumber: i + 1,
 	}
 }

--- a/models/homark/expression_equivalence_test.go
+++ b/models/homark/expression_equivalence_test.go
@@ -1,0 +1,438 @@
+package homark
+
+// Does declarative.yaml — this model written as data, with no Go — reproduce the model
+// stub.go builds in code?
+//
+// Two independent checks, because they fail in different ways. The step-for-step tests
+// compare single Iterate calls over randomised inputs, which catches a mis-stated formula
+// exactly. The suite test re-runs the model's own claim computations against the
+// declarative build, which catches a model that is subtly different in a way per-step
+// agreement would not: wrong wiring, wrong param values, wrong state layout.
+//
+// Every iteration here draws from a stream seeded exactly as the declarative one is:
+// rng.New(seed) is rand.New(rand.NewPCG(seed, seed)), the generator the bespoke iterations
+// build directly, and the pipeline's binomial reaches the same PCG either way — distuv wraps
+// whatever source it is handed in a rand.Rand, and that wrapper only forwards Uint64. Both
+// builds then take the same number of draws per step in the same order, so the two stay in
+// lockstep and equivalence is decidable directly rather than only in distribution.
+// Agreement is asserted to a tight tolerance rather than bit-for-bit: compiled Go is free to
+// contract a + b*c into a fused multiply-add, which rounds differently from the evaluator's
+// separate operations.
+
+import (
+	"math"
+	"math/rand/v2"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+
+	"github.com/umbralcalc/stochadex/models/cardgen"
+	"github.com/umbralcalc/stochadex/pkg/api"
+	"github.com/umbralcalc/stochadex/pkg/continuous"
+	"github.com/umbralcalc/stochadex/pkg/general"
+	"github.com/umbralcalc/stochadex/pkg/simulator"
+)
+
+// tolerance is well above FMA rounding and well below any difference a real modelling
+// discrepancy would produce.
+const tolerance = 1e-12
+
+// partitionNames is the model's partition order. It is load-bearing twice over: the Go
+// price_drift function reads its inputs by the index constants in stub.go, and the
+// declarative upstream aliases resolve through these names, so the two only agree while the
+// order does.
+var partitionNames = []string{
+	"bank_rate", "pipeline", "price_drift", "log_earnings", "log_price", "affordability",
+}
+
+// declarativeBuildStub assembles the model from declarative.yaml, matching BuildStub's
+// signature so it can be dropped into the behaviour helpers. The YAML holds the model; the
+// run knobs BuildStub takes as arguments are injected here, exactly as BuildStub injects
+// them into its Go partitions.
+func declarativeBuildStub(
+	approvalRate float64,
+	numSteps int,
+	seed uint64,
+) *simulator.ConfigGenerator {
+	config := api.LoadApiRunConfigFromYaml("declarative.yaml")
+	config.Main.Simulation = simulator.SimulationConfig{
+		OutputCondition: &simulator.EveryStepOutputCondition{},
+		TerminationCondition: &simulator.NumberOfStepsTerminationCondition{
+			MaxNumberOfSteps: numSteps,
+		},
+		TimestepFunction: &simulator.ConstantTimestepFunction{Stepsize: stepSizeMonths},
+		InitTimeValue:    0.0,
+	}
+	gen := config.Main.GetConfigGenerator()
+	gen.GetPartition("pipeline").Params.Map["approval_rate"] = []float64{approvalRate}
+	gen.GetPartition("bank_rate").Seed = seed
+	gen.GetPartition("pipeline").Seed = seed + 1
+	gen.GetPartition("log_earnings").Seed = seed + 2
+	gen.GetPartition("log_price").Seed = seed + 3
+	return gen
+}
+
+// declarativeIteration returns the expression iteration the YAML supplies for a partition,
+// alongside the params it declares.
+func declarativeIteration(
+	t *testing.T,
+	partition string,
+) (*general.ExpressionIteration, map[string][]float64) {
+	t.Helper()
+	config := declarativeBuildStub(DefaultApprovalRate, 10, 0).GetPartition(partition)
+	iteration, ok := config.Iteration.(*general.ExpressionIteration)
+	if !ok {
+		t.Fatalf("%s is not expression-backed: got %T", partition, config.Iteration)
+	}
+	return iteration, config.Params.Map
+}
+
+// modelSettings names every partition in the model's order at a fixed seed, which is what
+// lets the declarative price_drift and affordability resolve their upstream aliases to the
+// indices the Go build hardcodes.
+func modelSettings(seed uint64) *simulator.Settings {
+	iterations := make([]simulator.IterationSettings, len(partitionNames))
+	for i, name := range partitionNames {
+		iterations[i] = simulator.IterationSettings{
+			Name:   name,
+			Seed:   seed,
+			Params: simulator.NewParams(map[string][]float64{}),
+		}
+	}
+	return &simulator.Settings{Iterations: iterations}
+}
+
+// singleHistory builds a one-row state history per partition from the given scalar values,
+// so both builds read identical inputs from identical structures.
+func singleHistory(values []float64) []*simulator.StateHistory {
+	histories := make([]*simulator.StateHistory, len(values))
+	for i, v := range values {
+		histories[i] = &simulator.StateHistory{
+			Values:            mat.NewDense(1, 1, []float64{v}),
+			StateWidth:        1,
+			StateHistoryDepth: 1,
+		}
+	}
+	return histories
+}
+
+func stepTimesteps(i int) *simulator.CumulativeTimestepsHistory {
+	return &simulator.CumulativeTimestepsHistory{
+		Values:            mat.NewVecDense(1, []float64{float64(i) * stepSizeMonths}),
+		NextIncrement:     stepSizeMonths,
+		CurrentStepNumber: i + 1,
+	}
+}
+
+// assertClose fails when two values differ by more than the FMA-scale tolerance, comparing
+// relatively once the magnitude exceeds 1.
+func assertClose(t *testing.T, got, want float64, context string) float64 {
+	t.Helper()
+	d := math.Abs(got - want)
+	if s := math.Abs(want); s > 1 {
+		d /= s
+	}
+	if d > tolerance {
+		t.Fatalf("%s: declarative=%v bespoke=%v deviation=%g", context, got, want, d)
+	}
+	return d
+}
+
+// requireBranches fails when a branch was never reached: an untriggered branch means the
+// step-for-step comparison never covered it, so it is weaker than the case count suggests.
+func requireBranches(t *testing.T, branches map[string]int, names ...string) {
+	t.Helper()
+	for _, name := range names {
+		if branches[name] == 0 {
+			t.Errorf("branch %q never exercised; the comparison is weaker than it looks", name)
+		}
+	}
+	t.Logf("branches exercised: %v", branches)
+}
+
+func TestDeclarativeBankRateMatchesBespoke(t *testing.T) {
+	bespoke := &continuous.OrnsteinUhlenbeckIteration{}
+	declarative, _ := declarativeIteration(t, "bank_rate")
+	settings := modelSettings(5)
+	bespoke.Configure(0, settings)
+	declarative.Configure(0, settings)
+
+	rng := rand.New(rand.NewPCG(11, 12))
+	maxDev := 0.0
+
+	const cases = 20000
+	for i := 0; i < cases; i++ {
+		p := simulator.NewParams(map[string][]float64{
+			"thetas": {rng.Float64() * 0.4},
+			"mus":    {rng.Float64() * 8},
+			"sigmas": {rng.Float64() * 0.6},
+		})
+		state := []float64{rng.Float64()*10 - 2}
+		ts := stepTimesteps(i)
+
+		want := bespoke.Iterate(&p, 0, singleHistory(state), ts)
+		got := declarative.Iterate(&p, 0, singleHistory(state), ts)
+		maxDev = math.Max(maxDev, assertClose(t, got[0], want[0], "bank rate"))
+	}
+	t.Logf("max deviation: %g", maxDev)
+}
+
+func TestDeclarativePipelineMatchesBespoke(t *testing.T) {
+	bespoke := &StochasticPipelineIteration{}
+	declarative, _ := declarativeIteration(t, "pipeline")
+	settings := modelSettings(5)
+	bespoke.Configure(1, settings)
+	declarative.Configure(1, settings)
+
+	rng := rand.New(rand.NewPCG(21, 22))
+	branches := map[string]int{}
+	maxDev := 0.0
+
+	const cases = 18000
+	for i := 0; i < cases; i++ {
+		// Nine input regimes, each chosen so the branch it targets is reached for a reason
+		// the test can state rather than hope for.
+		var stock, completionRate, attritionRate, approvalRate float64
+		mode := i % 9
+		completionRate = 0.15
+		attritionRate = 0.02
+		approvalRate = rng.Float64() * 150
+		switch mode {
+		case 0, 1, 2, 3:
+			// A stock of at least 200 units at a 0.15 completion rate cannot complete every
+			// unit, so remaining is positive and the attrition draw always follows the
+			// completion draw — which is the ordering the two streams have to agree on.
+			stock = 200 + rng.Float64()*400
+		case 4:
+			stock = 200 + rng.Float64()*400
+			completionRate = 0
+		case 5:
+			stock = 200 + rng.Float64()*400
+			attritionRate = 0
+		case 6:
+			// Negative stock: floor is clamped to zero, neither draw happens, and a small
+			// inflow leaves the new stock negative and clamped too.
+			stock = -rng.Float64() * 40
+			approvalRate = rng.Float64() * 5
+		case 7:
+			stock = rng.Float64()
+		case 8:
+			// Under 25 units distuv switches from rejection to the direct method; both
+			// builds go through the same distuv call, but the regime is worth covering.
+			stock = 1 + rng.Float64()*23
+		}
+		p := simulator.NewParams(map[string][]float64{
+			"completion_rate": {completionRate},
+			"attrition_rate":  {attritionRate},
+			"approval_rate":   {approvalRate},
+		})
+		ts := stepTimesteps(i)
+
+		want := bespoke.Iterate(&p, 1, singleHistory([]float64{0, stock}), ts)
+		got := declarative.Iterate(&p, 1, singleHistory([]float64{0, stock}), ts)
+
+		n := math.Floor(stock)
+		if n < 0 {
+			branches["n_clamped_negative_stock"]++
+			n = 0
+		}
+		switch {
+		case n == 0:
+			branches["completions_skipped_empty_pipeline"]++
+			branches["attritions_skipped_empty_remaining"]++
+		case completionRate == 0:
+			branches["completions_skipped_zero_rate"]++
+			// No unit completed, so remaining is the whole stock and attrition draws.
+			branches["attritions_drawn"]++
+		default:
+			branches["completions_drawn"]++
+			if attritionRate == 0 {
+				branches["attritions_skipped_zero_rate"]++
+			} else if mode != 8 {
+				branches["attritions_drawn"]++
+			}
+		}
+		if want[0] == 0 {
+			branches["stock_clamped_at_zero"]++
+		}
+		maxDev = math.Max(maxDev, assertClose(t, got[0], want[0], "pipeline stock"))
+	}
+	requireBranches(t, branches,
+		"n_clamped_negative_stock",
+		"completions_drawn",
+		"completions_skipped_zero_rate",
+		"completions_skipped_empty_pipeline",
+		"attritions_drawn",
+		"attritions_skipped_zero_rate",
+		"attritions_skipped_empty_remaining",
+		"stock_clamped_at_zero",
+	)
+	t.Logf("max deviation: %g", maxDev)
+}
+
+func TestDeclarativePriceDriftMatchesBespoke(t *testing.T) {
+	initLogEarnings := math.Log(DefaultInitEarnings)
+	bespoke := &general.ValuesFunctionIteration{
+		Function: HousingPriceDriftFunction(
+			bankRatePartition, pipelinePartition, logEarningsPartition, initLogEarnings,
+		),
+	}
+	declarative, params := declarativeIteration(t, "price_drift")
+	settings := modelSettings(5)
+	bespoke.Configure(priceDriftPartition, settings)
+	declarative.Configure(priceDriftPartition, settings)
+
+	// The Go closure bakes initLogEarnings in; the YAML states it as a param, so the two
+	// only agree while they carry the same number.
+	if got := params["init_log_earnings"][0]; got != initLogEarnings {
+		t.Fatalf("init_log_earnings: yaml=%v, closure=%v", got, initLogEarnings)
+	}
+
+	rng := rand.New(rand.NewPCG(31, 32))
+	branches := map[string]int{}
+	maxDev := 0.0
+
+	const cases = 20000
+	for i := 0; i < cases; i++ {
+		// A non-positive reference stock is rare in practice but is a live branch, so a
+		// fifth of the cases sweep it — including exactly zero, which is the boundary.
+		pipelineRef := 200 + rng.Float64()*2000
+		if i%5 == 0 {
+			pipelineRef = -rng.Float64() * 500
+		}
+		p := simulator.NewParams(map[string][]float64{
+			"drift_base":        {rng.Float64() * 0.01},
+			"bank_beta":         {-rng.Float64() * 0.05},
+			"pipeline_beta":     {rng.Float64() * 0.005},
+			"pipeline_ref":      {pipelineRef},
+			"market_fraction":   {rng.Float64()},
+			"demand_beta":       {rng.Float64() * 0.05},
+			"init_log_earnings": {initLogEarnings},
+		})
+		state := []float64{
+			rng.Float64() * 8,                     // bank_rate
+			rng.Float64() * 900,                   // pipeline
+			0,                                     // price_drift (its own state, unread)
+			initLogEarnings + rng.Float64() - 0.5, // log_earnings
+		}
+		ts := stepTimesteps(i)
+
+		want := bespoke.Iterate(&p, priceDriftPartition, singleHistory(state), ts)
+		got := declarative.Iterate(&p, priceDriftPartition, singleHistory(state), ts)
+
+		if pipelineRef <= 0 {
+			branches["pipeline_ref_fallback"]++
+		} else {
+			branches["pipeline_ref_used"]++
+		}
+		maxDev = math.Max(maxDev, assertClose(t, got[0], want[0], "price drift"))
+	}
+	requireBranches(t, branches, "pipeline_ref_fallback", "pipeline_ref_used")
+	t.Logf("max deviation: %g", maxDev)
+}
+
+func TestDeclarativeDriftDiffusionPartitionsMatchBespoke(t *testing.T) {
+	// log_earnings and log_price share an update; log_price differs only in taking its drift
+	// from price_drift within-step, which the run-level suite test covers.
+	for _, partition := range []string{"log_earnings", "log_price"} {
+		t.Run(partition, func(t *testing.T) {
+			index := logEarningsPartition
+			if partition == "log_price" {
+				index = logPricePartition
+			}
+			bespoke := &continuous.DriftDiffusionIteration{}
+			declarative, _ := declarativeIteration(t, partition)
+			settings := modelSettings(5)
+			bespoke.Configure(index, settings)
+			declarative.Configure(index, settings)
+
+			rng := rand.New(rand.NewPCG(41, 42))
+			maxDev := 0.0
+
+			const cases = 20000
+			for i := 0; i < cases; i++ {
+				p := simulator.NewParams(map[string][]float64{
+					"drift_coefficients":     {rng.Float64()*0.02 - 0.01},
+					"diffusion_coefficients": {rng.Float64() * 0.05},
+				})
+				state := make([]float64, len(partitionNames))
+				state[index] = 8 + rng.Float64()*6
+				ts := stepTimesteps(i)
+
+				want := bespoke.Iterate(&p, index, singleHistory(state), ts)
+				got := declarative.Iterate(&p, index, singleHistory(state), ts)
+				maxDev = math.Max(maxDev, assertClose(t, got[0], want[0], partition))
+			}
+			t.Logf("max deviation: %g", maxDev)
+		})
+	}
+}
+
+func TestDeclarativeAffordabilityMatchesBespoke(t *testing.T) {
+	bespoke := &AffordabilityFromLogsIteration{}
+	declarative, _ := declarativeIteration(t, "affordability")
+	settings := modelSettings(5)
+	// The Go iteration resolves its two inputs from partition-index params; the declarative
+	// one resolves the same two by name, which is why the YAML carries no index at all.
+	settings.Iterations[affordabilityPartition].Params = simulator.NewParams(
+		map[string][]float64{
+			"log_price_partition":    {float64(logPricePartition)},
+			"log_earnings_partition": {float64(logEarningsPartition)},
+		},
+	)
+	bespoke.Configure(affordabilityPartition, settings)
+	declarative.Configure(affordabilityPartition, settings)
+
+	rng := rand.New(rand.NewPCG(51, 52))
+	maxDev := 0.0
+
+	const cases = 20000
+	for i := 0; i < cases; i++ {
+		p := simulator.NewParams(map[string][]float64{})
+		state := make([]float64, len(partitionNames))
+		state[logEarningsPartition] = math.Log(DefaultInitEarnings) + rng.Float64() - 0.5
+		state[logPricePartition] = math.Log(DefaultInitPrice) + rng.Float64()*2 - 1
+		ts := stepTimesteps(i)
+
+		want := bespoke.Iterate(&p, affordabilityPartition, singleHistory(state), ts)
+		got := declarative.Iterate(&p, affordabilityPartition, singleHistory(state), ts)
+		maxDev = math.Max(maxDev, assertClose(t, got[0], want[0], "affordability"))
+	}
+	t.Logf("max deviation: %g", maxDev)
+}
+
+func TestDeclarativeHomarkAnswersTheSameClaims(t *testing.T) {
+	// The oracle is the model's own behaviour suite: every claim recomputed against the
+	// declarative build must still hold, and must hold with the same numbers the card
+	// reports — not merely point the same way.
+	if testing.Short() {
+		t.Skip("runs the full claim ensemble twice")
+	}
+	bespoke := ObservedBehaviour()
+	declarative := observedBehaviour(declarativeBuildStub)
+
+	if len(declarative) != len(bespoke) {
+		t.Fatalf("got %d claims, want %d", len(declarative), len(bespoke))
+	}
+	maxDev := 0.0
+	for i, claim := range declarative {
+		reference := bespoke[i]
+		if claim.ID != reference.ID {
+			t.Fatalf("claim %d: got ID %q, want %q", i, claim.ID, reference.ID)
+		}
+		// Still a true claim when the model is data.
+		if err := cardgen.Verify(claim); err != nil {
+			t.Errorf("claim %q does not hold for the declarative model: %v", claim.ID, err)
+			continue
+		}
+		if len(claim.Observations) != len(reference.Observations) {
+			t.Fatalf("claim %q: got %d observations, want %d",
+				claim.ID, len(claim.Observations), len(reference.Observations))
+		}
+		for k, obs := range claim.Observations {
+			maxDev = math.Max(maxDev, assertClose(t, obs.Value,
+				reference.Observations[k].Value, claim.ID+" / "+obs.Label))
+		}
+	}
+	t.Logf("max deviation across every observation on every claim: %g", maxDev)
+}

--- a/models/measles-risk-forecaster/behaviour.go
+++ b/models/measles-risk-forecaster/behaviour.go
@@ -14,6 +14,12 @@ import (
 // computation here — not in a _test.go file — is what lets the card show exactly
 // the numbers the test asserts on, so the two can never disagree.
 
+// stubBuilder assembles the model, matching BuildStub's signature. The behaviour
+// helpers take one rather than calling BuildStub directly so that an alternative
+// assembly of the same model — notably the declarative one in declarative.yaml —
+// can be put through this exact claim suite instead of a re-stated copy of it.
+type stubBuilder func(mmr2Coverage float64, maxGenerations int, seed uint64) *simulator.ConfigGenerator
+
 // stepAll drives a coordinator to termination.
 func stepAll(coordinator *simulator.PartitionCoordinator) {
 	var wg sync.WaitGroup
@@ -24,8 +30,13 @@ func stepAll(coordinator *simulator.PartitionCoordinator) {
 
 // runStub runs the stub to completion and returns the recorded state history for
 // every partition, keyed by partition name.
-func runStub(mmr2Coverage float64, maxGenerations int, seed uint64) *simulator.StateTimeStorage {
-	settings, implementations := BuildStub(mmr2Coverage, maxGenerations, seed).GenerateConfigs()
+func runStub(
+	build stubBuilder,
+	mmr2Coverage float64,
+	maxGenerations int,
+	seed uint64,
+) *simulator.StateTimeStorage {
+	settings, implementations := build(mmr2Coverage, maxGenerations, seed).GenerateConfigs()
 	store := simulator.NewStateTimeStorage()
 	implementations.OutputFunction = &simulator.StateTimeStorageOutputFunction{Store: store}
 	coordinator := simulator.NewPartitionCoordinator(settings, implementations)
@@ -38,12 +49,13 @@ func runStub(mmr2Coverage float64, maxGenerations int, seed uint64) *simulator.S
 // dispersion, the importation band, the per-UTLA surface) without bloating
 // BuildStub's signature — BuildStub still exposes only the one headline driver.
 func runScenarioOverride(
+	build stubBuilder,
 	mmr2Coverage float64,
 	maxGenerations int,
 	seed uint64,
 	override func(*simulator.ConfigGenerator),
 ) *simulator.StateTimeStorage {
-	gen := BuildStub(mmr2Coverage, maxGenerations, seed)
+	gen := build(mmr2Coverage, maxGenerations, seed)
 	if override != nil {
 		override(gen)
 	}
@@ -70,10 +82,10 @@ func totalCases(store *simulator.StateTimeStorage) float64 {
 
 // meanTotalCases ensemble-averages the national total across nScenarios seeds (each
 // seed draws its own shared national importation total M).
-func meanTotalCases(mmr2Coverage float64, maxGenerations, nScenarios int) float64 {
+func meanTotalCases(build stubBuilder, mmr2Coverage float64, maxGenerations, nScenarios int) float64 {
 	var sum float64
 	for k := 0; k < nScenarios; k++ {
-		sum += totalCases(runStub(mmr2Coverage, maxGenerations, uint64(1000+k)))
+		sum += totalCases(runStub(build, mmr2Coverage, maxGenerations, uint64(1000+k)))
 	}
 	return sum / float64(nScenarios)
 }
@@ -81,12 +93,14 @@ func meanTotalCases(mmr2Coverage float64, maxGenerations, nScenarios int) float6
 // meanTotalOverride ensemble-averages the national total across nScenarios seeds
 // under a fixed coverage (the illustrative baseline) and override.
 func meanTotalOverride(
+	build stubBuilder,
 	maxGenerations, nScenarios int,
 	override func(*simulator.ConfigGenerator),
 ) float64 {
 	var sum float64
 	for k := 0; k < nScenarios; k++ {
-		sum += totalCases(runScenarioOverride(DefaultMMR2Coverage, maxGenerations, uint64(4000+k), override))
+		sum += totalCases(runScenarioOverride(
+			build, DefaultMMR2Coverage, maxGenerations, uint64(4000+k), override))
 	}
 	return sum / float64(nScenarios)
 }
@@ -109,10 +123,15 @@ func finalCumulativeVector(store *simulator.StateTimeStorage) []float64 {
 
 // meanCumulativeVector ensemble-averages the per-UTLA final cumulative case counts
 // across nMembers seeds (baseSeed+k), damping the branching noise in any one run.
-func meanCumulativeVector(mmr2Coverage float64, maxGenerations, nMembers int, baseSeed uint64) []float64 {
+func meanCumulativeVector(
+	build stubBuilder,
+	mmr2Coverage float64,
+	maxGenerations, nMembers int,
+	baseSeed uint64,
+) []float64 {
 	var mean []float64
 	for k := 0; k < nMembers; k++ {
-		cum := finalCumulativeVector(runStub(mmr2Coverage, maxGenerations, baseSeed+uint64(k)))
+		cum := finalCumulativeVector(runStub(build, mmr2Coverage, maxGenerations, baseSeed+uint64(k)))
 		if mean == nil {
 			mean = make([]float64, len(cum))
 		}
@@ -130,10 +149,10 @@ func meanCumulativeVector(mmr2Coverage float64, maxGenerations, nMembers int, ba
 // then returns the mean count of the bottom third vs the top third of areas ranked
 // by effective susceptibility — the core causal gradient (susceptibility, not
 // chance, drives where cases concentrate) as a two-point [bottom, top] comparison.
-func susceptibilityTertileCases(maxGenerations, ensemble int) (bottom, top float64) {
+func susceptibilityTertileCases(build stubBuilder, maxGenerations, ensemble int) (bottom, top float64) {
 	susceptibility, _, _ := BuildUTLASurface(DefaultMMR2Coverage)
 	n := len(susceptibility)
-	meanCum := meanCumulativeVector(DefaultMMR2Coverage, maxGenerations, ensemble, 6000)
+	meanCum := meanCumulativeVector(build, DefaultMMR2Coverage, maxGenerations, ensemble, 6000)
 	// Rank areas by descending susceptibility (simple selection sort; n is small).
 	order := make([]int, n)
 	for i := range order {
@@ -161,11 +180,16 @@ func susceptibilityTertileCases(maxGenerations, ensemble int) (bottom, top float
 // cvNationalTotal returns the coefficient of variation of the national total across
 // nScenarios seeds under the given importation override — the summary statistic for
 // how over-dispersed the national total is.
-func cvNationalTotal(maxGenerations, nScenarios int, override func(*simulator.ConfigGenerator)) float64 {
+func cvNationalTotal(
+	build stubBuilder,
+	maxGenerations, nScenarios int,
+	override func(*simulator.ConfigGenerator),
+) float64 {
 	xs := make([]float64, nScenarios)
 	var mean float64
 	for k := 0; k < nScenarios; k++ {
-		xs[k] = totalCases(runScenarioOverride(DefaultMMR2Coverage, maxGenerations, uint64(5000+k), override))
+		xs[k] = totalCases(runScenarioOverride(
+			build, DefaultMMR2Coverage, maxGenerations, uint64(5000+k), override))
 		mean += xs[k]
 	}
 	mean /= float64(nScenarios)
@@ -189,35 +213,42 @@ func cvNationalTotal(maxGenerations, nScenarios int, override func(*simulator.Co
 //
 // The claim IDs match the subtest names under TestMeaslesExpectedBehaviour.
 func ObservedBehaviour() []cardgen.Claim {
+	return observedBehaviour(BuildStub)
+}
+
+// observedBehaviour computes the claims against a given assembly of the model. The
+// equivalence test runs it against the declarative build so that the data-only model
+// answers the same claims, measured the same way.
+func observedBehaviour(build stubBuilder) []cardgen.Claim {
 	const gens, nScenarios = DefaultMaxGenerations, 12
 	const total = "ensemble-mean national total cases"
 
 	// ----- Decision-path response (the actionable public-health lever) -----
-	lowCov := meanTotalCases(0.82, gens, nScenarios)
-	highCov := meanTotalCases(0.92, gens, nScenarios)
+	lowCov := meanTotalCases(build, 0.82, gens, nScenarios)
+	highCov := meanTotalCases(build, 0.92, gens, nScenarios)
 
 	// ----- Structural-driver responses -----
-	bottomThird, topThird := susceptibilityTertileCases(gens, 40)
+	bottomThird, topThird := susceptibilityTertileCases(build, gens, 40)
 
-	baseR0 := meanTotalOverride(gens, nScenarios, func(g *simulator.ConfigGenerator) {
+	baseR0 := meanTotalOverride(build, gens, nScenarios, func(g *simulator.ConfigGenerator) {
 		setParam(g, "outbreaks", "r0", 12.0)
 	})
-	hotterR0 := meanTotalOverride(gens, nScenarios, func(g *simulator.ConfigGenerator) {
+	hotterR0 := meanTotalOverride(build, gens, nScenarios, func(g *simulator.ConfigGenerator) {
 		setParam(g, "outbreaks", "r0", 18.0)
 	})
 
-	calm := meanTotalOverride(gens, nScenarios, func(g *simulator.ConfigGenerator) {
+	calm := meanTotalOverride(build, gens, nScenarios, func(g *simulator.ConfigGenerator) {
 		setParam(g, "national_importation", "seed_low", 10.0)
 		setParam(g, "national_importation", "seed_high", 30.0)
 	})
-	surging := meanTotalOverride(gens, nScenarios, func(g *simulator.ConfigGenerator) {
+	surging := meanTotalOverride(build, gens, nScenarios, func(g *simulator.ConfigGenerator) {
 		setParam(g, "national_importation", "seed_low", 100.0)
 		setParam(g, "national_importation", "seed_high", 300.0)
 	})
 
 	const cvEnsemble = 50
-	sharedCV := cvNationalTotal(gens, cvEnsemble, nil) // wide band [20, 120]
-	fixedCV := cvNationalTotal(gens, cvEnsemble, func(g *simulator.ConfigGenerator) {
+	sharedCV := cvNationalTotal(build, gens, cvEnsemble, nil) // wide band [20, 120]
+	fixedCV := cvNationalTotal(build, gens, cvEnsemble, func(g *simulator.ConfigGenerator) {
 		setParam(g, "national_importation", "seed_low", 56.0)
 		setParam(g, "national_importation", "seed_high", 56.0) // fixed M ≈ band mean
 	})

--- a/models/measles-risk-forecaster/declarative.yaml
+++ b/models/measles-risk-forecaster/declarative.yaml
@@ -65,23 +65,41 @@ main:
     - {name: infectious, width: 30}
     - {name: cumulative, width: 30}
     bindings:
+    # Go truncates the infectious count to an int before both the guard and the shape, so
+    # floor is what the state actually contributes. These bindings take no draws, so being
+    # eager costs only arithmetic.
+    - {name: cases, expr: "floor(infectious)"}
     - {name: remaining, expr: "susceptible_pool - cumulative"}
     # The max on the divisor only guards lanes that are inactive anyway: a lane is active
     # only when its pool is at least 1, so the quotient is untouched wherever it is used.
     - {name: r_eff, expr: "r0 * susceptibility * (remaining / max(susceptible_pool, 1))"}
-    - {name: active, expr: "infectious > 0 && remaining > 0 && susceptible_pool >= 1 && r_eff > 0"}
-    # Sum of n iid negative-binomial offspring counts is Poisson(Gamma(n*k, k/R_local)), so
-    # a whole generation is one Gamma plus one Poisson per area. The maxes keep both shape
-    # and rate positive in the inactive lanes, whose draws are discarded by the mask below.
-    - {name: shape, expr: "max(infectious, 1) * dispersion"}
-    - {name: rate, expr: "dispersion / max(r_eff, 0.000001)"}
+    - {name: active, expr: "cases > 0 && remaining > 0 && susceptible_pool >= 1 && r_eff > 0"}
     # Both the seeding and the branching draw, so they must sit inside a lazy where rather
-    # than in bindings of their own: bindings are eager, and would draw on every step.
-    # min against floor(remaining) is the Go cap (next = int(remaining) when next exceeds
-    # it), which agrees because next is already integral.
+    # than in bindings of their own: bindings are eager, and would draw on every step. step
+    # is a scalar, so this where evaluates only the generation it selects.
+    #
+    # The branching generations are a per-area loop in the Go, and each is what says that:
+    # lanes run in order and a lane finishes before the next starts, so each area takes its
+    # Gamma and then its Poisson before the next area draws at all — the interleaving an
+    # elementwise gamma(...) followed by poisson(...) cannot produce, since it would take
+    # all 30 Gammas first. Inside a lane every value is a scalar, so the guard is lazy and
+    # an inactive area evaluates nothing and draws nothing, exactly as the Go skips it.
+    # Together those are what put the two models on the same draw stream.
+    #
+    # Sum of n iid negative-binomial offspring counts is Poisson(Gamma(n*k, k/R_local)), so
+    # a whole generation is one Gamma plus one Poisson per area. min against floor(remaining)
+    # is the Go cap (next = int(remaining) when next exceeds it), which agrees because next
+    # is already integral.
+    #
+    # Generation 0 seeds each area from the shared national total: one Poisson per area over
+    # a 30-wide rate, which is already in area order, so it needs no each.
     - name: new_infectious
       expr: "where(step > 1,
-                   where(active, min(poisson(gamma(shape, rate)), floor(remaining)), 0),
+                   each(30, i, where(active[i] > 0,
+                                     min(poisson(gamma(cases[i] * dispersion,
+                                                       dispersion / r_eff[i])),
+                                         floor(remaining[i])),
+                                     0)),
                    poisson(national_seed_total * receptivity))"
     # Generation 0's cumulative is its seed count; afterwards it accrues. Inactive lanes
     # contribute a masked zero, so the accrual needs no guard of its own.

--- a/models/measles-risk-forecaster/declarative.yaml
+++ b/models/measles-risk-forecaster/declarative.yaml
@@ -1,0 +1,93 @@
+# The measles-risk-forecaster generative core, written entirely as data: no Go, no
+# compilation.
+#
+# This is the same model BuildStub assembles in stub.go, with the same partition names,
+# param keys, state layout and wiring, so the two can be compared directly (see
+# expression_equivalence_test.go). The run knobs BuildStub takes as arguments (central MMR2
+# coverage, horizon, seed) are injected by the caller; everything below is the model.
+#
+# The per-UTLA vectors below are BuildUTLASurface(DefaultMMR2Coverage) — the illustrative
+# 0.88-coverage surface — so this file runs standalone. A caller sweeping coverage
+# overwrites them exactly as BuildStub rebuilds them from its argument.
+#
+# The Go code carries the two-block state layout as an index constant (out[i] vs out[n+i],
+# with n = len(susceptibility)); here it is two named fields of width 30, which is what
+# removes the constant.
+main:
+  partitions:
+
+  # The shared national importation latent: one log-uniform seed total M per scenario,
+  # held across generations. Sharing it is what correlates the UTLAs.
+  - name: national_importation
+    params:
+      seed_low: [20.0]
+      seed_high: [120.0]
+    init_state_values: [0.0]
+    state_width: 1
+    state_history_depth: 2
+    seed: 0
+
+  # All UTLAs jointly: [infectious_1..30, cumulative_1..30]. Generation 0 seeds each area
+  # from the shared national total; later generations branch each area at its own
+  # R_local = R0 * s, depleted by the cases it has already accumulated.
+  - name: outbreaks
+    params:
+      susceptibility: [0.15809999999999991, 0.15408620689655161, 0.15007241379310332, 0.14605862068965503, 0.14204482758620685, 0.13803103448275855, 0.13401724137931026, 0.13000344827586197, 0.12598965517241378, 0.12197586206896549, 0.11796206896551709, 0.1139482758620689, 0.10993448275862061, 0.10592068965517232, 0.10190689655172402, 0.097893103448275842, 0.093879310344827549, 0.089865517241379256, 0.085851724137930963, 0.081837931034482669, 0.077824137931034376, 0.073810344827586083, 0.069796551724137901, 0.065782758620689608, 0.061768965517241314, 0.057755172413793021, 0.053741379310344839, 0.049727586206896435, 0.045713793103448142, 0.041699999999999959]
+      receptivity: [0.016, 0.031540229885057475, 0.047080459770114942, 0.026758620689655174, 0.042298850574712644, 0.021977011494252872, 0.037517241379310347, 0.017195402298850575, 0.032735632183908049, 0.048275862068965517, 0.027954022988505748, 0.043494252873563226, 0.023172413793103447, 0.038712643678160921, 0.018390804597701149, 0.033931034482758624, 0.049471264367816091, 0.029149425287356322, 0.044689655172413786, 0.024367816091954025, 0.039908045977011496, 0.019586206896551727, 0.035126436781609198, 0.050666666666666665, 0.030344827586206893, 0.045885057471264361, 0.025563218390804599, 0.04110344827586207, 0.020781609195402298, 0.036321839080459772]
+      susceptible_pool: [400, 400, 400, 400, 400, 400, 400, 400, 400, 400, 400, 400, 400, 400, 400, 400, 400, 400, 400, 400, 400, 400, 400, 400, 400, 400, 400, 400, 400, 400]
+      r0: [15.0]
+      dispersion: [0.5]
+      national_seed_total: [0.0]
+    # The shared national total feeds this step's seeding within the step.
+    params_from_upstream:
+      national_seed_total:
+        upstream: national_importation
+    init_state_values: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    state_width: 60
+    state_history_depth: 2
+    seed: 7919
+
+  expressions:
+
+  - partition: national_importation
+    fields:
+    - {name: m}
+    bindings:
+    # Mirrors the Go floor on a non-positive band edge, which exists so the log below is
+    # finite. seed_low is a scalar, so this where takes no draw either way.
+    - {name: low, expr: "where(seed_low > 0, seed_low, 0.000001)"}
+    outputs:
+    # M is drawn once and then held. step is a scalar, so the where is lazy and the hold
+    # path consumes no randomness — which is what keeps this stream aligned with the Go
+    # iteration's single uniform draw.
+    - "where(step > 1, m, shared(exp(uniform(log(low), log(seed_high)))))"
+
+  - partition: outbreaks
+    fields:
+    - {name: infectious, width: 30}
+    - {name: cumulative, width: 30}
+    bindings:
+    - {name: remaining, expr: "susceptible_pool - cumulative"}
+    # The max on the divisor only guards lanes that are inactive anyway: a lane is active
+    # only when its pool is at least 1, so the quotient is untouched wherever it is used.
+    - {name: r_eff, expr: "r0 * susceptibility * (remaining / max(susceptible_pool, 1))"}
+    - {name: active, expr: "infectious > 0 && remaining > 0 && susceptible_pool >= 1 && r_eff > 0"}
+    # Sum of n iid negative-binomial offspring counts is Poisson(Gamma(n*k, k/R_local)), so
+    # a whole generation is one Gamma plus one Poisson per area. The maxes keep both shape
+    # and rate positive in the inactive lanes, whose draws are discarded by the mask below.
+    - {name: shape, expr: "max(infectious, 1) * dispersion"}
+    - {name: rate, expr: "dispersion / max(r_eff, 0.000001)"}
+    # Both the seeding and the branching draw, so they must sit inside a lazy where rather
+    # than in bindings of their own: bindings are eager, and would draw on every step.
+    # min against floor(remaining) is the Go cap (next = int(remaining) when next exceeds
+    # it), which agrees because next is already integral.
+    - name: new_infectious
+      expr: "where(step > 1,
+                   where(active, min(poisson(gamma(shape, rate)), floor(remaining)), 0),
+                   poisson(national_seed_total * receptivity))"
+    # Generation 0's cumulative is its seed count; afterwards it accrues. Inactive lanes
+    # contribute a masked zero, so the accrual needs no guard of its own.
+    - {name: new_cumulative, expr: "where(step > 1, cumulative + new_infectious, new_infectious)"}
+    outputs:
+    - "new_infectious"
+    - "new_cumulative"

--- a/models/measles-risk-forecaster/declarative.yaml
+++ b/models/measles-risk-forecaster/declarative.yaml
@@ -23,7 +23,6 @@ main:
       seed_low: [20.0]
       seed_high: [120.0]
     init_state_values: [0.0]
-    state_width: 1
     state_history_depth: 2
     seed: 0
 
@@ -43,7 +42,6 @@ main:
       national_seed_total:
         upstream: national_importation
     init_state_values: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-    state_width: 60
     state_history_depth: 2
     seed: 7919
 

--- a/models/measles-risk-forecaster/expression_equivalence_test.go
+++ b/models/measles-risk-forecaster/expression_equivalence_test.go
@@ -9,32 +9,30 @@ package measles
 // declarative build, which catches a model that is subtly different in a way per-step
 // agreement would not: wrong wiring, wrong param values, wrong state layout.
 //
-// # Where the two streams part company, and why
+// # The oracle: exact, throughout
 //
-// national_importation and the outbreaks seeding generation are exactly comparable:
-// rng.New(seed) and rand.New(rand.NewPCG(seed, seed)) are the same generator, pkg/rng's
-// draws are bit-identical to the distuv ones the bespoke code uses, and the declarative
-// spec takes the same draws in the same order, so the two stay in lockstep and agreement
-// is asserted to a tight tolerance.
+// Every partition here is compared exactly, because both models run on the same draw
+// stream. rng.New(seed) and rand.New(rand.NewPCG(seed, seed)) are the same generator,
+// pkg/rng's Gamma and Poisson are bit-identical to the distuv ones the bespoke code uses,
+// and each spec takes the same draws in the same order as its Go counterpart. Agreement is
+// therefore asserted to a tight tolerance rather than to bit-identity: compiled Go
+// contracts a + b*c into an FMA, which rounds differently from the evaluator's separate
+// operations, and that residue is the FMA rather than the model.
 //
-// The outbreaks BRANCHING generations cannot be aligned, and this is a property of the
-// DSL, not of how the spec is written. JointOutbreakIteration walks the areas in order and,
-// for each ACTIVE one, takes a Gamma then a Poisson — so its stream is per-area
-// interleaved, and skips inactive areas entirely. An expression evaluates elementwise over
-// the whole vector: gamma(shape, rate) takes all 30 Gammas before poisson(...) takes any
-// Poisson, and a vector-conditioned where must evaluate both branches, so the masked-out
-// areas draw too. Neither the interleaving nor the skipping is expressible without a loop
-// construct the DSL deliberately does not have. The two models are therefore equal in
-// distribution but not path-equal, and the branching comparison below is distributional:
-// the deterministic structure (which areas are frozen, the depletion cap, the cumulative
-// accrual) is still checked exactly, per replicate, and only the drawn magnitudes are
-// compared through their sampling distribution.
+// The outbreaks branching generations are what makes this interesting. Go walks the areas
+// in order and, for each ACTIVE one, takes a Gamma and then a Poisson — a per-area
+// interleaved stream that skips inactive areas entirely. Elementwise evaluation cannot say
+// that: gamma(shape, rate) would take all 30 Gammas before poisson(...) took any, and a
+// vector-conditioned where must evaluate both branches, so masked-out areas would draw too.
+// each(30, i, ...) says both halves at once. Lanes run in order and a lane completes before
+// the next begins, which is the interleaving; and inside a lane every value is a scalar, so
+// the guard is lazy and a skipped area draws nothing. The two models are path-equal, so
+// this file asserts equality of values and not of distributions.
 //
-// That parting is inherited by the suite test: the claim ensembles are means over 12–50
-// realisations of a heavy-tailed branching process, so the declarative build answers each
-// claim correctly but not with the bespoke build's exact numbers. The suite test therefore
-// asserts what is true — every claim still verifies — and reports the ensemble spread
-// rather than pretending to a tolerance the streams cannot support.
+// Exactness carries into the suite test: the claim ensembles are means over realisations of
+// a heavy-tailed branching process, and on a shared stream they are the SAME realisations,
+// so the declarative build reproduces the bespoke build's numbers rather than merely its
+// directions.
 
 import (
 	"math"
@@ -261,11 +259,12 @@ func TestDeclarativeOutbreakSeedingMatchesBespoke(t *testing.T) {
 	t.Logf("max deviation: %g", maxDev)
 }
 
-func TestDeclarativeOutbreakBranchingStructureMatchesBespoke(t *testing.T) {
-	// The branching generations' draw streams cannot be aligned (see the file comment), so
-	// this checks everything about them that is NOT a drawn magnitude: which areas are
-	// frozen, the depletion cap, and the cumulative accrual. Those are the parts of the
-	// spec a mis-statement would break, and they are exactly checkable per replicate.
+func TestDeclarativeOutbreakBranchingMatchesBespoke(t *testing.T) {
+	// The branching generations, compared value for value: each puts both sides on one draw
+	// stream (see the file comment), so the drawn magnitudes must agree and not merely their
+	// distributions. The structural checks are kept alongside — which areas are frozen, the
+	// depletion cap, the cumulative accrual — because they hold each side to the model
+	// independently, and so still fail if both sides drifted together.
 	bespoke := &JointOutbreakIteration{}
 	declarative, params := declarativeIteration(t, "outbreaks")
 	settings := &simulator.Settings{
@@ -278,6 +277,7 @@ func TestDeclarativeOutbreakBranchingStructureMatchesBespoke(t *testing.T) {
 	n := len(susceptibility)
 	rng := rand.New(rand.NewPCG(51, 52))
 	branches := map[string]int{}
+	maxDev := 0.0
 
 	check := func(out, state, pool []float64, r0 float64, side string, i int) {
 		for k := 0; k < n; k++ {
@@ -338,12 +338,23 @@ func TestDeclarativeOutbreakBranchingStructureMatchesBespoke(t *testing.T) {
 		if i%9 == 0 {
 			r0 = 0
 		}
+		// The Gamma shape is cases*dispersion, and pkg/rng switches sampler on it: the
+		// Liu–Martin–Syring log-space method below 0.2, a plain exponential at exactly 1, and
+		// Marsaglia–Tsang otherwise. Sweeping dispersion across all three puts every branch of
+		// the sampler on the stream, so a divergence in any of them would surface here.
+		dispersion := 0.2 + rng.Float64()
+		switch {
+		case i%11 == 0:
+			dispersion = 0.01 // shape below 0.2 for the small generations above
+		case i%13 == 0:
+			dispersion = 1.0 // shape of exactly 1 wherever a lane holds a single case
+		}
 		p := simulator.NewParams(map[string][]float64{
 			"susceptibility":      susceptibility,
 			"receptivity":         params["receptivity"],
 			"susceptible_pool":    pool,
 			"r0":                  {r0},
-			"dispersion":          {0.2 + rng.Float64()},
+			"dispersion":          {dispersion},
 			"national_seed_total": {50.0},
 		})
 		step := 2 + rng.IntN(12)
@@ -352,6 +363,10 @@ func TestDeclarativeOutbreakBranchingStructureMatchesBespoke(t *testing.T) {
 		got := declarative.Iterate(&p, 0, historyOf(state), stepsAt(step))
 		check(want, state, pool, r0, "bespoke", i)
 		check(got, state, pool, r0, "declarative", i)
+		// The whole point: same stream, so same values, not merely the same distribution.
+		for k := range want {
+			maxDev = math.Max(maxDev, assertClose(t, got[k], want[k], "branching"))
+		}
 
 		// Counted in the order the Go guards test them, so each area lands in the branch
 		// that actually decided its update.
@@ -368,111 +383,41 @@ func TestDeclarativeOutbreakBranchingStructureMatchesBespoke(t *testing.T) {
 				branches["zero_r_local"]++
 			default:
 				branches["branched"]++
-				// Counted per side: the two streams differ, so an area whose cap binds on
-				// one need not have binding on the other.
 				if want[k] == math.Floor(remaining) {
-					branches["cap_bound_bespoke"]++
+					branches["cap_bound"]++
 				}
-				if got[k] == math.Floor(remaining) {
-					branches["cap_bound_declarative"]++
+				// Which of pkg/rng's three Gamma samplers this lane's shape selects.
+				switch shape := math.Floor(state[k]) * dispersion; {
+				case shape < 0.2:
+					branches["gamma_small_shape"]++
+				case shape == 1:
+					branches["gamma_unit_shape"]++
+				default:
+					branches["gamma_marsaglia_tsang"]++
 				}
 			}
 		}
 	}
 	for _, b := range []string{
-		"zero_r_local", "extinct", "depleted", "sub_unit_pool", "branched",
-		"cap_bound_bespoke", "cap_bound_declarative",
+		"zero_r_local", "extinct", "depleted", "sub_unit_pool", "branched", "cap_bound",
+		"gamma_small_shape", "gamma_unit_shape", "gamma_marsaglia_tsang",
 	} {
 		if branches[b] == 0 {
 			t.Errorf("branch %q never exercised; the comparison is weaker than it looks", b)
 		}
 	}
 	t.Logf("branches exercised: %v", branches)
-}
-
-func TestDeclarativeOutbreakBranchingMatchesInDistribution(t *testing.T) {
-	// The magnitudes the structural test above leaves alone, checked the only way the
-	// unalignable streams allow: both sides' per-area sample means over a common scenario
-	// must sit on the analytic mean of the branching kernel, E[next_i] = I_i * R_local_i,
-	// and on each other.
-	bespoke := &JointOutbreakIteration{}
-	declarative, params := declarativeIteration(t, "outbreaks")
-	settings := &simulator.Settings{
-		Iterations: []simulator.IterationSettings{{Name: "outbreaks", Seed: 23}},
-	}
-	bespoke.Configure(0, settings)
-	declarative.Configure(0, settings)
-
-	susceptibility := params["susceptibility"]
-	pool := params["susceptible_pool"]
-	n := len(susceptibility)
-	const r0, dispersion = 15.0, DefaultDispersion
-
-	// A scenario chosen so the depletion cap never binds — with an empty pool of 400 and at
-	// most 3 infectious at R_local well under 3, hitting 400 in one generation has no
-	// meaningful probability — because the cap would bias the mean away from the analytic
-	// value this compares against.
-	state := make([]float64, 2*n)
-	for k := 0; k < n; k++ {
-		state[k] = float64(1 + k%3)
-	}
-	p := simulator.NewParams(map[string][]float64{
-		"susceptibility":      susceptibility,
-		"receptivity":         params["receptivity"],
-		"susceptible_pool":    pool,
-		"r0":                  {r0},
-		"dispersion":          {dispersion},
-		"national_seed_total": {50.0},
-	})
-
-	const replicates = 20000
-	sums := [2][]float64{make([]float64, n), make([]float64, n)}
-	squares := [2][]float64{make([]float64, n), make([]float64, n)}
-	for i := 0; i < replicates; i++ {
-		for side, out := range [2][]float64{
-			bespoke.Iterate(&p, 0, historyOf(state), stepsAt(2)),
-			declarative.Iterate(&p, 0, historyOf(state), stepsAt(2)),
-		} {
-			for k := 0; k < n; k++ {
-				sums[side][k] += out[k]
-				squares[side][k] += out[k] * out[k]
-			}
-		}
-	}
-
-	worst := 0.0
-	for k := 0; k < n; k++ {
-		rLocal := r0 * susceptibility[k] * ((pool[k] - state[n+k]) / pool[k])
-		analytic := state[k] * rLocal
-		var mean, se [2]float64
-		for side := 0; side < 2; side++ {
-			mean[side] = sums[side][k] / replicates
-			variance := squares[side][k]/replicates - mean[side]*mean[side]
-			se[side] = math.Sqrt(variance / replicates)
-			// Four standard errors: a false failure needs a ~1-in-16,000 deviation, and 60
-			// comparisons run here.
-			if z := math.Abs(mean[side]-analytic) / se[side]; z > 4 {
-				t.Errorf("area %d %s: mean %v is %.1f standard errors from the analytic %v",
-					k, [2]string{"bespoke", "declarative"}[side], mean[side], z, analytic)
-			}
-		}
-		z := math.Abs(mean[0]-mean[1]) / math.Sqrt(se[0]*se[0]+se[1]*se[1])
-		if z > 4 {
-			t.Errorf("area %d: declarative mean %v and bespoke mean %v differ by %.1f "+
-				"standard errors", k, mean[1], mean[0], z)
-		}
-		worst = math.Max(worst, z)
-	}
-	t.Logf("largest declarative-vs-bespoke separation across the 30 areas: %.2f "+
-		"standard errors", worst)
+	t.Logf("max deviation: %g", maxDev)
 }
 
 func TestDeclarativeMeaslesAnswersTheSameClaims(t *testing.T) {
 	// The oracle is the model's own behaviour suite: every claim recomputed against the
-	// declarative build must still hold. It cannot hold with the SAME numbers — the
-	// branching streams do not align (see the file comment), so each claim's ensemble is a
-	// different set of realisations of the same distribution — so the numbers are reported
-	// rather than asserted on, and what is asserted is what the claims actually say.
+	// declarative build must still hold, AND must hold with the same numbers. The second
+	// half is the stronger half. Verify only checks that each claim moves in its stated
+	// direction, and direction is cheap — a claim suite cannot tell two mechanisms apart if
+	// both respond the same way. Reproducing the observations exactly says the declarative
+	// build is running the same model over the same draws, which is what a wrong param,
+	// wrong wiring or wrong state layout would break.
 	if testing.Short() {
 		t.Skip("runs the full claim ensemble twice")
 	}
@@ -482,6 +427,7 @@ func TestDeclarativeMeaslesAnswersTheSameClaims(t *testing.T) {
 	if len(declarative) != len(bespoke) {
 		t.Fatalf("got %d claims, want %d", len(declarative), len(bespoke))
 	}
+	maxDev := 0.0
 	for i, claim := range declarative {
 		reference := bespoke[i]
 		if claim.ID != reference.ID {
@@ -498,19 +444,13 @@ func TestDeclarativeMeaslesAnswersTheSameClaims(t *testing.T) {
 		}
 		for k, obs := range claim.Observations {
 			want := reference.Observations[k].Value
-			relative := math.Abs(obs.Value-want) / math.Max(math.Abs(want), 1e-12)
-			t.Logf("%s / %s: declarative=%.4g bespoke=%.4g relative=%.1f%%",
-				claim.ID, obs.Label, obs.Value, want, 100*relative)
-			// A stochastic band, not an equivalence: both ensembles are fixed-seed and so
-			// this is deterministic, and it is set well above the ensemble noise between
-			// two independent realisations (the worst seen is ~21%) but far below what a
-			// wrong param, wrong wiring or wrong state layout does to these totals, which
-			// is multiples rather than percentages.
-			if relative > 0.5 {
-				t.Errorf("%s / %s: declarative=%v and bespoke=%v differ by %.0f%%, "+
-					"more than ensemble noise explains",
-					claim.ID, obs.Label, obs.Value, want, 100*relative)
+			if obs.Label != reference.Observations[k].Label {
+				t.Fatalf("claim %q observation %d: got label %q, want %q",
+					claim.ID, k, obs.Label, reference.Observations[k].Label)
 			}
+			maxDev = math.Max(maxDev,
+				assertClose(t, obs.Value, want, claim.ID+" / "+obs.Label))
 		}
 	}
+	t.Logf("max deviation across every claim observation: %g", maxDev)
 }

--- a/models/measles-risk-forecaster/expression_equivalence_test.go
+++ b/models/measles-risk-forecaster/expression_equivalence_test.go
@@ -1,0 +1,516 @@
+package measles
+
+// Does declarative.yaml — this model written as data, with no Go — reproduce the model
+// stub.go builds in code?
+//
+// Two independent checks, because they fail in different ways. The step-for-step tests
+// compare single Iterate calls over randomised inputs, which catches a mis-stated formula
+// exactly. The suite test re-runs the model's own claim computations against the
+// declarative build, which catches a model that is subtly different in a way per-step
+// agreement would not: wrong wiring, wrong param values, wrong state layout.
+//
+// # Where the two streams part company, and why
+//
+// national_importation and the outbreaks seeding generation are exactly comparable:
+// rng.New(seed) and rand.New(rand.NewPCG(seed, seed)) are the same generator, pkg/rng's
+// draws are bit-identical to the distuv ones the bespoke code uses, and the declarative
+// spec takes the same draws in the same order, so the two stay in lockstep and agreement
+// is asserted to a tight tolerance.
+//
+// The outbreaks BRANCHING generations cannot be aligned, and this is a property of the
+// DSL, not of how the spec is written. JointOutbreakIteration walks the areas in order and,
+// for each ACTIVE one, takes a Gamma then a Poisson — so its stream is per-area
+// interleaved, and skips inactive areas entirely. An expression evaluates elementwise over
+// the whole vector: gamma(shape, rate) takes all 30 Gammas before poisson(...) takes any
+// Poisson, and a vector-conditioned where must evaluate both branches, so the masked-out
+// areas draw too. Neither the interleaving nor the skipping is expressible without a loop
+// construct the DSL deliberately does not have. The two models are therefore equal in
+// distribution but not path-equal, and the branching comparison below is distributional:
+// the deterministic structure (which areas are frozen, the depletion cap, the cumulative
+// accrual) is still checked exactly, per replicate, and only the drawn magnitudes are
+// compared through their sampling distribution.
+//
+// That parting is inherited by the suite test: the claim ensembles are means over 12–50
+// realisations of a heavy-tailed branching process, so the declarative build answers each
+// claim correctly but not with the bespoke build's exact numbers. The suite test therefore
+// asserts what is true — every claim still verifies — and reports the ensemble spread
+// rather than pretending to a tolerance the streams cannot support.
+
+import (
+	"math"
+	"math/rand/v2"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+
+	"github.com/umbralcalc/stochadex/models/cardgen"
+	"github.com/umbralcalc/stochadex/pkg/api"
+	"github.com/umbralcalc/stochadex/pkg/general"
+	"github.com/umbralcalc/stochadex/pkg/simulator"
+)
+
+// tolerance is well above FMA rounding and well below any difference a real modelling
+// discrepancy would produce.
+const tolerance = 1e-12
+
+// declarativeBuildStub assembles the model from declarative.yaml, matching BuildStub's
+// signature so it can be dropped into the behaviour helpers. The YAML holds the model; the
+// run knobs BuildStub takes as arguments are injected here, exactly as BuildStub injects
+// them into its Go partitions — including the per-UTLA surface, which BuildStub likewise
+// derives from its coverage argument rather than storing.
+func declarativeBuildStub(
+	mmr2Coverage float64,
+	maxGenerations int,
+	seed uint64,
+) *simulator.ConfigGenerator {
+	config := api.LoadApiRunConfigFromYaml("declarative.yaml")
+	config.Main.Simulation = simulator.SimulationConfig{
+		OutputCondition: &simulator.EveryStepOutputCondition{},
+		TerminationCondition: &simulator.NumberOfStepsTerminationCondition{
+			MaxNumberOfSteps: maxGenerations,
+		},
+		TimestepFunction: &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+		InitTimeValue:    0.0,
+	}
+	gen := config.Main.GetConfigGenerator()
+	susceptibility, receptivity, pool := BuildUTLASurface(mmr2Coverage)
+	outbreaks := gen.GetPartition("outbreaks")
+	outbreaks.Params.Map["susceptibility"] = susceptibility
+	outbreaks.Params.Map["receptivity"] = receptivity
+	outbreaks.Params.Map["susceptible_pool"] = pool
+	outbreaks.Seed = seed + 7919
+	gen.GetPartition("national_importation").Seed = seed
+	return gen
+}
+
+// declarativeIteration returns the expression iteration the YAML supplies for a partition,
+// alongside the params it declares.
+func declarativeIteration(
+	t *testing.T,
+	partition string,
+) (*general.ExpressionIteration, map[string][]float64) {
+	t.Helper()
+	config := declarativeBuildStub(DefaultMMR2Coverage, 10, 0).GetPartition(partition)
+	iteration, ok := config.Iteration.(*general.ExpressionIteration)
+	if !ok {
+		t.Fatalf("%s is not expression-backed: got %T", partition, config.Iteration)
+	}
+	return iteration, config.Params.Map
+}
+
+// assertClose fails when two values differ by more than the FMA-scale tolerance, comparing
+// relatively once the magnitude exceeds 1.
+func assertClose(t *testing.T, got, want float64, context string) float64 {
+	t.Helper()
+	d := math.Abs(got - want)
+	if s := math.Abs(want); s > 1 {
+		d /= s
+	}
+	if d > tolerance {
+		t.Fatalf("%s: declarative=%v bespoke=%v deviation=%g", context, got, want, d)
+	}
+	return d
+}
+
+// stepsAt builds a timesteps history reporting the given step number, which is the only
+// part of it either iteration reads.
+func stepsAt(step int) *simulator.CumulativeTimestepsHistory {
+	return &simulator.CumulativeTimestepsHistory{
+		Values:            mat.NewVecDense(1, []float64{float64(step)}),
+		NextIncrement:     1.0,
+		CurrentStepNumber: step,
+	}
+}
+
+// historyOf wraps one state row as a single-partition history, fresh each call so neither
+// iteration can be handed the other's buffer.
+func historyOf(state []float64) []*simulator.StateHistory {
+	return []*simulator.StateHistory{{
+		Values:            mat.NewDense(1, len(state), append([]float64{}, state...)),
+		StateWidth:        len(state),
+		StateHistoryDepth: 1,
+	}}
+}
+
+func TestDeclarativeNationalImportationMatchesBespoke(t *testing.T) {
+	bespoke := &NationalImportationIteration{}
+	declarative, _ := declarativeIteration(t, "national_importation")
+	settings := &simulator.Settings{
+		Iterations: []simulator.IterationSettings{{Name: "national_importation", Seed: 5}},
+	}
+	bespoke.Configure(0, settings)
+	declarative.Configure(0, settings)
+
+	rng := rand.New(rand.NewPCG(31, 32))
+	branches := map[string]int{}
+	maxDev := 0.0
+
+	const cases = 20000
+	for i := 0; i < cases; i++ {
+		// Sweep the band floor across zero so the log-guard fires, and the step number
+		// across 1 so both the draw and the hold are compared. The hold must take no draw
+		// on either side, or every later case would disagree — which is exactly what makes
+		// this a test of the lazy where and not just of the log-uniform formula.
+		low := 20.0 + rng.Float64()*100
+		if i%7 == 0 {
+			low = -rng.Float64()
+		}
+		high := 150.0 + rng.Float64()*200
+		step := 1
+		if i%2 == 0 {
+			step = 2 + rng.IntN(20)
+		}
+		p := simulator.NewParams(map[string][]float64{
+			"seed_low":  {low},
+			"seed_high": {high},
+		})
+		state := []float64{rng.Float64() * 200}
+
+		want := bespoke.Iterate(&p, 0, historyOf(state), stepsAt(step))
+		got := declarative.Iterate(&p, 0, historyOf(state), stepsAt(step))
+
+		if step > 1 {
+			branches["held"]++
+		} else {
+			branches["drawn"]++
+		}
+		if low > 0 {
+			branches["positive_band_floor"]++
+		} else {
+			branches["clamped_band_floor"]++
+		}
+		maxDev = math.Max(maxDev, assertClose(t, got[0], want[0], "national seed total"))
+	}
+	for _, b := range []string{"held", "drawn", "positive_band_floor", "clamped_band_floor"} {
+		if branches[b] == 0 {
+			t.Errorf("branch %q never exercised; the comparison is weaker than it looks", b)
+		}
+	}
+	t.Logf("branches exercised: %v", branches)
+	t.Logf("max deviation: %g", maxDev)
+}
+
+func TestDeclarativeOutbreakSeedingMatchesBespoke(t *testing.T) {
+	// Generation 0 is the one outbreaks step whose draws do align: one Poisson per area, in
+	// area order, on both sides.
+	bespoke := &JointOutbreakIteration{}
+	declarative, params := declarativeIteration(t, "outbreaks")
+	settings := &simulator.Settings{
+		Iterations: []simulator.IterationSettings{{Name: "outbreaks", Seed: 13}},
+	}
+	bespoke.Configure(0, settings)
+	declarative.Configure(0, settings)
+
+	n := len(params["susceptibility"])
+	rng := rand.New(rand.NewPCG(41, 42))
+	branches := map[string]int{}
+	maxDev := 0.0
+
+	const cases = 2000
+	for i := 0; i < cases; i++ {
+		// The band spans both of pkg/rng's Poisson algorithms — the direct
+		// exponential-interarrival method below lambda 10 and PTRS above it — so a
+		// disagreement in either branch of the sampler would show up here too.
+		total := 1.0 + rng.Float64()*600
+		p := simulator.NewParams(map[string][]float64{
+			"susceptibility":      params["susceptibility"],
+			"receptivity":         params["receptivity"],
+			"susceptible_pool":    params["susceptible_pool"],
+			"r0":                  {DefaultR0},
+			"dispersion":          {DefaultDispersion},
+			"national_seed_total": {total},
+		})
+		state := make([]float64, 2*n)
+
+		want := bespoke.Iterate(&p, 0, historyOf(state), stepsAt(1))
+		got := declarative.Iterate(&p, 0, historyOf(state), stepsAt(1))
+
+		for k := 0; k < n; k++ {
+			lambda := total * params["receptivity"][k]
+			if lambda < 10 {
+				branches["small_lambda_lane"]++
+			} else {
+				branches["large_lambda_lane"]++
+			}
+			if want[k] == 0 {
+				branches["zero_seed_lane"]++
+			} else {
+				branches["seeded_lane"]++
+			}
+		}
+		for k := range want {
+			maxDev = math.Max(maxDev, assertClose(t, got[k], want[k], "seeding"))
+		}
+		// Generation 0 must put the seed count into both blocks from a single draw; a spec
+		// that drew twice would pass the elementwise check above and fail this.
+		for k := 0; k < n; k++ {
+			if got[k] != got[n+k] {
+				t.Fatalf("case %d area %d: cumulative %v does not equal infectious %v",
+					i, k, got[n+k], got[k])
+			}
+		}
+	}
+	for _, b := range []string{
+		"small_lambda_lane", "large_lambda_lane", "zero_seed_lane", "seeded_lane",
+	} {
+		if branches[b] == 0 {
+			t.Errorf("branch %q never exercised; the comparison is weaker than it looks", b)
+		}
+	}
+	t.Logf("branches exercised: %v", branches)
+	t.Logf("max deviation: %g", maxDev)
+}
+
+func TestDeclarativeOutbreakBranchingStructureMatchesBespoke(t *testing.T) {
+	// The branching generations' draw streams cannot be aligned (see the file comment), so
+	// this checks everything about them that is NOT a drawn magnitude: which areas are
+	// frozen, the depletion cap, and the cumulative accrual. Those are the parts of the
+	// spec a mis-statement would break, and they are exactly checkable per replicate.
+	bespoke := &JointOutbreakIteration{}
+	declarative, params := declarativeIteration(t, "outbreaks")
+	settings := &simulator.Settings{
+		Iterations: []simulator.IterationSettings{{Name: "outbreaks", Seed: 17}},
+	}
+	bespoke.Configure(0, settings)
+	declarative.Configure(0, settings)
+
+	susceptibility := params["susceptibility"]
+	n := len(susceptibility)
+	rng := rand.New(rand.NewPCG(51, 52))
+	branches := map[string]int{}
+
+	check := func(out, state, pool []float64, r0 float64, side string, i int) {
+		for k := 0; k < n; k++ {
+			infectious := state[k]
+			cumulative := state[n+k]
+			remaining := pool[k] - cumulative
+			frozen := infectious <= 0 || remaining <= 0 || pool[k] < 1 ||
+				r0*susceptibility[k]*(remaining/math.Max(pool[k], 1)) <= 0
+			if frozen {
+				if out[k] != 0 || out[n+k] != cumulative {
+					t.Fatalf("%s case %d area %d: frozen area moved: %v, %v -> %v, %v",
+						side, i, k, infectious, cumulative, out[k], out[n+k])
+				}
+				continue
+			}
+			if out[k] > math.Floor(remaining) {
+				t.Fatalf("%s case %d area %d: %v new cases exceeds the %v remaining",
+					side, i, k, out[k], remaining)
+			}
+			if out[n+k] != cumulative+out[k] {
+				t.Fatalf("%s case %d area %d: cumulative %v is not %v + %v",
+					side, i, k, out[n+k], cumulative, out[k])
+			}
+		}
+	}
+
+	const cases = 4000
+	for i := 0; i < cases; i++ {
+		pool := make([]float64, n)
+		state := make([]float64, 2*n)
+		for k := 0; k < n; k++ {
+			switch k % 5 {
+			case 0: // extinct: no infectious cases left
+				state[k] = 0
+				pool[k] = 400
+				state[n+k] = math.Floor(rng.Float64() * 50)
+			case 1: // depleted: the whole reachable pool has already been infected
+				state[k] = math.Floor(1 + rng.Float64()*5)
+				pool[k] = 400
+				state[n+k] = 400 + math.Floor(rng.Float64()*10)
+			case 2: // sub-unit pool: too few susceptibles to reach anyone
+				state[k] = math.Floor(1 + rng.Float64()*5)
+				pool[k] = rng.Float64() * 0.9
+				state[n+k] = 0
+			case 3: // a small pool branching hard, so the cap on new cases binds
+				pool[k] = 5 + math.Floor(rng.Float64()*3)
+				state[k] = 20 + math.Floor(rng.Float64()*20)
+				state[n+k] = math.Floor(rng.Float64() * 2)
+			default: // freely branching
+				pool[k] = 400
+				state[k] = math.Floor(1 + rng.Float64()*8)
+				state[n+k] = math.Floor(rng.Float64() * 100)
+			}
+		}
+		// Sweep R0 through zero so the zero-R_local guard inside the Go kernel — reachable
+		// only through a degenerate scenario — is compared too.
+		r0 := 4.0 + rng.Float64()*14
+		if i%9 == 0 {
+			r0 = 0
+		}
+		p := simulator.NewParams(map[string][]float64{
+			"susceptibility":      susceptibility,
+			"receptivity":         params["receptivity"],
+			"susceptible_pool":    pool,
+			"r0":                  {r0},
+			"dispersion":          {0.2 + rng.Float64()},
+			"national_seed_total": {50.0},
+		})
+		step := 2 + rng.IntN(12)
+
+		want := bespoke.Iterate(&p, 0, historyOf(state), stepsAt(step))
+		got := declarative.Iterate(&p, 0, historyOf(state), stepsAt(step))
+		check(want, state, pool, r0, "bespoke", i)
+		check(got, state, pool, r0, "declarative", i)
+
+		// Counted in the order the Go guards test them, so each area lands in the branch
+		// that actually decided its update.
+		for k := 0; k < n; k++ {
+			remaining := pool[k] - state[n+k]
+			switch {
+			case state[k] <= 0:
+				branches["extinct"]++
+			case remaining <= 0:
+				branches["depleted"]++
+			case pool[k] < 1:
+				branches["sub_unit_pool"]++
+			case r0*susceptibility[k]*(remaining/pool[k]) <= 0:
+				branches["zero_r_local"]++
+			default:
+				branches["branched"]++
+				// Counted per side: the two streams differ, so an area whose cap binds on
+				// one need not have binding on the other.
+				if want[k] == math.Floor(remaining) {
+					branches["cap_bound_bespoke"]++
+				}
+				if got[k] == math.Floor(remaining) {
+					branches["cap_bound_declarative"]++
+				}
+			}
+		}
+	}
+	for _, b := range []string{
+		"zero_r_local", "extinct", "depleted", "sub_unit_pool", "branched",
+		"cap_bound_bespoke", "cap_bound_declarative",
+	} {
+		if branches[b] == 0 {
+			t.Errorf("branch %q never exercised; the comparison is weaker than it looks", b)
+		}
+	}
+	t.Logf("branches exercised: %v", branches)
+}
+
+func TestDeclarativeOutbreakBranchingMatchesInDistribution(t *testing.T) {
+	// The magnitudes the structural test above leaves alone, checked the only way the
+	// unalignable streams allow: both sides' per-area sample means over a common scenario
+	// must sit on the analytic mean of the branching kernel, E[next_i] = I_i * R_local_i,
+	// and on each other.
+	bespoke := &JointOutbreakIteration{}
+	declarative, params := declarativeIteration(t, "outbreaks")
+	settings := &simulator.Settings{
+		Iterations: []simulator.IterationSettings{{Name: "outbreaks", Seed: 23}},
+	}
+	bespoke.Configure(0, settings)
+	declarative.Configure(0, settings)
+
+	susceptibility := params["susceptibility"]
+	pool := params["susceptible_pool"]
+	n := len(susceptibility)
+	const r0, dispersion = 15.0, DefaultDispersion
+
+	// A scenario chosen so the depletion cap never binds — with an empty pool of 400 and at
+	// most 3 infectious at R_local well under 3, hitting 400 in one generation has no
+	// meaningful probability — because the cap would bias the mean away from the analytic
+	// value this compares against.
+	state := make([]float64, 2*n)
+	for k := 0; k < n; k++ {
+		state[k] = float64(1 + k%3)
+	}
+	p := simulator.NewParams(map[string][]float64{
+		"susceptibility":      susceptibility,
+		"receptivity":         params["receptivity"],
+		"susceptible_pool":    pool,
+		"r0":                  {r0},
+		"dispersion":          {dispersion},
+		"national_seed_total": {50.0},
+	})
+
+	const replicates = 20000
+	sums := [2][]float64{make([]float64, n), make([]float64, n)}
+	squares := [2][]float64{make([]float64, n), make([]float64, n)}
+	for i := 0; i < replicates; i++ {
+		for side, out := range [2][]float64{
+			bespoke.Iterate(&p, 0, historyOf(state), stepsAt(2)),
+			declarative.Iterate(&p, 0, historyOf(state), stepsAt(2)),
+		} {
+			for k := 0; k < n; k++ {
+				sums[side][k] += out[k]
+				squares[side][k] += out[k] * out[k]
+			}
+		}
+	}
+
+	worst := 0.0
+	for k := 0; k < n; k++ {
+		rLocal := r0 * susceptibility[k] * ((pool[k] - state[n+k]) / pool[k])
+		analytic := state[k] * rLocal
+		var mean, se [2]float64
+		for side := 0; side < 2; side++ {
+			mean[side] = sums[side][k] / replicates
+			variance := squares[side][k]/replicates - mean[side]*mean[side]
+			se[side] = math.Sqrt(variance / replicates)
+			// Four standard errors: a false failure needs a ~1-in-16,000 deviation, and 60
+			// comparisons run here.
+			if z := math.Abs(mean[side]-analytic) / se[side]; z > 4 {
+				t.Errorf("area %d %s: mean %v is %.1f standard errors from the analytic %v",
+					k, [2]string{"bespoke", "declarative"}[side], mean[side], z, analytic)
+			}
+		}
+		z := math.Abs(mean[0]-mean[1]) / math.Sqrt(se[0]*se[0]+se[1]*se[1])
+		if z > 4 {
+			t.Errorf("area %d: declarative mean %v and bespoke mean %v differ by %.1f "+
+				"standard errors", k, mean[1], mean[0], z)
+		}
+		worst = math.Max(worst, z)
+	}
+	t.Logf("largest declarative-vs-bespoke separation across the 30 areas: %.2f "+
+		"standard errors", worst)
+}
+
+func TestDeclarativeMeaslesAnswersTheSameClaims(t *testing.T) {
+	// The oracle is the model's own behaviour suite: every claim recomputed against the
+	// declarative build must still hold. It cannot hold with the SAME numbers — the
+	// branching streams do not align (see the file comment), so each claim's ensemble is a
+	// different set of realisations of the same distribution — so the numbers are reported
+	// rather than asserted on, and what is asserted is what the claims actually say.
+	if testing.Short() {
+		t.Skip("runs the full claim ensemble twice")
+	}
+	bespoke := ObservedBehaviour()
+	declarative := observedBehaviour(declarativeBuildStub)
+
+	if len(declarative) != len(bespoke) {
+		t.Fatalf("got %d claims, want %d", len(declarative), len(bespoke))
+	}
+	for i, claim := range declarative {
+		reference := bespoke[i]
+		if claim.ID != reference.ID {
+			t.Fatalf("claim %d: got ID %q, want %q", i, claim.ID, reference.ID)
+		}
+		// Still a true claim when the model is data.
+		if err := cardgen.Verify(claim); err != nil {
+			t.Errorf("claim %q does not hold for the declarative model: %v", claim.ID, err)
+			continue
+		}
+		if len(claim.Observations) != len(reference.Observations) {
+			t.Fatalf("claim %q: got %d observations, want %d",
+				claim.ID, len(claim.Observations), len(reference.Observations))
+		}
+		for k, obs := range claim.Observations {
+			want := reference.Observations[k].Value
+			relative := math.Abs(obs.Value-want) / math.Max(math.Abs(want), 1e-12)
+			t.Logf("%s / %s: declarative=%.4g bespoke=%.4g relative=%.1f%%",
+				claim.ID, obs.Label, obs.Value, want, 100*relative)
+			// A stochastic band, not an equivalence: both ensembles are fixed-seed and so
+			// this is deterministic, and it is set well above the ensemble noise between
+			// two independent realisations (the worst seen is ~21%) but far below what a
+			// wrong param, wrong wiring or wrong state layout does to these totals, which
+			// is multiples rather than percentages.
+			if relative > 0.5 {
+				t.Errorf("%s / %s: declarative=%v and bespoke=%v differ by %.0f%%, "+
+					"more than ensemble noise explains",
+					claim.ID, obs.Label, obs.Value, want, 100*relative)
+			}
+		}
+	}
+}

--- a/models/measles-risk-forecaster/stub_test.go
+++ b/models/measles-risk-forecaster/stub_test.go
@@ -28,7 +28,7 @@ func TestMeaslesStub(t *testing.T) {
 		const cov = DefaultMMR2Coverage
 		_, _, pool := BuildUTLASurface(cov)
 		n := len(pool)
-		store := runStub(cov, DefaultMaxGenerations, 42)
+		store := runStub(BuildStub, cov, DefaultMaxGenerations, 42)
 		rows := store.GetValues("outbreaks")
 
 		var prevCumulative []float64
@@ -100,8 +100,8 @@ func TestMeaslesStub(t *testing.T) {
 	// scenarios so the claim is about the distribution.
 	t.Run("lower coverage raises total cases", func(t *testing.T) {
 		const gens, nScenarios = DefaultMaxGenerations, 16
-		lowCoverage := meanTotalCases(0.80, gens, nScenarios)
-		highCoverage := meanTotalCases(0.94, gens, nScenarios)
+		lowCoverage := meanTotalCases(BuildStub, 0.80, gens, nScenarios)
+		highCoverage := meanTotalCases(BuildStub, 0.94, gens, nScenarios)
 		if !(lowCoverage > highCoverage) {
 			t.Fatalf("expected lower coverage to raise total cases: "+
 				"low(0.80)=%.0f high(0.94)=%.0f", lowCoverage, highCoverage)

--- a/models/measles-risk-forecaster/transmission.go
+++ b/models/measles-risk-forecaster/transmission.go
@@ -46,7 +46,7 @@ func effectivePool(s, population, fraction, reachableCeiling float64) float64 {
 }
 
 // nextGeneration draws the total number of secondary cases produced by the current
-// generation of `infectious` cases, each with negative-binomial offspring (mean
+// generation of infectious cases, each with negative-binomial offspring (mean
 // rLocal, dispersion k). Because the sum of n iid NegBin offspring counts is itself
 // Poisson(Gamma(shape = n*k, rate = k/rLocal)), the whole generation is one Gamma
 // draw plus one Poisson draw — exact, and O(1) in the generation size. This single

--- a/models/trywizard/behaviour.go
+++ b/models/trywizard/behaviour.go
@@ -13,17 +13,31 @@ import (
 // computation here — not in a _test.go file — is what lets the card show exactly
 // the numbers the test asserts on, so the two can never disagree.
 
+// stubBuilder assembles the model, matching buildStubWithStrategy's signature —
+// the constructor these helpers use, rather than BuildStub, because the claims
+// sweep the whole substitution plan and not just its one headline minute. The
+// helpers take one rather than calling buildStubWithStrategy directly so that an
+// alternative assembly of the same model — notably the declarative one in
+// declarative.yaml — can be put through this exact claim suite instead of a
+// re-stated copy of it.
+type stubBuilder func(
+	strategy *SubstitutionStrategy,
+	numSteps int,
+	seed uint64,
+) *simulator.ConfigGenerator
+
 // runStrategy runs the stub for an arbitrary substitution strategy with an
 // optional override hook applied to the generated config, so a behaviour can vary
 // the substitution plan and/or any partition's params (coefficients, conversion
 // probabilities) without bloating BuildStub's one-driver signature.
 func runStrategy(
+	build stubBuilder,
 	strategy *SubstitutionStrategy,
 	numSteps int,
 	seed uint64,
 	override func(*simulator.ConfigGenerator),
 ) *simulator.StateTimeStorage {
-	gen := buildStubWithStrategy(strategy, numSteps, seed)
+	gen := build(strategy, numSteps, seed)
 	if override != nil {
 		override(gen)
 	}
@@ -47,6 +61,7 @@ func finalRow(store *simulator.StateTimeStorage, partition string) []float64 {
 // meanFinal ensemble-averages the final value of component idx of the named
 // partition over nMembers seeds, for a given strategy and override.
 func meanFinal(
+	build stubBuilder,
 	strategy *SubstitutionStrategy,
 	numSteps, nMembers int,
 	partition string,
@@ -55,7 +70,7 @@ func meanFinal(
 ) float64 {
 	var sum float64
 	for m := 0; m < nMembers; m++ {
-		store := runStrategy(strategy, numSteps, uint64(5000+m), override)
+		store := runStrategy(build, strategy, numSteps, uint64(5000+m), override)
 		sum += finalRow(store, partition)[idx]
 	}
 	return sum / float64(nMembers)
@@ -64,12 +79,13 @@ func meanFinal(
 // homeWinProbability is the fraction of an nMembers ensemble in which the home
 // side finishes ahead (final score difference > 0).
 func homeWinProbability(
+	build stubBuilder,
 	strategy *SubstitutionStrategy,
 	numSteps, nMembers int,
 ) float64 {
 	wins := 0
 	for m := 0; m < nMembers; m++ {
-		store := runStrategy(strategy, numSteps, uint64(6000+m), nil)
+		store := runStrategy(build, strategy, numSteps, uint64(6000+m), nil)
 		if finalRow(store, "match_state")[StateIdxScoreDiff] > 0 {
 			wins++
 		}
@@ -102,6 +118,13 @@ func scoreCoeffsWith(edit func(c []float64)) []float64 {
 //
 // The claim IDs match the subtest names under TestRugbyExpectedBehaviour.
 func ObservedBehaviour() []cardgen.Claim {
+	return observedBehaviour(buildStubWithStrategy)
+}
+
+// observedBehaviour computes the claims against a given assembly of the model. The
+// equivalence test runs it against the declarative build so that the data-only model
+// answers the same claims, measured the same way.
+func observedBehaviour(build stubBuilder) []cardgen.Claim {
 	const steps = DefaultNumSteps
 	const (
 		homeTries = "ensemble-mean home tries"
@@ -109,42 +132,42 @@ func ObservedBehaviour() []cardgen.Claim {
 	)
 
 	// --- Headline: earlier home substitution raises the home try count ---
-	lateHomeTries := meanFinal(homeSubsAll(70, DefaultAwaySubMinute), steps, 24, "score_events", 0, nil)
-	earlyHomeTries := meanFinal(homeSubsAll(20, DefaultAwaySubMinute), steps, 24, "score_events", 0, nil)
+	lateHomeTries := meanFinal(build, homeSubsAll(70, DefaultAwaySubMinute), steps, 24, "score_events", 0, nil)
+	earlyHomeTries := meanFinal(build, homeSubsAll(20, DefaultAwaySubMinute), steps, 24, "score_events", 0, nil)
 
 	// --- Decision-path responses (actionable levers) ---
-	lateWinProb := homeWinProbability(homeSubsAll(65, DefaultAwaySubMinute), steps, 60)
-	earlyWinProb := homeWinProbability(homeSubsAll(15, DefaultAwaySubMinute), steps, 60)
+	lateWinProb := homeWinProbability(build, homeSubsAll(65, DefaultAwaySubMinute), steps, 60)
+	earlyWinProb := homeWinProbability(build, homeSubsAll(15, DefaultAwaySubMinute), steps, 60)
 
 	partial := &SubstitutionStrategy{}
 	partial.HomeSubs[0] = 20 // only one home group
 	for g := 0; g < NumPositionGroups; g++ {
 		partial.AwaySubs[g] = DefaultAwaySubMinute
 	}
-	partialTries := meanFinal(partial, steps, 30, "score_events", 0, nil)
-	fullTries := meanFinal(homeSubsAll(20, DefaultAwaySubMinute), steps, 30, "score_events", 0, nil)
+	partialTries := meanFinal(build, partial, steps, 30, "score_events", 0, nil)
+	fullTries := meanFinal(build, homeSubsAll(20, DefaultAwaySubMinute), steps, 30, "score_events", 0, nil)
 
-	lateAwayTries := meanFinal(homeSubsAll(DefaultHomeSubMinute, 70), steps, 30, "score_events", 1, nil)
-	earlyAwayTries := meanFinal(homeSubsAll(DefaultHomeSubMinute, 20), steps, 30, "score_events", 1, nil)
+	lateAwayTries := meanFinal(build, homeSubsAll(DefaultHomeSubMinute, 70), steps, 30, "score_events", 1, nil)
+	earlyAwayTries := meanFinal(build, homeSubsAll(DefaultHomeSubMinute, 20), steps, 30, "score_events", 1, nil)
 
 	// --- Structural-driver responses (non-actionable) ---
 	defaultStrategy := DefaultSubstitutionStrategy(DefaultHomeSubMinute)
 
-	interceptBase := meanFinal(defaultStrategy, steps, 24, "score_events", 0, nil)
-	interceptStrong := meanFinal(defaultStrategy, steps, 24, "score_events", 0, func(g *simulator.ConfigGenerator) {
+	interceptBase := meanFinal(build, defaultStrategy, steps, 24, "score_events", 0, nil)
+	interceptStrong := meanFinal(build, defaultStrategy, steps, 24, "score_events", 0, func(g *simulator.ConfigGenerator) {
 		g.GetPartition("score_rates").Params.Map["coefficients"] = scoreCoeffsWith(func(c []float64) {
 			c[0] = -2.5 // raise home try intercept from -3.0
 		})
 	})
 
-	convBase := meanFinal(defaultStrategy, steps, 24, "match_state", StateIdxHomeScore, nil)
-	convHigh := meanFinal(defaultStrategy, steps, 24, "match_state", StateIdxHomeScore, func(g *simulator.ConfigGenerator) {
+	convBase := meanFinal(build, defaultStrategy, steps, 24, "match_state", StateIdxHomeScore, nil)
+	convHigh := meanFinal(build, defaultStrategy, steps, 24, "match_state", StateIdxHomeScore, func(g *simulator.ConfigGenerator) {
 		g.GetPartition("conversion_events").Params.Map["conversion_probs"] = []float64{0.98, DefaultAwayConversionProb}
 	})
 
 	subEffectStrategy := homeSubsAll(20, DefaultAwaySubMinute) // early sub so the boost window is large
-	subEffectBase := meanFinal(subEffectStrategy, steps, 30, "score_events", 0, nil)
-	subEffectStrong := meanFinal(subEffectStrategy, steps, 30, "score_events", 0, func(g *simulator.ConfigGenerator) {
+	subEffectBase := meanFinal(build, subEffectStrategy, steps, 30, "score_events", 0, nil)
+	subEffectStrong := meanFinal(build, subEffectStrategy, steps, 30, "score_events", 0, func(g *simulator.ConfigGenerator) {
 		g.GetPartition("score_rates").Params.Map["coefficients"] = scoreCoeffsWith(func(c []float64) {
 			for j := 1; j <= NumPositionGroups; j++ {
 				c[j] = 0.4 // stronger home try covariate effect (from 0.15)
@@ -153,11 +176,11 @@ func ObservedBehaviour() []cardgen.Claim {
 	})
 
 	symmetric := homeSubsAll(DefaultHomeSubMinute, DefaultHomeSubMinute)
-	symHomeTries := meanFinal(symmetric, steps, 40, "score_events", 0, nil)
-	symAwayTries := meanFinal(symmetric, steps, 40, "score_events", 1, nil)
+	symHomeTries := meanFinal(build, symmetric, steps, 40, "score_events", 0, nil)
+	symAwayTries := meanFinal(build, symmetric, steps, 40, "score_events", 1, nil)
 
-	cardBase := meanFinal(defaultStrategy, steps, 30, "card_events", 0, nil)
-	cardStrict := meanFinal(defaultStrategy, steps, 30, "card_events", 0, func(g *simulator.ConfigGenerator) {
+	cardBase := meanFinal(build, defaultStrategy, steps, 30, "card_events", 0, nil)
+	cardStrict := meanFinal(build, defaultStrategy, steps, 30, "card_events", 0, func(g *simulator.ConfigGenerator) {
 		c := DefaultCardCoefficients()
 		c[0] = -3.3 // raise home yellow intercept from -4.5
 		g.GetPartition("card_rates").Params.Map["coefficients"] = c

--- a/models/trywizard/declarative.yaml
+++ b/models/trywizard/declarative.yaml
@@ -7,13 +7,9 @@
 # (substitution strategy, horizon, seed) are injected by the caller; everything below is the
 # model.
 #
-# Seven of the eight partitions are expressions. match_state is declared here for its wiring
-# and params but carries NO expression entry: it reads the card_events history ten steps back
-# to age out yellow cards, and the DSL only ever exposes a partition's current row (an
-# upstreams alias is RawRowView(0)). Its one Go function value is attached by the caller —
-# that lag-10 read is the single thing here that is not sayable as data.
+# All eight partitions are expressions: the model is entirely data, with no Go left in it.
 #
-# Two departures from stub.go's params, both replacing something the Go carries as structure
+# Three departures from stub.go's params, each replacing something the Go carries as structure
 # rather than as data:
 #
 #   sub_minutes  stands in for the whole SubstitutionStrategy → GenerateCovariates → replay
@@ -24,10 +20,15 @@
 #   score_prev   is conversion_events' upstreams alias for score_events, replacing the Go's
 #                params_as_partitions index plus a manual row-0 history read. Both are the
 #                same lag-1 read; the alias just names it.
+#   card_hist    is match_state's upstreams alias for card_events, replacing its
+#                params_as_partitions index plus a manual lag-10 history read. lag(card_hist,
+#                10) is that same read, named; see the match_state expression below.
 #
-# The coefficient blocks are indexed longhand because the DSL has no slicing: a channel's
-# nine coefficients sit at a stride-9 offset in one flat vector, and there is no way to say
-# "the nine starting at 18" other than to name them.
+# A channel's nine rate coefficients sit at a stride-9 offset in one flat vector, which
+# slice addresses directly: dot(concat(1, covariates), slice(coefficients, 18, 9)) is the
+# home-penalty channel's whole log-rate. The leading 1 is the design-matrix statement of the
+# intercept — it also makes the evaluator accumulate the sum in exactly the order the Go's
+# loop does, starting from the intercept.
 main:
   partitions:
 
@@ -115,7 +116,7 @@ main:
     seed: 0
 
   # Derived match state: [home_score, away_score, diff, home_active_yellows,
-  # away_active_yellows, half]. Wiring only — the iteration is Go, see the header.
+  # away_active_yellows, half].
   - name: match_state
     params_from_upstream:
       score_values:
@@ -124,8 +125,6 @@ main:
         upstream: conversion_events
       card_values:
         upstream: card_events
-    params_as_partitions:
-      card_partition: [card_events]
     init_state_values: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     state_history_depth: 1
     seed: 0
@@ -146,18 +145,21 @@ main:
     outputs: ["where(sub_minutes > 0 && step >= sub_minutes, 1, 0)"]
 
   - partition: score_rates
-    # One field per channel rather than a single width-4 block: a channel's coefficients can
-    # only be reached by scalar index, so each output has to be written on its own.
+    # One field per channel rather than a single width-4 block, because each channel selects
+    # its own baseline element and so needs its own scalar (hence lazy) guard.
     fields:
     - {name: home_try}
     - {name: away_try}
     - {name: home_penalty}
     - {name: away_penalty}
+    # A channel's log-rate is its nine coefficients against [1, covariates]: the design row
+    # whose leading 1 picks up the intercept.
     bindings:
-    - {name: lr_home_try, expr: "coefficients[0] + coefficients[1] * covariates[0] + coefficients[2] * covariates[1] + coefficients[3] * covariates[2] + coefficients[4] * covariates[3] + coefficients[5] * covariates[4] + coefficients[6] * covariates[5] + coefficients[7] * covariates[6] + coefficients[8] * covariates[7]"}
-    - {name: lr_away_try, expr: "coefficients[9] + coefficients[10] * covariates[0] + coefficients[11] * covariates[1] + coefficients[12] * covariates[2] + coefficients[13] * covariates[3] + coefficients[14] * covariates[4] + coefficients[15] * covariates[5] + coefficients[16] * covariates[6] + coefficients[17] * covariates[7]"}
-    - {name: lr_home_penalty, expr: "coefficients[18] + coefficients[19] * covariates[0] + coefficients[20] * covariates[1] + coefficients[21] * covariates[2] + coefficients[22] * covariates[3] + coefficients[23] * covariates[4] + coefficients[24] * covariates[5] + coefficients[25] * covariates[6] + coefficients[26] * covariates[7]"}
-    - {name: lr_away_penalty, expr: "coefficients[27] + coefficients[28] * covariates[0] + coefficients[29] * covariates[1] + coefficients[30] * covariates[2] + coefficients[31] * covariates[3] + coefficients[32] * covariates[4] + coefficients[33] * covariates[5] + coefficients[34] * covariates[6] + coefficients[35] * covariates[7]"}
+    - {name: design, expr: "concat(1, covariates)"}
+    - {name: lr_home_try, expr: "dot(design, slice(coefficients, 0, 9))"}
+    - {name: lr_away_try, expr: "dot(design, slice(coefficients, 9, 9))"}
+    - {name: lr_home_penalty, expr: "dot(design, slice(coefficients, 18, 9))"}
+    - {name: lr_away_penalty, expr: "dot(design, slice(coefficients, 27, 9))"}
     # A zero baseline entry means "no baseline", not "a rate of zero", so it multiplies only
     # where it is positive. The guard is scalar, hence lazy.
     outputs:
@@ -171,8 +173,9 @@ main:
     - {name: home_yellow}
     - {name: away_yellow}
     bindings:
-    - {name: lr_home_yellow, expr: "coefficients[0] + coefficients[1] * covariates[0] + coefficients[2] * covariates[1] + coefficients[3] * covariates[2] + coefficients[4] * covariates[3] + coefficients[5] * covariates[4] + coefficients[6] * covariates[5] + coefficients[7] * covariates[6] + coefficients[8] * covariates[7]"}
-    - {name: lr_away_yellow, expr: "coefficients[9] + coefficients[10] * covariates[0] + coefficients[11] * covariates[1] + coefficients[12] * covariates[2] + coefficients[13] * covariates[3] + coefficients[14] * covariates[4] + coefficients[15] * covariates[5] + coefficients[16] * covariates[6] + coefficients[17] * covariates[7]"}
+    - {name: design, expr: "concat(1, covariates)"}
+    - {name: lr_home_yellow, expr: "dot(design, slice(coefficients, 0, 9))"}
+    - {name: lr_away_yellow, expr: "dot(design, slice(coefficients, 9, 9))"}
     # The card channels sit after the four score channels in the shared baseline vector.
     outputs:
     - "where(baseline[4] > 0, baseline[4] * exp(lr_home_yellow), exp(lr_home_yellow))"
@@ -208,3 +211,34 @@ main:
     outputs:
     - "home_conv + home_hits"
     - "away_conv + away_hits"
+
+  # The three event streams arrive within-step as params_from_upstream, exactly as they do in
+  # the Go, so every output here is derived rather than accumulated.
+  - partition: match_state
+    fields:
+    - {name: home_score}
+    - {name: away_score}
+    - {name: score_diff}
+    - {name: home_active_yellow}
+    - {name: away_active_yellow}
+    - {name: half}
+    upstreams:
+      card_hist: card_events
+    bindings:
+    # 5 for a try, 2 for its conversion, 3 for a penalty — the sport's rules, carried as
+    # literals exactly as the Go carries them.
+    - {name: home_points, expr: "score_values[0] * 5 + conversion_values[0] * 2 + score_values[2] * 3"}
+    - {name: away_points, expr: "score_values[1] * 5 + conversion_values[1] * 2 + score_values[3] * 3"}
+    # Yellow cards expire after ten minutes and card_values is cumulative, so the cards still
+    # active are the ones accumulated since the row ten steps back. This is the read the DSL
+    # could not make until lag existed: card_hist alone is row 0. card_events keeps
+    # state_history_depth 11 for it — one row per minute of the window, plus the row itself.
+    - {name: cards_ten_back, expr: "lag(card_hist, 10)"}
+    outputs:
+    - "home_points"
+    - "away_points"
+    - "home_points - away_points"
+    - "card_values[0] - cards_ten_back[0]"
+    - "card_values[1] - cards_ten_back[1]"
+    # Second half from the 40th minute on.
+    - "where(t >= 40, 1, 0)"

--- a/models/trywizard/declarative.yaml
+++ b/models/trywizard/declarative.yaml
@@ -1,0 +1,218 @@
+# The rugby-match generative core, written as data: no Go, no compilation.
+#
+# This is the same model buildStubWithStrategy assembles in stub.go, with the same partition
+# names, param keys, state layout and wiring, so the two can be compared directly (see
+# expression_equivalence_test.go, which checks per-step agreement and re-runs the whole
+# behaviour suite against this file). The run knobs the Go builder takes as arguments
+# (substitution strategy, horizon, seed) are injected by the caller; everything below is the
+# model.
+#
+# Seven of the eight partitions are expressions. match_state is declared here for its wiring
+# and params but carries NO expression entry: it reads the card_events history ten steps back
+# to age out yellow cards, and the DSL only ever exposes a partition's current row (an
+# upstreams alias is RawRowView(0)). Its one Go function value is attached by the caller —
+# that lag-10 read is the single thing here that is not sayable as data.
+#
+# Two departures from stub.go's params, both replacing something the Go carries as structure
+# rather than as data:
+#
+#   sub_minutes  stands in for the whole SubstitutionStrategy → GenerateCovariates → replay
+#                path. The Go pre-computes an nSteps+1 row covariate matrix and streams it;
+#                the rule it bakes in (a group's covariate switches on at its minute, and
+#                minute 0 means never) is one expression, so the matrix — and the need to
+#                know nSteps up front — disappears.
+#   score_prev   is conversion_events' upstreams alias for score_events, replacing the Go's
+#                params_as_partitions index plus a manual row-0 history read. Both are the
+#                same lag-1 read; the alias just names it.
+#
+# The coefficient blocks are indexed longhand because the DSL has no slicing: a channel's
+# nine coefficients sit at a stride-9 offset in one flat vector, and there is no way to say
+# "the nine starting at 18" other than to name them.
+main:
+  partitions:
+
+  # Constant zero baseline, so the rate channels fall back to exp(intercept + covariates).
+  # The downstream's kernel-smoothed time-varying baseline is a data-fitting concern.
+  - name: baseline_rates
+    params:
+      param_values: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    init_state_values: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    state_width: 6
+    state_history_depth: 1
+    seed: 0
+
+  # Per-minute binary substitution covariates: [home ×4 position groups, away ×4].
+  - name: sub_covariates
+    params:
+      sub_minutes: [55.0, 55.0, 55.0, 55.0, 55.0, 55.0, 55.0, 55.0]
+    init_state_values: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    state_width: 8
+    state_history_depth: 1
+    seed: 0
+
+  # Log-linear try/penalty rates: [home_try, away_try, home_penalty, away_penalty].
+  - name: score_rates
+    params:
+      coefficients: [
+        -3.0, 0.15, 0.15, 0.15, 0.15, 0.0, 0.0, 0.0, 0.0,
+        -3.1, 0.0, 0.0, 0.0, 0.0, 0.15, 0.15, 0.15, 0.15,
+        -3.5, 0.05, 0.05, 0.05, 0.05, 0.0, 0.0, 0.0, 0.0,
+        -3.6, 0.0, 0.0, 0.0, 0.0, 0.05, 0.05, 0.05, 0.05,
+      ]
+    params_from_upstream:
+      covariates:
+        upstream: sub_covariates
+      baseline:
+        upstream: baseline_rates
+    init_state_values: [0.0, 0.0, 0.0, 0.0]
+    state_width: 4
+    state_history_depth: 1
+    seed: 0
+
+  # Log-linear yellow-card rates: [home_yellow, away_yellow]. No substitution effect, so
+  # every covariate coefficient is zero — stated rather than assumed, since the Go carries
+  # the same eight zeros per channel.
+  - name: card_rates
+    params:
+      coefficients: [
+        -4.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        -4.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      ]
+    params_from_upstream:
+      covariates:
+        upstream: sub_covariates
+      baseline:
+        upstream: baseline_rates
+    init_state_values: [0.0, 0.0]
+    state_width: 2
+    state_history_depth: 1
+    seed: 0
+
+  # Cox process over the four score channels, forced within-step by score_rates.
+  - name: score_events
+    params_from_upstream:
+      rates:
+        upstream: score_rates
+    init_state_values: [0.0, 0.0, 0.0, 0.0]
+    state_width: 4
+    state_history_depth: 2
+    seed: 0
+
+  # Cox process over the two card channels. The depth is YellowCardMinutes + 1, because
+  # match_state ages yellow cards out by differencing against the row ten steps back.
+  - name: card_events
+    params_from_upstream:
+      rates:
+        upstream: card_rates
+    init_state_values: [0.0, 0.0]
+    state_width: 2
+    state_history_depth: 11
+    seed: 0
+
+  # One Bernoulli conversion attempt per try scored this step.
+  - name: conversion_events
+    params:
+      conversion_probs: [0.75, 0.72]
+    params_from_upstream:
+      try_values:
+        upstream: score_events
+    init_state_values: [0.0, 0.0]
+    state_width: 2
+    state_history_depth: 1
+    seed: 0
+
+  # Derived match state: [home_score, away_score, diff, home_active_yellows,
+  # away_active_yellows, half]. Wiring only — the iteration is Go, see the header.
+  - name: match_state
+    params_from_upstream:
+      score_values:
+        upstream: score_events
+      conversion_values:
+        upstream: conversion_events
+      card_values:
+        upstream: card_events
+    params_as_partitions:
+      card_partition: [card_events]
+    init_state_values: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    state_width: 6
+    state_history_depth: 1
+    seed: 0
+
+  expressions:
+
+  - partition: baseline_rates
+    fields:
+    - {name: baseline, width: 6}
+    outputs: ["param_values"]
+
+  - partition: sub_covariates
+    fields:
+    - {name: covariates, width: 8}
+    # Minute 0 means "never substitute this group", which is why the guard is not just
+    # step >= sub_minutes. The condition is a vector, so both branches are evaluated — free
+    # here, as neither draws.
+    outputs: ["where(sub_minutes > 0 && step >= sub_minutes, 1, 0)"]
+
+  - partition: score_rates
+    # One field per channel rather than a single width-4 block: a channel's coefficients can
+    # only be reached by scalar index, so each output has to be written on its own.
+    fields:
+    - {name: home_try}
+    - {name: away_try}
+    - {name: home_penalty}
+    - {name: away_penalty}
+    bindings:
+    - {name: lr_home_try, expr: "coefficients[0] + coefficients[1] * covariates[0] + coefficients[2] * covariates[1] + coefficients[3] * covariates[2] + coefficients[4] * covariates[3] + coefficients[5] * covariates[4] + coefficients[6] * covariates[5] + coefficients[7] * covariates[6] + coefficients[8] * covariates[7]"}
+    - {name: lr_away_try, expr: "coefficients[9] + coefficients[10] * covariates[0] + coefficients[11] * covariates[1] + coefficients[12] * covariates[2] + coefficients[13] * covariates[3] + coefficients[14] * covariates[4] + coefficients[15] * covariates[5] + coefficients[16] * covariates[6] + coefficients[17] * covariates[7]"}
+    - {name: lr_home_penalty, expr: "coefficients[18] + coefficients[19] * covariates[0] + coefficients[20] * covariates[1] + coefficients[21] * covariates[2] + coefficients[22] * covariates[3] + coefficients[23] * covariates[4] + coefficients[24] * covariates[5] + coefficients[25] * covariates[6] + coefficients[26] * covariates[7]"}
+    - {name: lr_away_penalty, expr: "coefficients[27] + coefficients[28] * covariates[0] + coefficients[29] * covariates[1] + coefficients[30] * covariates[2] + coefficients[31] * covariates[3] + coefficients[32] * covariates[4] + coefficients[33] * covariates[5] + coefficients[34] * covariates[6] + coefficients[35] * covariates[7]"}
+    # A zero baseline entry means "no baseline", not "a rate of zero", so it multiplies only
+    # where it is positive. The guard is scalar, hence lazy.
+    outputs:
+    - "where(baseline[0] > 0, baseline[0] * exp(lr_home_try), exp(lr_home_try))"
+    - "where(baseline[1] > 0, baseline[1] * exp(lr_away_try), exp(lr_away_try))"
+    - "where(baseline[2] > 0, baseline[2] * exp(lr_home_penalty), exp(lr_home_penalty))"
+    - "where(baseline[3] > 0, baseline[3] * exp(lr_away_penalty), exp(lr_away_penalty))"
+
+  - partition: card_rates
+    fields:
+    - {name: home_yellow}
+    - {name: away_yellow}
+    bindings:
+    - {name: lr_home_yellow, expr: "coefficients[0] + coefficients[1] * covariates[0] + coefficients[2] * covariates[1] + coefficients[3] * covariates[2] + coefficients[4] * covariates[3] + coefficients[5] * covariates[4] + coefficients[6] * covariates[5] + coefficients[7] * covariates[6] + coefficients[8] * covariates[7]"}
+    - {name: lr_away_yellow, expr: "coefficients[9] + coefficients[10] * covariates[0] + coefficients[11] * covariates[1] + coefficients[12] * covariates[2] + coefficients[13] * covariates[3] + coefficients[14] * covariates[4] + coefficients[15] * covariates[5] + coefficients[16] * covariates[6] + coefficients[17] * covariates[7]"}
+    # The card channels sit after the four score channels in the shared baseline vector.
+    outputs:
+    - "where(baseline[4] > 0, baseline[4] * exp(lr_home_yellow), exp(lr_home_yellow))"
+    - "where(baseline[5] > 0, baseline[5] * exp(lr_away_yellow), exp(lr_away_yellow))"
+
+  # Cox thinning, one uniform per channel per step, in channel order — which is what keeps
+  # this partition's draw stream identical to the engine's CoxProcessIteration rather than
+  # merely identically distributed.
+  - partition: score_events
+    fields:
+    - {name: counts, width: 4}
+    outputs: ["counts + where(rates > (rates + 1 / dt) * iid(4, uniform(0, 1)), 1, 0)"]
+
+  - partition: card_events
+    fields:
+    - {name: counts, width: 2}
+    outputs: ["counts + where(rates > (rates + 1 / dt) * iid(2, uniform(0, 1)), 1, 0)"]
+
+  - partition: conversion_events
+    fields:
+    - {name: home_conv}
+    - {name: away_conv}
+    upstreams:
+      score_prev: score_events
+    bindings:
+    - {name: new_home, expr: "try_values[0] - score_prev[0]"}
+    - {name: new_away, expr: "try_values[1] - score_prev[1]"}
+    # One trial per new try, home before away. The outer guard is scalar and so lazy, which
+    # both keeps iid off its illegal zero count and — the point — draws nothing at all on a
+    # step with no tries, exactly as the Go loop does not.
+    - {name: home_hits, expr: "where(new_home > 0, sum(iid(new_home, where(uniform(0, 1) < conversion_probs[0], 1, 0))), 0)"}
+    - {name: away_hits, expr: "where(new_away > 0, sum(iid(new_away, where(uniform(0, 1) < conversion_probs[1], 1, 0))), 0)"}
+    outputs:
+    - "home_conv + home_hits"
+    - "away_conv + away_hits"

--- a/models/trywizard/declarative.yaml
+++ b/models/trywizard/declarative.yaml
@@ -37,7 +37,6 @@ main:
     params:
       param_values: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     init_state_values: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-    state_width: 6
     state_history_depth: 1
     seed: 0
 
@@ -46,7 +45,6 @@ main:
     params:
       sub_minutes: [55.0, 55.0, 55.0, 55.0, 55.0, 55.0, 55.0, 55.0]
     init_state_values: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-    state_width: 8
     state_history_depth: 1
     seed: 0
 
@@ -65,7 +63,6 @@ main:
       baseline:
         upstream: baseline_rates
     init_state_values: [0.0, 0.0, 0.0, 0.0]
-    state_width: 4
     state_history_depth: 1
     seed: 0
 
@@ -84,7 +81,6 @@ main:
       baseline:
         upstream: baseline_rates
     init_state_values: [0.0, 0.0]
-    state_width: 2
     state_history_depth: 1
     seed: 0
 
@@ -94,7 +90,6 @@ main:
       rates:
         upstream: score_rates
     init_state_values: [0.0, 0.0, 0.0, 0.0]
-    state_width: 4
     state_history_depth: 2
     seed: 0
 
@@ -105,7 +100,6 @@ main:
       rates:
         upstream: card_rates
     init_state_values: [0.0, 0.0]
-    state_width: 2
     state_history_depth: 11
     seed: 0
 
@@ -117,7 +111,6 @@ main:
       try_values:
         upstream: score_events
     init_state_values: [0.0, 0.0]
-    state_width: 2
     state_history_depth: 1
     seed: 0
 
@@ -134,7 +127,6 @@ main:
     params_as_partitions:
       card_partition: [card_events]
     init_state_values: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-    state_width: 6
     state_history_depth: 1
     seed: 0
 

--- a/models/trywizard/expression_equivalence_test.go
+++ b/models/trywizard/expression_equivalence_test.go
@@ -20,11 +20,10 @@ package rugby
 // free to contract a + b*c into a fused multiply-add, which rounds differently from the
 // evaluator's separate operations.
 //
-// match_state has no step-for-step test because it has no declarative form: it reads the
-// card_events history ten rows back and the DSL exposes only the current row. The suite
-// test still covers it — the claims that read match_state (win probability, home score)
-// run through the same Go function value in both builds, over declaratively-generated
-// inputs.
+// Every partition is compared, match_state included: its lag-10 read of the card_events
+// history — once the one thing here with no declarative form, since an upstreams alias only
+// ever gives row 0 — is now lag(card_hist, 10), so the declarative build carries no Go at
+// all.
 
 import (
 	"math"
@@ -58,10 +57,8 @@ func subMinutes(strategy *SubstitutionStrategy) []float64 {
 // declarativeBuildStub assembles the model from declarative.yaml, matching
 // buildStubWithStrategy's signature so it can be dropped into the behaviour helpers. The
 // YAML holds the model; the run knobs the Go builder takes as arguments are injected here,
-// exactly as it injects them into its Go partitions.
-//
-// match_state is the one partition the YAML cannot carry, so its Go function value is
-// attached here — see the file header.
+// exactly as it injects them into its Go partitions. No iteration is attached: every
+// partition, match_state included, comes out of the file.
 func declarativeBuildStub(
 	strategy *SubstitutionStrategy,
 	numSteps int,
@@ -81,9 +78,6 @@ func declarativeBuildStub(
 	gen.GetPartition("score_events").Seed = seed
 	gen.GetPartition("card_events").Seed = seed + 1
 	gen.GetPartition("conversion_events").Seed = seed + 2
-	matchState := gen.GetPartition("match_state")
-	matchState.Iteration = &general.ValuesFunctionIteration{Function: MatchStateFunction}
-	gen.ResetPartition("match_state", matchState)
 	return gen
 }
 
@@ -450,6 +444,157 @@ func TestDeclarativeConversionsMatchBespoke(t *testing.T) {
 	}
 	for _, b := range []string{
 		"no_new_tries", "new_tries", "conversion_made", "conversion_missed",
+	} {
+		if branches[b] == 0 {
+			t.Errorf("branch %q never exercised; the comparison is weaker than it looks", b)
+		}
+	}
+	t.Logf("branches exercised: %v", branches)
+	t.Logf("max deviation: %g", maxDev)
+}
+
+// cardHistory builds card_events' cumulative history: depth rows of two non-decreasing
+// counts, newest first, so row r is the total r steps ago. Increments are drawn per row and
+// per channel, which is what makes the rows differ — a history that were flat across the
+// window would agree with any lag offset at all and so pin nothing.
+func cardHistory(rng *rand.Rand, depth int) *simulator.StateHistory {
+	rows := mat.NewDense(depth, CardRateWidth, nil)
+	total := make([]float64, CardRateWidth)
+	for r := depth - 1; r >= 0; r-- {
+		for k := range total {
+			if rng.IntN(3) == 0 {
+				total[k]++
+			}
+		}
+		rows.SetRow(r, total)
+	}
+	return &simulator.StateHistory{
+		Values:            rows,
+		StateWidth:        CardRateWidth,
+		StateHistoryDepth: depth,
+	}
+}
+
+// atTime returns a timesteps history at cumulative time now. match_state reads t rather than
+// the step number, so the two are decoupled here.
+func atTime(now, increment float64, step int) *simulator.CumulativeTimestepsHistory {
+	return &simulator.CumulativeTimestepsHistory{
+		Values:            mat.NewVecDense(1, []float64{now}),
+		NextIncrement:     increment,
+		CurrentStepNumber: step,
+	}
+}
+
+// MatchStateFunction clamps its lookback to historyDepth-1 when a partition keeps fewer rows
+// than the ten-minute window. The clamp is unreachable in this stub's wiring — card_events is
+// built at YellowCardMinutes+1 rows precisely so the window fits — and it has no declarative
+// counterpart, since lag panics rather than silently shortening the read. So the comparison
+// below runs at the model's depth only, and the clamp is deliberately not swept.
+func TestDeclarativeMatchStateMatchesBespoke(t *testing.T) {
+	// Index 1 is card_events: the bespoke function reaches it through the card_partition
+	// param and reads Values.At(10, k) by hand, the declarative one through its card_hist
+	// upstream alias and lag(card_hist, 10). Both are the same read of the same row. The
+	// other three inputs are within-step params_from_upstream on both sides, so they arrive
+	// as params either way.
+	settings := &simulator.Settings{
+		Iterations: []simulator.IterationSettings{
+			{Name: "match_state", Seed: 5},
+			{Name: "card_events", Seed: 0},
+		},
+	}
+	bespoke := &general.ValuesFunctionIteration{Function: MatchStateFunction}
+	declarative, _ := declarativeIteration(t, "match_state")
+	bespoke.Configure(0, settings)
+	declarative.Configure(0, settings)
+
+	rng := rand.New(rand.NewPCG(91, 92))
+	branches := map[string]int{}
+	maxDev := 0.0
+
+	const cases = 20000
+	for i := 0; i < cases; i++ {
+		cards := cardHistory(rng, YellowCardMinutes+1)
+		current := cards.Values.RawRowView(0)
+		// card_values is card_events' within-step output, so it is this step's total: at or
+		// above row 0, which is last step's.
+		cardValues := []float64{
+			current[0] + float64(rng.IntN(2)),
+			current[1] + float64(rng.IntN(2)),
+		}
+		scoreValues := []float64{
+			float64(rng.IntN(6)), float64(rng.IntN(6)),
+			float64(rng.IntN(8)), float64(rng.IntN(8)),
+		}
+		convValues := []float64{
+			float64(rng.IntN(int(scoreValues[0]) + 1)),
+			float64(rng.IntN(int(scoreValues[1]) + 1)),
+		}
+		// Time is swept across the half boundary, and lands exactly on it often enough to pin
+		// the >= rather than a >. The increment does not enter match_state at all — no output
+		// here uses dt — but it is varied anyway so that a twin which had reached for it
+		// would show up.
+		now := float64(rng.IntN(81))
+		if i%7 == 0 {
+			now = 40
+		}
+		increment := []float64{1.0, 0.5, 2.0}[i%3]
+
+		p := simulator.NewParams(map[string][]float64{
+			"score_values":      scoreValues,
+			"conversion_values": convValues,
+			"card_values":       cardValues,
+			"card_partition":    {1},
+		})
+		ts := atTime(now, increment, i+1)
+		mk := func() []*simulator.StateHistory {
+			return []*simulator.StateHistory{
+				history(make([]float64, MatchStateWidth), 1),
+				cards,
+			}
+		}
+
+		want := bespoke.Iterate(&p, 0, mk(), ts)
+		wantCopy := append([]float64(nil), want...)
+		got := declarative.Iterate(&p, 0, mk(), ts)
+
+		if now >= 40 {
+			branches["second_half"]++
+		} else {
+			branches["first_half"]++
+		}
+		switch {
+		case wantCopy[StateIdxScoreDiff] > 0:
+			branches["home_leading"]++
+		case wantCopy[StateIdxScoreDiff] < 0:
+			branches["away_leading"]++
+		default:
+			branches["scores_level"]++
+		}
+		for k, idx := range []int{StateIdxHomeActiveYellow, StateIdxAwayActiveYellow} {
+			if wantCopy[idx] > 0 {
+				branches["yellow_active"]++
+			} else {
+				branches["no_active_yellow"]++
+			}
+			// A card that has left the window: the row ten back is non-zero, so the lag term
+			// is load-bearing rather than a subtraction of zero.
+			if cards.Values.At(YellowCardMinutes, k) > 0 {
+				branches["yellow_aged_out"]++
+			}
+			// The rows either side of the window differ, so reading one row too few or too
+			// many would give a different answer here.
+			if cards.Values.At(YellowCardMinutes, k) !=
+				cards.Values.At(YellowCardMinutes-1, k) {
+				branches["window_edge_pinned"]++
+			}
+		}
+		for k := range wantCopy {
+			maxDev = math.Max(maxDev, assertClose(t, got[k], wantCopy[k], "match_state"))
+		}
+	}
+	for _, b := range []string{
+		"first_half", "second_half", "home_leading", "away_leading", "scores_level",
+		"yellow_active", "no_active_yellow", "yellow_aged_out", "window_edge_pinned",
 	} {
 		if branches[b] == 0 {
 			t.Errorf("branch %q never exercised; the comparison is weaker than it looks", b)

--- a/models/trywizard/expression_equivalence_test.go
+++ b/models/trywizard/expression_equivalence_test.go
@@ -1,0 +1,496 @@
+package rugby
+
+// Does declarative.yaml — this model written as data — reproduce the model stub.go builds
+// in code?
+//
+// Two independent checks, because they fail in different ways. The step-for-step tests
+// compare single Iterate calls over randomised inputs, which catches a mis-stated formula
+// exactly. The suite test re-runs the model's own claim computations against the
+// declarative build, which catches a model that is subtly different in a way per-step
+// agreement would not: wrong wiring, wrong param values, wrong state layout.
+//
+// Every stochastic partition here draws from a stream seeded exactly as the declarative one
+// is (rng.New(seed) and rand.New(rand.NewPCG(seed, seed)) are the same generator), and takes
+// the same number of draws in the same order per step, so the two stay in lockstep and
+// equivalence is decidable directly rather than only in distribution. Two facts make that
+// possible: sampler.Uniform(0, 1) is Float64()*(1-0)+0, i.e. exactly the Float64() the Cox
+// process and the conversion iteration draw; and iid(n, ...) evaluates its expression n
+// times in order, which is the same n draws in the same order as the Go loops it stands in
+// for. Agreement is asserted to a tight tolerance rather than bit-for-bit: compiled Go is
+// free to contract a + b*c into a fused multiply-add, which rounds differently from the
+// evaluator's separate operations.
+//
+// match_state has no step-for-step test because it has no declarative form: it reads the
+// card_events history ten rows back and the DSL exposes only the current row. The suite
+// test still covers it — the claims that read match_state (win probability, home score)
+// run through the same Go function value in both builds, over declaratively-generated
+// inputs.
+
+import (
+	"math"
+	"math/rand/v2"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+
+	"github.com/umbralcalc/stochadex/models/cardgen"
+	"github.com/umbralcalc/stochadex/pkg/api"
+	"github.com/umbralcalc/stochadex/pkg/discrete"
+	"github.com/umbralcalc/stochadex/pkg/general"
+	"github.com/umbralcalc/stochadex/pkg/simulator"
+)
+
+// tolerance is well above FMA rounding and well below any difference a real modelling
+// discrepancy would produce.
+const tolerance = 1e-12
+
+// subMinutes flattens a strategy into the sub_minutes param: the four home groups followed
+// by the four away groups, which is the covariate layout the rate coefficients index.
+func subMinutes(strategy *SubstitutionStrategy) []float64 {
+	minutes := make([]float64, SubCovWidth)
+	for g := 0; g < NumPositionGroups; g++ {
+		minutes[g] = float64(strategy.HomeSubs[g])
+		minutes[NumPositionGroups+g] = float64(strategy.AwaySubs[g])
+	}
+	return minutes
+}
+
+// declarativeBuildStub assembles the model from declarative.yaml, matching
+// buildStubWithStrategy's signature so it can be dropped into the behaviour helpers. The
+// YAML holds the model; the run knobs the Go builder takes as arguments are injected here,
+// exactly as it injects them into its Go partitions.
+//
+// match_state is the one partition the YAML cannot carry, so its Go function value is
+// attached here — see the file header.
+func declarativeBuildStub(
+	strategy *SubstitutionStrategy,
+	numSteps int,
+	seed uint64,
+) *simulator.ConfigGenerator {
+	config := api.LoadApiRunConfigFromYaml("declarative.yaml")
+	config.Main.Simulation = simulator.SimulationConfig{
+		OutputCondition: &simulator.EveryStepOutputCondition{},
+		TerminationCondition: &simulator.NumberOfStepsTerminationCondition{
+			MaxNumberOfSteps: numSteps,
+		},
+		TimestepFunction: &simulator.ConstantTimestepFunction{Stepsize: stepSizeMinutes},
+		InitTimeValue:    0.0,
+	}
+	gen := config.Main.GetConfigGenerator()
+	gen.GetPartition("sub_covariates").Params.Map["sub_minutes"] = subMinutes(strategy)
+	gen.GetPartition("score_events").Seed = seed
+	gen.GetPartition("card_events").Seed = seed + 1
+	gen.GetPartition("conversion_events").Seed = seed + 2
+	matchState := gen.GetPartition("match_state")
+	matchState.Iteration = &general.ValuesFunctionIteration{Function: MatchStateFunction}
+	gen.ResetPartition("match_state", matchState)
+	return gen
+}
+
+// declarativeIteration returns the expression iteration the YAML supplies for a partition,
+// alongside the params it declares.
+func declarativeIteration(
+	t *testing.T,
+	partition string,
+) (*general.ExpressionIteration, map[string][]float64) {
+	t.Helper()
+	config := declarativeBuildStub(
+		DefaultSubstitutionStrategy(DefaultHomeSubMinute),
+		DefaultNumSteps,
+		0,
+	).GetPartition(partition)
+	iteration, ok := config.Iteration.(*general.ExpressionIteration)
+	if !ok {
+		t.Fatalf("%s is not expression-backed: got %T", partition, config.Iteration)
+	}
+	return iteration, config.Params.Map
+}
+
+// assertClose fails when two values differ by more than the FMA-scale tolerance, comparing
+// relatively once the magnitude exceeds 1.
+func assertClose(t *testing.T, got, want float64, context string) float64 {
+	t.Helper()
+	d := math.Abs(got - want)
+	if s := math.Abs(want); s > 1 {
+		d /= s
+	}
+	if d > tolerance {
+		t.Fatalf("%s: declarative=%v bespoke=%v deviation=%g", context, got, want, d)
+	}
+	return d
+}
+
+// singleIteration is a settings block for comparing one partition in isolation, seeded so
+// both sides build the same generator.
+func singleIteration(name string, seed uint64) *simulator.Settings {
+	return &simulator.Settings{
+		Iterations: []simulator.IterationSettings{{Name: name, Seed: seed}},
+	}
+}
+
+// history wraps one row of state as a partition's history, fresh per call so that neither
+// iteration can see the other's writes.
+func history(values []float64, depth int) *simulator.StateHistory {
+	rows := mat.NewDense(depth, len(values), nil)
+	rows.SetRow(0, values)
+	return &simulator.StateHistory{
+		Values:            rows,
+		StateWidth:        len(values),
+		StateHistoryDepth: depth,
+	}
+}
+
+// steps returns a timesteps history positioned at step number i with the given increment.
+func steps(i int, increment float64) *simulator.CumulativeTimestepsHistory {
+	return &simulator.CumulativeTimestepsHistory{
+		Values:            mat.NewVecDense(1, []float64{float64(i)}),
+		NextIncrement:     increment,
+		CurrentStepNumber: i,
+	}
+}
+
+func TestDeclarativeSubCovariatesMatchBespoke(t *testing.T) {
+	declarative, _ := declarativeIteration(t, "sub_covariates")
+	declarative.Configure(0, singleIteration("sub_covariates", 5))
+
+	rng := rand.New(rand.NewPCG(31, 32))
+	branches := map[string]int{}
+	maxDev := 0.0
+
+	const cases = 400
+	for c := 0; c < cases; c++ {
+		// Minute 0 means "never substitute this group", which is a different branch from a
+		// minute the match simply has not reached yet, so both are drawn here.
+		strategy := &SubstitutionStrategy{}
+		for g := 0; g < NumPositionGroups; g++ {
+			if rng.IntN(4) > 0 {
+				strategy.HomeSubs[g] = rng.IntN(DefaultNumSteps)
+			}
+			if rng.IntN(4) > 0 {
+				strategy.AwaySubs[g] = rng.IntN(DefaultNumSteps)
+			}
+		}
+		minutes := subMinutes(strategy)
+		p := simulator.NewParams(map[string][]float64{"sub_minutes": minutes})
+		bespoke := &general.FromStorageIteration{
+			Data: strategy.GenerateCovariates(DefaultNumSteps + 1),
+		}
+		bespoke.Configure(0, singleIteration("sub_covariates", 5))
+
+		for step := 1; step <= DefaultNumSteps; step++ {
+			ts := steps(step, stepSizeMinutes)
+			want := bespoke.Iterate(&p, 0,
+				[]*simulator.StateHistory{history(make([]float64, SubCovWidth), 1)}, ts)
+			got := declarative.Iterate(&p, 0,
+				[]*simulator.StateHistory{history(make([]float64, SubCovWidth), 1)}, ts)
+
+			for k := range want {
+				switch {
+				case minutes[k] == 0:
+					branches["never_substituted"]++
+				case float64(step) < minutes[k]:
+					branches["before_minute"]++
+				default:
+					branches["after_minute"]++
+				}
+				maxDev = math.Max(maxDev, assertClose(t, got[k], want[k], "covariate"))
+			}
+		}
+	}
+	for _, b := range []string{"never_substituted", "before_minute", "after_minute"} {
+		if branches[b] == 0 {
+			t.Errorf("branch %q never exercised; the comparison is weaker than it looks", b)
+		}
+	}
+	t.Logf("branches exercised: %v", branches)
+	t.Logf("max deviation: %g", maxDev)
+}
+
+// rateCase draws a randomised log-linear rate problem: coefficients for width channels, the
+// eight substitution covariates, and a baseline that is zero often enough to sweep both
+// sides of the per-channel baseline guard.
+func rateCase(
+	rng *rand.Rand,
+	width int,
+) (coefficients, covariates, baseline []float64) {
+	coefficients = make([]float64, width*CoeffsPerRate)
+	for i := range coefficients {
+		coefficients[i] = rng.Float64()*6 - 4
+	}
+	covariates = make([]float64, SubCovWidth)
+	for i := range covariates {
+		// Binary in the model proper, but continuous values are drawn too: they make a
+		// dropped or misplaced coefficient visible, which a 0/1 covariate can hide.
+		if rng.IntN(2) == 0 {
+			covariates[i] = float64(rng.IntN(2))
+		} else {
+			covariates[i] = rng.Float64() * 2
+		}
+	}
+	baseline = make([]float64, RateEventWidth)
+	for i := range baseline {
+		if rng.IntN(2) == 0 {
+			baseline[i] = rng.Float64() * 3
+		}
+	}
+	return coefficients, covariates, baseline
+}
+
+// assertRatesMatch compares a rate partition against its bespoke rate function, counting
+// how often each side of the baseline guard is taken over the channels at baseOffset.
+func assertRatesMatch(
+	t *testing.T,
+	partition string,
+	function func(
+		params *simulator.Params,
+		partitionIndex int,
+		stateHistories []*simulator.StateHistory,
+		timestepsHistory *simulator.CumulativeTimestepsHistory,
+	) []float64,
+	width, baseOffset int,
+	seed uint64,
+) {
+	t.Helper()
+	bespoke := &general.ValuesFunctionIteration{Function: function}
+	declarative, _ := declarativeIteration(t, partition)
+	settings := singleIteration(partition, 5)
+	bespoke.Configure(0, settings)
+	declarative.Configure(0, settings)
+
+	rng := rand.New(rand.NewPCG(seed, seed+1))
+	branches := map[string]int{}
+	maxDev := 0.0
+
+	const cases = 5000
+	for i := 0; i < cases; i++ {
+		coefficients, covariates, baseline := rateCase(rng, width)
+		p := simulator.NewParams(map[string][]float64{
+			"coefficients": coefficients,
+			"covariates":   covariates,
+			"baseline":     baseline,
+		})
+		ts := steps(i+1, stepSizeMinutes)
+		want := function(&p, 0, []*simulator.StateHistory{history(make([]float64, width), 1)}, ts)
+		got := declarative.Iterate(&p, 0,
+			[]*simulator.StateHistory{history(make([]float64, width), 1)}, ts)
+
+		for k := 0; k < width; k++ {
+			if baseline[baseOffset+k] > 0 {
+				branches["baseline_applied"]++
+			} else {
+				branches["no_baseline"]++
+			}
+			maxDev = math.Max(maxDev, assertClose(t, got[k], want[k], partition))
+		}
+	}
+	for _, b := range []string{"baseline_applied", "no_baseline"} {
+		if branches[b] == 0 {
+			t.Errorf("branch %q never exercised; the comparison is weaker than it looks", b)
+		}
+	}
+	t.Logf("%s branches exercised: %v", partition, branches)
+	t.Logf("%s max deviation: %g", partition, maxDev)
+}
+
+// The intercept-only and no-baseline fallbacks inside computeRates dispatch on the LENGTH of
+// the coefficient and baseline vectors, which the declarative model fixes by construction
+// (36 or 18 coefficients, a 6-wide baseline from upstream). They are unreachable in this
+// stub's wiring and have no declarative counterpart — the DSL cannot introspect a width —
+// so they are deliberately not swept here.
+func TestDeclarativeScoreRatesMatchBespoke(t *testing.T) {
+	assertRatesMatch(t, "score_rates", ScoreEventRateFunction, ScoreRateWidth, 0, 41)
+}
+
+func TestDeclarativeCardRatesMatchBespoke(t *testing.T) {
+	assertRatesMatch(t, "card_rates", CardEventRateFunction, CardRateWidth, ScoreRateWidth, 51)
+}
+
+// assertCoxMatches compares a Cox-process partition against discrete.CoxProcessIteration.
+// Both are configured at the same seed and draw exactly one uniform per channel per step, so
+// the streams stay aligned across the whole sweep and the thinning decisions must agree
+// case for case, not merely on average.
+func assertCoxMatches(t *testing.T, partition string, width int, seed uint64) {
+	t.Helper()
+	bespoke := &discrete.CoxProcessIteration{}
+	declarative, _ := declarativeIteration(t, partition)
+	settings := singleIteration(partition, 5)
+	bespoke.Configure(0, settings)
+	declarative.Configure(0, settings)
+
+	rng := rand.New(rand.NewPCG(seed, seed+1))
+	branches := map[string]int{}
+	maxDev := 0.0
+
+	const cases = 20000
+	counts := make([]float64, width)
+	for i := 0; i < cases; i++ {
+		rates := make([]float64, width)
+		for k := range rates {
+			// Spanning rates that almost never fire and rates that almost always do, so the
+			// thinning threshold is compared across its whole range rather than in the tail
+			// the calibrated intercepts happen to sit in.
+			rates[k] = math.Exp(rng.Float64()*6 - 5)
+		}
+		// The increment enters the threshold as 1/dt, so it is varied rather than pinned at
+		// the model's one minute.
+		increment := []float64{1.0, 0.5, 2.0}[i%3]
+		p := simulator.NewParams(map[string][]float64{"rates": rates})
+		ts := steps(i+1, increment)
+
+		want := bespoke.Iterate(&p, 0, []*simulator.StateHistory{history(counts, 2)}, ts)
+		wantCopy := append([]float64(nil), want...)
+		got := declarative.Iterate(&p, 0, []*simulator.StateHistory{history(counts, 2)}, ts)
+
+		for k := 0; k < width; k++ {
+			if wantCopy[k] > counts[k] {
+				branches["event_fired"]++
+			} else {
+				branches["no_event"]++
+			}
+			maxDev = math.Max(maxDev, assertClose(t, got[k], wantCopy[k], partition))
+		}
+		copy(counts, wantCopy)
+	}
+	for _, b := range []string{"event_fired", "no_event"} {
+		if branches[b] == 0 {
+			t.Errorf("branch %q never exercised; the comparison is weaker than it looks", b)
+		}
+	}
+	t.Logf("%s branches exercised: %v", partition, branches)
+	t.Logf("%s max deviation: %g", partition, maxDev)
+}
+
+func TestDeclarativeScoreEventsMatchBespoke(t *testing.T) {
+	assertCoxMatches(t, "score_events", ScoreRateWidth, 61)
+}
+
+func TestDeclarativeCardEventsMatchBespoke(t *testing.T) {
+	assertCoxMatches(t, "card_events", CardRateWidth, 71)
+}
+
+func TestDeclarativeConversionsMatchBespoke(t *testing.T) {
+	// Index 1 is score_events: the bespoke iteration finds it through the
+	// score_events_partition param, the declarative one through its score_prev upstream
+	// alias. Both are the same lag-1 read of the same partition.
+	settings := &simulator.Settings{
+		Iterations: []simulator.IterationSettings{
+			{
+				Name: "conversion_events",
+				Seed: 5,
+				Params: simulator.NewParams(map[string][]float64{
+					"score_events_partition": {1},
+				}),
+			},
+			{Name: "score_events", Seed: 0},
+		},
+	}
+	bespoke := &ConversionIteration{}
+	declarative, _ := declarativeIteration(t, "conversion_events")
+	bespoke.Configure(0, settings)
+	declarative.Configure(0, settings)
+
+	rng := rand.New(rand.NewPCG(81, 82))
+	branches := map[string]int{}
+	maxDev := 0.0
+
+	const cases = 20000
+	conv := []float64{0, 0}
+	prevTries := []float64{0, 0, 0, 0}
+	for i := 0; i < cases; i++ {
+		// A step with no tries must draw nothing at all, or every later step is compared
+		// against a stream that has slipped — so the zero case is swept heavily.
+		newHome, newAway := 0, 0
+		if i%3 == 0 {
+			newHome = rng.IntN(3)
+		}
+		if i%4 == 0 {
+			newAway = rng.IntN(3)
+		}
+		tries := []float64{
+			prevTries[0] + float64(newHome),
+			prevTries[1] + float64(newAway),
+			prevTries[2],
+			prevTries[3],
+		}
+		// Probabilities span both extremes so successes and misses both occur.
+		probs := []float64{rng.Float64(), rng.Float64()}
+		p := simulator.NewParams(map[string][]float64{
+			"conversion_probs": probs,
+			"try_values":       tries,
+		})
+		ts := steps(i+1, stepSizeMinutes)
+		mk := func() []*simulator.StateHistory {
+			return []*simulator.StateHistory{
+				history(conv, 1),
+				history(prevTries, 2),
+			}
+		}
+
+		want := bespoke.Iterate(&p, 0, mk(), ts)
+		got := declarative.Iterate(&p, 0, mk(), ts)
+
+		homeHits := int(want[0] - conv[0])
+		awayHits := int(want[1] - conv[1])
+		if newHome+newAway == 0 {
+			branches["no_new_tries"]++
+		} else {
+			branches["new_tries"]++
+			if homeHits+awayHits > 0 {
+				branches["conversion_made"]++
+			}
+			if homeHits+awayHits < newHome+newAway {
+				branches["conversion_missed"]++
+			}
+		}
+		for k := range want {
+			maxDev = math.Max(maxDev, assertClose(t, got[k], want[k], "conversions"))
+		}
+		conv = append([]float64(nil), want...)
+		prevTries = tries
+	}
+	for _, b := range []string{
+		"no_new_tries", "new_tries", "conversion_made", "conversion_missed",
+	} {
+		if branches[b] == 0 {
+			t.Errorf("branch %q never exercised; the comparison is weaker than it looks", b)
+		}
+	}
+	t.Logf("branches exercised: %v", branches)
+	t.Logf("max deviation: %g", maxDev)
+}
+
+func TestDeclarativeRugbyAnswersTheSameClaims(t *testing.T) {
+	// The oracle is the model's own behaviour suite: every claim recomputed against the
+	// declarative build must still hold, and must hold with the same numbers the card
+	// reports — not merely point the same way.
+	if testing.Short() {
+		t.Skip("runs the full claim ensemble twice")
+	}
+	bespoke := ObservedBehaviour()
+	declarative := observedBehaviour(declarativeBuildStub)
+
+	if len(declarative) != len(bespoke) {
+		t.Fatalf("got %d claims, want %d", len(declarative), len(bespoke))
+	}
+	maxDev := 0.0
+	for i, claim := range declarative {
+		reference := bespoke[i]
+		if claim.ID != reference.ID {
+			t.Fatalf("claim %d: got ID %q, want %q", i, claim.ID, reference.ID)
+		}
+		// Still a true claim when the model is data.
+		if err := cardgen.Verify(claim); err != nil {
+			t.Errorf("claim %q does not hold for the declarative model: %v", claim.ID, err)
+			continue
+		}
+		if len(claim.Observations) != len(reference.Observations) {
+			t.Fatalf("claim %q: got %d observations, want %d",
+				claim.ID, len(claim.Observations), len(reference.Observations))
+		}
+		for k, obs := range claim.Observations {
+			maxDev = math.Max(maxDev, assertClose(t, obs.Value,
+				reference.Observations[k].Value, claim.ID+" / "+obs.Label))
+		}
+	}
+	t.Logf("max deviation across every observation on every claim: %g", maxDev)
+}

--- a/pkg/api/dead_keys.go
+++ b/pkg/api/dead_keys.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+// deadKeyPattern matches yaml.v2's complaint about a key with no corresponding struct field:
+// "line 8: field state_width not found in type simulator.PartitionConfig".
+var deadKeyPattern = regexp.MustCompile(`field (\S+) not found in type`)
+
+// unknownYamlKeys strictly parses data into v and reports the keys yaml could find no field
+// for. Any other parse failure is ignored: this is a key check, and a genuine type error is
+// the business of the real Unmarshal that follows.
+//
+// A key this view does not own shows up here whether it is dead or merely somebody else's,
+// so a caller must intersect two views rather than trust one alone.
+func unknownYamlKeys(data []byte, v any) map[string]bool {
+	keys := make(map[string]bool)
+	var typeError *yaml.TypeError
+	if err := yaml.UnmarshalStrict(data, v); err != nil && errors.As(err, &typeError) {
+		for _, message := range typeError.Errors {
+			if match := deadKeyPattern.FindStringSubmatch(message); match != nil {
+				keys[match[1]] = true
+			}
+		}
+	}
+	return keys
+}
+
+// validateNoDeadKeys rejects a config key that neither view of the file will ever read.
+//
+// yaml.v2 ignores an unknown key in silence, so a typo, or a key left behind by an older
+// schema, does nothing whatsoever while looking load-bearing. This is not hypothetical: a
+// state_width key sat in every config in this repo doing nothing (the width comes from
+// init_state_values), and pkg/simulator's partition fixture still carried two keys naming a
+// schema that no longer exists. Both read as meaningful and neither was.
+//
+// Plain strict parsing cannot express the rule, because the two views deliberately share one
+// file and split its keys: the concrete view owns params and seed but has no iteration, the
+// code-generation view owns iteration and simulation but has no params, and each rejects the
+// other's keys. Neither is the whole schema. Their union is, so a key is dead only when BOTH
+// reject it.
+func validateNoDeadKeys(data []byte) error {
+	var concrete ApiRunConfig
+	var templated ApiRunConfigStrings
+	unknownToConcrete := unknownYamlKeys(data, &concrete)
+	unknownToTemplated := unknownYamlKeys(data, &templated)
+
+	dead := make([]string, 0, len(unknownToConcrete))
+	for key := range unknownToConcrete {
+		if unknownToTemplated[key] {
+			dead = append(dead, key)
+		}
+	}
+	if len(dead) == 0 {
+		return nil
+	}
+	sort.Strings(dead)
+	return fmt.Errorf(
+		"api: config sets %s, which nothing reads — check for a typo, or a key from an "+
+			"older schema", strings.Join(dead, ", "))
+}

--- a/pkg/api/dead_keys_test.go
+++ b/pkg/api/dead_keys_test.go
@@ -1,0 +1,139 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// A key yaml.v2 does not recognise is ignored in silence, which is how state_width came to
+// sit in every config in this repo doing nothing. These tests pin the rule that catches it,
+// and — just as importantly — pin that it stays quiet about the keys the two views
+// legitimately split between them, since that is what makes it safe to apply to both.
+
+func TestDeadKeysAreRejected(t *testing.T) {
+	t.Run("a key no view reads is reported by name", func(t *testing.T) {
+		err := validateNoDeadKeys([]byte(`
+main:
+  partitions:
+  - name: walk
+    params: {drift: [0.5]}
+    init_state_values: [0.0]
+    state_history_depth: 1
+    state_widht: 1
+`))
+		if err == nil {
+			t.Fatal("expected a typo'd key to be rejected")
+		}
+		if !strings.Contains(err.Error(), "state_widht") {
+			t.Errorf("the error should name the offending key, got: %q", err)
+		}
+	})
+
+	t.Run("a key from a superseded schema is reported", func(t *testing.T) {
+		// The shape pkg/simulator's fixture carried for years: the wiring key was split into
+		// params_from_upstream_partition and params_from_indices before becoming the single
+		// params_from_upstream. Neither old key errored; both did nothing.
+		err := validateNoDeadKeys([]byte(`
+main:
+  partitions:
+  - name: walk
+    init_state_values: [0.0]
+    params_from_upstream_partition:
+      other: source
+`))
+		if err == nil || !strings.Contains(err.Error(), "params_from_upstream_partition") {
+			t.Fatalf("expected the superseded key to be reported, got: %v", err)
+		}
+	})
+
+	t.Run("every dead key is reported at once, sorted", func(t *testing.T) {
+		err := validateNoDeadKeys([]byte(`
+main:
+  partitions:
+  - name: walk
+    init_state_values: [0.0]
+    zebra: 1
+    apple: 2
+`))
+		if err == nil {
+			t.Fatal("expected the dead keys to be rejected")
+		}
+		// Sorted, so the message is stable rather than map-order dependent.
+		if !strings.Contains(err.Error(), "apple, zebra") {
+			t.Errorf("expected both keys reported in sorted order, got: %q", err)
+		}
+	})
+}
+
+func TestLegitimateKeysAreNotMistakenForDead(t *testing.T) {
+	// The point of intersecting the two views. Each of these is unknown to one view and owned
+	// by the other, so a naive strict parse against either would reject the file.
+	t.Run("keys split across the two views all pass", func(t *testing.T) {
+		err := validateNoDeadKeys([]byte(`
+main:
+  partitions:
+  # iteration, extra_packages and extra_vars belong to the code-generation view; params,
+  # init_state_values, seed and state_history_depth belong to the concrete view.
+  - name: walk
+    iteration: "&continuous.WienerProcessIteration{}"
+    extra_packages: ["github.com/umbralcalc/stochadex/pkg/continuous"]
+    extra_vars: [{variance: "0.1"}]
+    params: {variances: [0.1]}
+    params_as_partitions: {other: [somewhere]}
+    params_from_upstream:
+      inflow: {upstream: source}
+    init_state_values: [0.0]
+    state_history_depth: 1
+    seed: 3
+  expressions:
+  - partition: walk
+    fields: [{name: x, width: 1}]
+    upstreams: {drv: driver}
+    bindings: [{name: b, expr: "x + 1"}]
+    outputs: ["b"]
+  simulation:
+    output_condition: "&simulator.NilOutputCondition{}"
+embedded:
+# The embedded run is inlined, so its partitions sit directly here — there is no run key.
+- name: inner
+  partitions:
+  - name: p
+    init_state_values: [0.0]
+`))
+		if err != nil {
+			t.Errorf("legitimate keys were reported dead: %v", err)
+		}
+	})
+
+	t.Run("free-form params keys are never dead", func(t *testing.T) {
+		// Params is an inline map, so any key under it is data, not schema.
+		err := validateNoDeadKeys([]byte(`
+main:
+  partitions:
+  - name: walk
+    init_state_values: [0.0]
+    params:
+      anything_at_all: [1.0]
+      state_width: [7.0]
+`))
+		if err != nil {
+			t.Errorf("param names must not be checked against the schema: %v", err)
+		}
+	})
+
+	t.Run("every config file in the repo is clean", func(t *testing.T) {
+		// The regression guard: this is what state_width would have tripped.
+		for _, path := range []string{
+			"test_program_config.yaml",
+			"test_program_embedded_config.yaml",
+			"test_program_expression_config.yaml",
+			"test_program_expression_coupled_config.yaml",
+		} {
+			t.Run(path, func(t *testing.T) {
+				if didPanic(func() { LoadApiRunConfigFromYaml(path) }) {
+					t.Errorf("%s has a key nothing reads", path)
+				}
+			})
+		}
+	})
+}

--- a/pkg/api/program.go
+++ b/pkg/api/program.go
@@ -128,6 +128,10 @@ func (r *RunConfig) GetConfigGenerator() *simulator.ConfigGenerator {
 	for i := range r.Expressions {
 		expression := &r.Expressions[i]
 		partition := generator.GetPartition(expression.Partition)
+		if partition == nil {
+			panic("api: expression names partition " + expression.Partition +
+				" but no partition of that name is defined")
+		}
 		partition.Iteration = &expression.ExpressionIteration
 		generator.ResetPartition(expression.Partition, partition)
 	}

--- a/pkg/api/program.go
+++ b/pkg/api/program.go
@@ -54,13 +54,13 @@ type PartitionConfigStrings struct {
 // ExpressionConfig binds a declarative expression specification to a partition by name, so
 // that a partition's whole update can be written as data in the config file.
 //
-// Unlike the `iteration` field — which is a Go expression, and so requires this package's
+// Unlike the iteration field — which is a Go expression, and so requires this package's
 // code-generation step and a Go toolchain — an expression specification is just data: it is
 // loaded straight from the YAML and evaluated at run time. A config using only expressions
 // therefore needs no compilation at all, which is what lets a simulation be specified by
 // something that does not write Go.
 //
-// A partition named here may omit its `iteration` field, exactly as a partition backed by an
+// A partition named here may omit its iteration field, exactly as a partition backed by an
 // embedded run may. The specification is inlined, so its keys are those of
 // general.ExpressionIteration:
 //
@@ -145,9 +145,8 @@ type EmbeddedRunConfig struct {
 // a runnable main for a simulation run.
 type RunConfigStrings struct {
 	Partitions []PartitionConfigStrings `yaml:"partitions"`
-	// Expressions are pure data and need no code generation, so this view holds the same
-	// type as RunConfig: it is here so that validation knows which partitions legitimately
-	// omit an `iteration`, and so the same YAML parses in both views.
+	// Expressions are data, so this view holds the same type as RunConfig. Validation reads
+	// it to know which partitions may legitimately omit an iteration.
 	Expressions []ExpressionConfig                `yaml:"expressions,omitempty"`
 	Simulation  simulator.SimulationConfigStrings `yaml:"simulation"`
 }

--- a/pkg/api/program.go
+++ b/pkg/api/program.go
@@ -51,6 +51,32 @@ type PartitionConfigStrings struct {
 	ExtraVars     []map[string]string `yaml:"extra_vars,omitempty"`
 }
 
+// ExpressionConfig binds a declarative expression specification to a partition by name, so
+// that a partition's whole update can be written as data in the config file.
+//
+// Unlike the `iteration` field — which is a Go expression, and so requires this package's
+// code-generation step and a Go toolchain — an expression specification is just data: it is
+// loaded straight from the YAML and evaluated at run time. A config using only expressions
+// therefore needs no compilation at all, which is what lets a simulation be specified by
+// something that does not write Go.
+//
+// A partition named here may omit its `iteration` field, exactly as a partition backed by an
+// embedded run may. The specification is inlined, so its keys are those of
+// general.ExpressionIteration:
+//
+//	expressions:
+//	  - partition: battery
+//	    fields:
+//	      - {name: soc}
+//	      - {name: actual_dispatch}
+//	    bindings:
+//	      - {name: dispatch, expr: "clamp(dispatch_mw, -power_rating_mw, power_rating_mw)"}
+//	    outputs: ["clamp(soc + dispatch * dt, 0, energy_capacity_mwh)", "dispatch"]
+type ExpressionConfig struct {
+	Partition                   string `yaml:"partition"`
+	general.ExpressionIteration `yaml:",inline"`
+}
+
 // RunConfig represents a complete simulation run configuration with partitions
 // and simulation settings.
 //
@@ -80,18 +106,30 @@ type PartitionConfigStrings struct {
 //   - See simulator.PartitionConfig for partition configuration details
 //   - See simulator.SimulationConfig for simulation control parameters
 //   - See ApiRunConfig for API-level configuration with embedded runs
+//   - See ExpressionConfig for supplying a partition's iteration as data instead of Go
 type RunConfig struct {
 	Partitions []simulator.PartitionConfig `yaml:"partitions"`
-	Simulation simulator.SimulationConfig  `yaml:"-"`
+	// Expressions declaratively supply the iteration for the partitions they name.
+	Expressions []ExpressionConfig         `yaml:"expressions,omitempty"`
+	Simulation  simulator.SimulationConfig `yaml:"-"`
 }
 
 // GetConfigGenerator constructs a ConfigGenerator preloaded with the run's
-// SimulationConfig and Partitions.
+// SimulationConfig and Partitions, and gives any partition named by an Expressions entry a
+// declarative ExpressionIteration built from that entry.
 func (r *RunConfig) GetConfigGenerator() *simulator.ConfigGenerator {
 	generator := simulator.NewConfigGenerator()
 	generator.SetSimulation(&r.Simulation)
 	for _, partition := range r.Partitions {
 		generator.SetPartition(&partition)
+	}
+	// Index rather than range by value: the iteration is the embedded struct, so it has to
+	// be the one owned by this config, not a copy of the loop variable.
+	for i := range r.Expressions {
+		expression := &r.Expressions[i]
+		partition := generator.GetPartition(expression.Partition)
+		partition.Iteration = &expression.ExpressionIteration
+		generator.ResetPartition(expression.Partition, partition)
 	}
 	return generator
 }
@@ -106,8 +144,12 @@ type EmbeddedRunConfig struct {
 // RunConfigStrings provides the string-templated inputs required to generate
 // a runnable main for a simulation run.
 type RunConfigStrings struct {
-	Partitions []PartitionConfigStrings          `yaml:"partitions"`
-	Simulation simulator.SimulationConfigStrings `yaml:"simulation"`
+	Partitions []PartitionConfigStrings `yaml:"partitions"`
+	// Expressions are pure data and need no code generation, so this view holds the same
+	// type as RunConfig: it is here so that validation knows which partitions legitimately
+	// omit an `iteration`, and so the same YAML parses in both views.
+	Expressions []ExpressionConfig                `yaml:"expressions,omitempty"`
+	Simulation  simulator.SimulationConfigStrings `yaml:"simulation"`
 }
 
 // EmbeddedRunConfigStrings names and provides string-templated inputs for an
@@ -225,13 +267,16 @@ func validateApiRunConfigStrings(config *ApiRunConfigStrings) {
 	for _, embedded := range config.Embedded {
 		embeddedNames[embedded.Name] = true
 	}
+	expressionNames := make(map[string]bool)
+	for _, expression := range config.Main.Expressions {
+		expressionNames[expression.Partition] = true
+	}
 	for _, partition := range config.Main.Partitions {
 		if partition.Iteration == "" {
-			_, ok := embeddedNames[partition.Name]
-			if !ok {
+			if !embeddedNames[partition.Name] && !expressionNames[partition.Name] {
 				panic("config omits iteration for partition name: " +
 					partition.Name +
-					" and no embedded simulation runs have this name")
+					" and no embedded simulation runs or expression specs have this name")
 			}
 		}
 	}

--- a/pkg/api/program.go
+++ b/pkg/api/program.go
@@ -240,6 +240,9 @@ func LoadApiRunConfigFromYaml(path string) *ApiRunConfig {
 	if err != nil {
 		panic(err)
 	}
+	if deadKeyErr := validateNoDeadKeys(yamlFile); deadKeyErr != nil {
+		panic(deadKeyErr)
+	}
 	var config ApiRunConfig
 	err = yaml.Unmarshal(yamlFile, &config)
 	for index := range config.Main.Partitions {
@@ -291,6 +294,9 @@ func LoadApiRunConfigStringsFromYaml(path string) *ApiRunConfigStrings {
 	yamlFile, err := os.ReadFile(path)
 	if err != nil {
 		panic(err)
+	}
+	if deadKeyErr := validateNoDeadKeys(yamlFile); deadKeyErr != nil {
+		panic(deadKeyErr)
 	}
 	var config ApiRunConfigStrings
 	err = yaml.Unmarshal(yamlFile, &config)

--- a/pkg/api/program_expression_test.go
+++ b/pkg/api/program_expression_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/umbralcalc/stochadex/pkg/general"
@@ -152,6 +153,162 @@ func TestExpressionOnlyConfigRunsFromYaml(t *testing.T) {
 				if got[i][0] != want[i] {
 					t.Fatalf("row %d: got %v, want %v (all: %v)", i, got[i][0], want[i], got)
 				}
+			}
+		},
+	)
+}
+
+func TestExpressionsResolveUpstreamsFromYaml(t *testing.T) {
+	t.Run(
+		"a coupled model written only as data runs and couples correctly",
+		func(t *testing.T) {
+			config := LoadApiRunConfigFromYaml("test_program_expression_coupled_config.yaml")
+			store := simulator.NewStateTimeStorage()
+			config.Main.Simulation = simulator.SimulationConfig{
+				OutputCondition: &simulator.EveryStepOutputCondition{},
+				OutputFunction:  &simulator.StateTimeStorageOutputFunction{Store: store},
+				TerminationCondition: &simulator.NumberOfStepsTerminationCondition{
+					MaxNumberOfSteps: 3,
+				},
+				TimestepFunction: &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+			}
+			simulator.NewPartitionCoordinator(
+				config.GetConfigGenerator().GenerateConfigs(),
+			).Run()
+
+			// driver: d' = d + 2*1, from 1 -> 1, 3, 5, 7.
+			driver := store.GetValues("driver")
+			wantDriver := []float64{1, 3, 5, 7}
+			for i := range wantDriver {
+				if driver[i][0] != wantDriver[i] {
+					t.Fatalf("driver: got %v, want %v", driver, wantDriver)
+				}
+			}
+			// responder reads the driver's PREVIOUS value (a state-history read is lag-1),
+			// so r' = r + 10*d_prev accumulates 1, 3, 5: 0, 10, 40, 90.
+			responder := store.GetValues("responder")
+			wantResponder := []float64{0, 10, 40, 90}
+			for i := range wantResponder {
+				if responder[i][0] != wantResponder[i] {
+					t.Fatalf("responder: got %v, want %v", responder, wantResponder)
+				}
+			}
+		},
+	)
+}
+
+func TestExpressionsWorkInsideEmbeddedRuns(t *testing.T) {
+	t.Run(
+		"an embedded run's partition can be specified as data",
+		func(t *testing.T) {
+			// Wiring lives on RunConfig rather than ApiRunConfig precisely so that embedded
+			// runs get it too; this pins that down.
+			newPartition := func(name string, iteration simulator.Iteration) simulator.PartitionConfig {
+				p := simulator.PartitionConfig{
+					Name:              name,
+					Iteration:         iteration,
+					Params:            simulator.NewParams(make(map[string][]float64)),
+					InitStateValues:   []float64{0.0},
+					StateHistoryDepth: 1,
+				}
+				p.Init()
+				return p
+			}
+			simulation := func() simulator.SimulationConfig {
+				return simulator.SimulationConfig{
+					OutputCondition: &simulator.NilOutputCondition{},
+					OutputFunction:  &simulator.NilOutputFunction{},
+					TerminationCondition: &simulator.NumberOfStepsTerminationCondition{
+						MaxNumberOfSteps: 2,
+					},
+					TimestepFunction: &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+					InitTimeValue:    0.0,
+				}
+			}
+			host := newPartition("embedded_sim", &general.ConstantValuesIteration{})
+			host.Params.Set("burn_in_steps", []float64{0})
+
+			embedded := EmbeddedRunConfig{
+				Name: "embedded_sim",
+				Run: RunConfig{
+					Partitions: []simulator.PartitionConfig{newPartition("inner", nil)},
+					Expressions: []ExpressionConfig{{
+						Partition: "inner",
+						ExpressionIteration: general.ExpressionIteration{
+							Fields:  []general.ExpressionField{{Name: "x"}},
+							Outputs: []string{"x + 1"},
+						},
+					}},
+					Simulation: simulation(),
+				},
+			}
+			config := &ApiRunConfig{
+				Main: RunConfig{
+					Partitions: []simulator.PartitionConfig{host},
+					Simulation: simulation(),
+				},
+				Embedded: []EmbeddedRunConfig{embedded},
+			}
+
+			inner := embedded.Run.GetConfigGenerator().GetPartition("inner").Iteration
+			if _, ok := inner.(*general.ExpressionIteration); !ok {
+				t.Errorf("embedded run's partition was not wired: got %T", inner)
+			}
+			// And the whole thing still builds and runs end to end.
+			simulator.NewPartitionCoordinator(
+				config.GetConfigGenerator().GenerateConfigs(),
+			).Run()
+		},
+	)
+}
+
+func TestExpressionNamingAnUnknownPartitionIsRejected(t *testing.T) {
+	t.Run(
+		"a spec naming a partition that does not exist reports it clearly",
+		func(t *testing.T) {
+			config := &RunConfig{
+				Partitions: []simulator.PartitionConfig{},
+				Expressions: []ExpressionConfig{{
+					Partition: "ghost",
+					ExpressionIteration: general.ExpressionIteration{
+						Fields:  []general.ExpressionField{{Name: "x"}},
+						Outputs: []string{"x"},
+					},
+				}},
+			}
+			defer func() {
+				r := recover()
+				if r == nil {
+					t.Fatal("expected a panic for an expression naming an unknown partition")
+				}
+				if got := stringify(r); !strings.Contains(got, "ghost") {
+					t.Errorf("panic should name the offending partition, got: %q", got)
+				}
+			}()
+			config.GetConfigGenerator()
+		},
+	)
+}
+
+func TestExpressionsParseInTheStringsView(t *testing.T) {
+	t.Run(
+		"the same YAML parses in the code-generation view and validates",
+		func(t *testing.T) {
+			// Both views read the same file, so an expressions field must not break the
+			// templated view that drives code generation.
+			config := LoadApiRunConfigStringsFromYaml("test_program_expression_config.yaml")
+			if len(config.Main.Expressions) != 1 {
+				t.Fatalf("got %d expression specs, want 1", len(config.Main.Expressions))
+			}
+			if config.Main.Expressions[0].Partition != "walk" {
+				t.Errorf("spec partition: got %q, want walk",
+					config.Main.Expressions[0].Partition)
+			}
+			// The partition carries no iteration string, and validation accepted it purely
+			// because the expression spec names it.
+			if config.Main.Partitions[0].Iteration != "" {
+				t.Errorf("expected no iteration string, got %q",
+					config.Main.Partitions[0].Iteration)
 			}
 		},
 	)

--- a/pkg/api/program_expression_test.go
+++ b/pkg/api/program_expression_test.go
@@ -1,0 +1,158 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/umbralcalc/stochadex/pkg/general"
+	"github.com/umbralcalc/stochadex/pkg/simulator"
+)
+
+// An expression specification supplies a partition's iteration as data, so — unlike the
+// `iteration` field, which is a Go expression needing code generation — a config built only
+// from expressions runs with no Go toolchain at all. These tests cover that contract:
+// validation accepts the partition, the generator wires the iteration, and a config off disk
+// runs end to end.
+
+func TestValidateAcceptsExpressionBackedPartitions(t *testing.T) {
+	t.Run(
+		"a partition with no iteration is valid when an expression spec matches",
+		func(t *testing.T) {
+			config := &ApiRunConfigStrings{
+				Main: RunConfigStrings{
+					Partitions: []PartitionConfigStrings{
+						{Name: "declarative"}, // no iteration, but matched below
+					},
+					Expressions: []ExpressionConfig{{Partition: "declarative"}},
+				},
+			}
+			if didPanic(func() { validateApiRunConfigStrings(config) }) {
+				t.Error("validation panicked despite a matching expression spec")
+			}
+		},
+	)
+	t.Run(
+		"a partition with neither an iteration, an embedded run nor an expression panics",
+		func(t *testing.T) {
+			config := &ApiRunConfigStrings{
+				Main: RunConfigStrings{
+					Partitions:  []PartitionConfigStrings{{Name: "orphan"}},
+					Expressions: []ExpressionConfig{{Partition: "somebody_else"}},
+				},
+			}
+			if !didPanic(func() { validateApiRunConfigStrings(config) }) {
+				t.Error("expected a panic for a partition no expression spec names")
+			}
+		},
+	)
+}
+
+func TestGetConfigGeneratorWiresExpressions(t *testing.T) {
+	t.Run(
+		"the named partition gets an ExpressionIteration and others are untouched",
+		func(t *testing.T) {
+			newPartition := func(name string, iteration simulator.Iteration) simulator.PartitionConfig {
+				p := simulator.PartitionConfig{
+					Name:              name,
+					Iteration:         iteration,
+					Params:            simulator.NewParams(make(map[string][]float64)),
+					InitStateValues:   []float64{0.0},
+					StateHistoryDepth: 1,
+				}
+				p.Init()
+				return p
+			}
+			config := &RunConfig{
+				Partitions: []simulator.PartitionConfig{
+					newPartition("plain", &general.ConstantValuesIteration{}),
+					// Declared with no iteration at all: the expression supplies it.
+					newPartition("declarative", nil),
+				},
+				Expressions: []ExpressionConfig{{
+					Partition: "declarative",
+					ExpressionIteration: general.ExpressionIteration{
+						Fields:  []general.ExpressionField{{Name: "x"}},
+						Outputs: []string{"x + 1"},
+					},
+				}},
+				Simulation: simulator.SimulationConfig{
+					OutputCondition: &simulator.NilOutputCondition{},
+					OutputFunction:  &simulator.NilOutputFunction{},
+					TerminationCondition: &simulator.NumberOfStepsTerminationCondition{
+						MaxNumberOfSteps: 2,
+					},
+					TimestepFunction: &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+				},
+			}
+
+			generator := config.GetConfigGenerator()
+
+			wired := generator.GetPartition("declarative").Iteration
+			if _, ok := wired.(*general.ExpressionIteration); !ok {
+				t.Errorf("declarative partition was not wired: got %T", wired)
+			}
+			plain := generator.GetPartition("plain").Iteration
+			if _, ok := plain.(*general.ConstantValuesIteration); !ok {
+				t.Errorf("plain partition was unexpectedly swapped: got %T", plain)
+			}
+			simulator.NewPartitionCoordinator(generator.GenerateConfigs()).Run()
+		},
+	)
+}
+
+func TestExpressionOnlyConfigRunsFromYaml(t *testing.T) {
+	t.Run(
+		"a config whose partition is specified only as data loads and runs",
+		func(t *testing.T) {
+			config := LoadApiRunConfigFromYaml("test_program_expression_config.yaml")
+
+			// The inlined specification must have survived the YAML round-trip.
+			if len(config.Main.Expressions) != 1 {
+				t.Fatalf("got %d expression specs, want 1", len(config.Main.Expressions))
+			}
+			spec := config.Main.Expressions[0]
+			if spec.Partition != "walk" {
+				t.Errorf("spec partition: got %q, want walk", spec.Partition)
+			}
+			if len(spec.Fields) != 1 || spec.Fields[0].Name != "x" {
+				t.Errorf("inlined fields not parsed: %+v", spec.Fields)
+			}
+			if len(spec.Outputs) != 1 || spec.Outputs[0] != "x + drift * dt" {
+				t.Errorf("inlined outputs not parsed: %+v", spec.Outputs)
+			}
+			// The partition itself declares no iteration; the expression supplies it.
+			if config.Main.Partitions[0].Iteration != nil {
+				t.Errorf("expected no iteration on the partition, got %T",
+					config.Main.Partitions[0].Iteration)
+			}
+
+			// Simulation is not YAML-loaded on RunConfig, so supply it here.
+			store := simulator.NewStateTimeStorage()
+			config.Main.Simulation = simulator.SimulationConfig{
+				OutputCondition: &simulator.EveryStepOutputCondition{},
+				OutputFunction:  &simulator.StateTimeStorageOutputFunction{Store: store},
+				TerminationCondition: &simulator.NumberOfStepsTerminationCondition{
+					MaxNumberOfSteps: 4,
+				},
+				TimestepFunction: &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+			}
+
+			generator := config.GetConfigGenerator()
+			if _, ok := generator.GetPartition("walk").Iteration.(*general.ExpressionIteration); !ok {
+				t.Fatalf("walk was not wired to an ExpressionIteration")
+			}
+			simulator.NewPartitionCoordinator(generator.GenerateConfigs()).Run()
+
+			// x' = x + drift*dt, with drift 0.5 and dt 1: 0, 0.5, 1, 1.5, 2.
+			got := store.GetValues("walk")
+			want := []float64{0, 0.5, 1.0, 1.5, 2.0}
+			if len(got) != len(want) {
+				t.Fatalf("got %d rows, want %d: %v", len(got), len(want), got)
+			}
+			for i := range want {
+				if got[i][0] != want[i] {
+					t.Fatalf("row %d: got %v, want %v (all: %v)", i, got[i][0], want[i], got)
+				}
+			}
+		},
+	)
+}

--- a/pkg/api/test_program_config.yaml
+++ b/pkg/api/test_program_config.yaml
@@ -5,14 +5,12 @@ main:
       variances: [1.0, 1.0, 1.0, 1.0, 1.0]
     init_state_values: [0.45, 1.4, 0.01, -0.13, 0.7]
     seed: 7167
-    state_width: 5
     state_history_depth: 2
   - name: second_wiener_process
     params:
       variances: [1.0, 1.0, 1.0]
     init_state_values: [0.0, 0.0, 0.0]
     seed: 1024
-    state_width: 3
     state_history_depth: 2
   - name: other_thing
     params:
@@ -20,5 +18,4 @@ main:
       burn_in_steps: [0]
     init_state_values: [0.45, 1.4, 0.01, -0.13, 0.7, 0.0, 0.0, 0.0, 0.67, -0.01, 0.1]
     seed: 111
-    state_width: 11
     state_history_depth: 2

--- a/pkg/api/test_program_embedded_config.yaml
+++ b/pkg/api/test_program_embedded_config.yaml
@@ -5,14 +5,12 @@ main:
       variances: [1.0, 1.0, 1.0, 1.0, 1.0]
     init_state_values: [0.45, 1.4, 0.01, -0.13, 0.7]
     seed: 7167
-    state_width: 5
     state_history_depth: 2
   - name: second_wiener_process
     params:
       variances: [1.0, 1.0, 1.0]
     init_state_values: [0.0, 0.0, 0.0]
     seed: 1024
-    state_width: 3
     state_history_depth: 2
   - name: embedded_sim
     params:
@@ -20,7 +18,6 @@ main:
       burn_in_steps: [0]
     init_state_values: [0.45, 1.4, 0.01, -0.13, 0.7, 0.0, 0.0, 0.0, 0.67, -0.01, 0.1]
     seed: 111
-    state_width: 11
     state_history_depth: 2
 embedded:
 - name: embedded_sim
@@ -30,18 +27,15 @@ embedded:
       variances: [1.0, 1.0, 1.0, 1.0, 1.0]
     init_state_values: [0.45, 1.4, 0.01, -0.13, 0.7]
     seed: 7167
-    state_width: 5
     state_history_depth: 2
   - name: second_wiener_process_embed_sim
     params:
       variances: [1.0, 1.0, 1.0]
     init_state_values: [0.0, 0.0, 0.0]
     seed: 1024
-    state_width: 3
     state_history_depth: 2
   - name: constant_values_embed_sim
     params: {}
     init_state_values: [0.67, -0.01, 0.1]
     seed: 14462
-    state_width: 3
     state_history_depth: 2

--- a/pkg/api/test_program_expression_config.yaml
+++ b/pkg/api/test_program_expression_config.yaml
@@ -1,0 +1,19 @@
+# A partition specified entirely as data: no `iteration` Go expression anywhere, so this
+# config needs no code generation and no Go toolchain to run.
+main:
+  partitions:
+  - name: walk
+    params:
+      drift: [0.5]
+    init_state_values: [0.0]
+    state_width: 1
+    state_history_depth: 1
+    seed: 3
+  expressions:
+  - partition: walk
+    fields:
+    - name: x
+    outputs:
+    - "x + drift * dt"
+  simulation:
+    output_condition: "&simulator.NilOutputCondition{}"

--- a/pkg/api/test_program_expression_config.yaml
+++ b/pkg/api/test_program_expression_config.yaml
@@ -6,7 +6,6 @@ main:
     params:
       drift: [0.5]
     init_state_values: [0.0]
-    state_width: 1
     state_history_depth: 1
     seed: 3
   expressions:

--- a/pkg/api/test_program_expression_coupled_config.yaml
+++ b/pkg/api/test_program_expression_coupled_config.yaml
@@ -6,14 +6,12 @@ main:
     params:
       rate: [2.0]
     init_state_values: [1.0]
-    state_width: 1
     state_history_depth: 1
     seed: 0
   - name: responder
     params:
       gain: [10.0]
     init_state_values: [0.0]
-    state_width: 1
     state_history_depth: 1
     seed: 0
   expressions:

--- a/pkg/api/test_program_expression_coupled_config.yaml
+++ b/pkg/api/test_program_expression_coupled_config.yaml
@@ -1,0 +1,33 @@
+# Two partitions specified entirely as data, one reading the other: exercises upstream
+# resolution by name and params_from_upstream through the config layer, with no Go anywhere.
+main:
+  partitions:
+  - name: driver
+    params:
+      rate: [2.0]
+    init_state_values: [1.0]
+    state_width: 1
+    state_history_depth: 1
+    seed: 0
+  - name: responder
+    params:
+      gain: [10.0]
+    init_state_values: [0.0]
+    state_width: 1
+    state_history_depth: 1
+    seed: 0
+  expressions:
+  - partition: driver
+    fields:
+    - name: d
+    outputs:
+    - "d + rate * dt"
+  - partition: responder
+    fields:
+    - name: r
+    upstreams:
+      drv: driver
+    outputs:
+    - "r + gain * drv[0]"
+  simulation:
+    output_condition: "&simulator.NilOutputCondition{}"

--- a/pkg/general/expression.go
+++ b/pkg/general/expression.go
@@ -1,0 +1,511 @@
+package general
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"math"
+	"strconv"
+
+	"gonum.org/v1/gonum/stat/distuv"
+
+	"github.com/umbralcalc/stochadex/pkg/rng"
+	"github.com/umbralcalc/stochadex/pkg/simulator"
+)
+
+// ExpressionField names a contiguous block of a partition's state vector so that
+// expressions can refer to it by name instead of by index. Fields are laid out in the
+// order given, so a partition with fields {"soc", 1} and {"charge", 1} has state
+// [soc, charge], and one with {"infectious", 40} and {"cumulative", 40} has an
+// 80-wide state of two 40-wide blocks.
+type ExpressionField struct {
+	Name string `yaml:"name"`
+	// Width defaults to 1 when zero.
+	Width int `yaml:"width,omitempty"`
+}
+
+// ExpressionBinding is one named intermediate value in the evaluation DAG. Bindings are
+// evaluated in order, and each may refer to any binding declared before it.
+type ExpressionBinding struct {
+	Name string `yaml:"name"`
+	Expr string `yaml:"expr"`
+}
+
+// ExpressionIteration is a declarative Iteration: the per-step update is given as string
+// expressions rather than Go code, so a whole partition can be specified as data (and hence
+// from YAML, or by an agent) with no compilation step.
+//
+// The update is a small DAG: Bindings are named intermediates evaluated in order, then one
+// Outputs expression per field produces that field's next value. Everything is evaluated
+// elementwise over vectors, with length-1 values broadcasting, so the same expression works
+// for a scalar partition and a 10,000-element one.
+//
+// Names available to expressions:
+//   - each of this partition's own Fields, holding its current (most recent) value;
+//   - each entry of Params, by key;
+//   - each alias in Upstreams, holding that partition's current state vector (index it with
+//     alias[i]);
+//   - "dt" (the timestep increment), "t" (the current cumulative time) and "step" (the
+//     current step number);
+//   - any Binding declared earlier.
+//
+// Functions: where, clamp, min, max, abs, floor, exp, log, sqrt, pow, fill, sum, dot, and
+// the stochastic draws normal, uniform, exponential, poisson, gamma, beta and binomial.
+// Draws take expressions as their parameters, so compound sampling composes naturally — a
+// negative-binomial branching step is just poisson(gamma(shape, rate)).
+//
+// # How wide a draw is
+//
+// A draw produces one independent sample per element of its broadcast parameters. So
+// poisson(rates) with a 40-wide rates param gives 40 independent draws, which is the usual
+// modelling form. But normal(0, 1) has only scalar parameters, so it is a SINGLE draw — and
+// if that is then combined with a wide value it broadcasts, meaning the same sample lands in
+// every element. `x + normal(0, 1)` over a 40-wide x adds one shared shock to all 40, which
+// is rarely what is meant. For independent noise per element either give the draw a
+// vector-valued parameter (the natural form: a per-element sigma), or widen it explicitly
+// with fill: `x + normal(fill(40, 0), 1)`, or `x + normal(0 * x, 1)` to match x's width.
+//
+// Conditionals are expressions, not statements: where(cond, a, b). When cond is a scalar the
+// untaken branch is NOT evaluated, so guards like where(n > 0, binomial(n, p), 0) are safe
+// and draw no randomness on the guarded path. When cond is a vector both branches must be
+// evaluated to select elementwise (as in NumPy), which means a vector-guarded draw consumes
+// randomness in every lane. Prefer scalar guards where that matters.
+//
+// This is deliberately not a general-purpose language: there are no loops, no assignment and
+// no recursion, so an expression always terminates and can be read at a glance.
+type ExpressionIteration struct {
+	// Fields names the blocks of this partition's state, in layout order.
+	Fields []ExpressionField `yaml:"fields"`
+	// Upstreams maps an alias used in expressions to another partition's name, making that
+	// partition's current state readable. Resolving names to indices happens in Configure.
+	Upstreams map[string]string `yaml:"upstreams,omitempty"`
+	// Bindings are ordered named intermediates.
+	Bindings []ExpressionBinding `yaml:"bindings,omitempty"`
+	// Outputs holds one expression per entry of Fields, in the same order, each evaluating
+	// to that field's width (or to a scalar, which is broadcast across it).
+	Outputs []string `yaml:"outputs"`
+
+	offsets        []int
+	width          int
+	upstreamIndex  map[string]int
+	parsedBindings []parsedExprBinding
+	parsedOutputs  []ast.Expr
+	sampler        *rng.Sampler
+	out            []float64
+}
+
+type parsedExprBinding struct {
+	name string
+	expr ast.Expr
+}
+
+// Configure resolves the state layout, resolves upstream partition names to indices, parses
+// every expression once, and seeds the draw sampler from the partition's seed. It panics on
+// a malformed specification: a partition that cannot be built is a hard configuration error,
+// not something to discover mid-run.
+func (e *ExpressionIteration) Configure(
+	partitionIndex int,
+	settings *simulator.Settings,
+) {
+	if len(e.Outputs) != len(e.Fields) {
+		panic(fmt.Sprintf(
+			"expression: %d outputs for %d fields; there must be exactly one per field",
+			len(e.Outputs), len(e.Fields)))
+	}
+	e.offsets = make([]int, len(e.Fields))
+	e.width = 0
+	for i, f := range e.Fields {
+		if f.Name == "" {
+			panic("expression: field at index " + strconv.Itoa(i) + " has no name")
+		}
+		w := f.Width
+		if w == 0 {
+			w = 1
+		}
+		if w < 0 {
+			panic("expression: field " + f.Name + " has negative width")
+		}
+		e.offsets[i] = e.width
+		e.width += w
+	}
+	e.out = make([]float64, e.width)
+
+	e.upstreamIndex = make(map[string]int, len(e.Upstreams))
+	for alias, name := range e.Upstreams {
+		found := -1
+		for i, it := range settings.Iterations {
+			if it.Name == name {
+				found = i
+				break
+			}
+		}
+		if found < 0 {
+			panic("expression: upstream partition " + name + " (alias " + alias + ") not found")
+		}
+		e.upstreamIndex[alias] = found
+	}
+
+	e.parsedBindings = make([]parsedExprBinding, 0, len(e.Bindings))
+	for _, b := range e.Bindings {
+		parsed, err := parser.ParseExpr(b.Expr)
+		if err != nil {
+			panic("expression: parsing binding " + b.Name + ": " + err.Error())
+		}
+		e.parsedBindings = append(e.parsedBindings, parsedExprBinding{b.Name, parsed})
+	}
+	e.parsedOutputs = make([]ast.Expr, len(e.Outputs))
+	for i, o := range e.Outputs {
+		parsed, err := parser.ParseExpr(o)
+		if err != nil {
+			panic("expression: parsing output for field " +
+				e.Fields[i].Name + ": " + err.Error())
+		}
+		e.parsedOutputs[i] = parsed
+	}
+
+	e.sampler = rng.New(settings.Iterations[partitionIndex].Seed)
+}
+
+// Iterate evaluates the bindings in order and then each field's output expression,
+// concatenating the results into the next state vector.
+func (e *ExpressionIteration) Iterate(
+	params *simulator.Params,
+	partitionIndex int,
+	stateHistories []*simulator.StateHistory,
+	timestepsHistory *simulator.CumulativeTimestepsHistory,
+) []float64 {
+	env := make(exprEnv, len(e.Fields)+len(params.Map)+len(e.upstreamIndex)+3)
+	state := stateHistories[partitionIndex].Values.RawRowView(0)
+	for i, f := range e.Fields {
+		w := f.Width
+		if w == 0 {
+			w = 1
+		}
+		env[f.Name] = exprValue(state[e.offsets[i] : e.offsets[i]+w])
+	}
+	for name, values := range params.Map {
+		env[name] = exprValue(values)
+	}
+	for alias, index := range e.upstreamIndex {
+		env[alias] = exprValue(stateHistories[index].Values.RawRowView(0))
+	}
+	env["dt"] = exprValue{timestepsHistory.NextIncrement}
+	env["t"] = exprValue{timestepsHistory.Values.AtVec(0)}
+	env["step"] = exprValue{float64(timestepsHistory.CurrentStepNumber)}
+
+	for _, b := range e.parsedBindings {
+		env[b.name] = evalExprNode(b.expr, env, e.sampler)
+	}
+	for i, o := range e.parsedOutputs {
+		w := e.Fields[i].Width
+		if w == 0 {
+			w = 1
+		}
+		v := evalExprNode(o, env, e.sampler)
+		switch len(v) {
+		case w:
+			copy(e.out[e.offsets[i]:], v)
+		case 1: // a scalar broadcasts across the whole field
+			for k := 0; k < w; k++ {
+				e.out[e.offsets[i]+k] = v[0]
+			}
+		default:
+			panic(fmt.Sprintf(
+				"expression: output for field %s produced width %d, want %d or 1",
+				e.Fields[i].Name, len(v), w))
+		}
+	}
+	return e.out
+}
+
+// exprValue is the single value type: a vector, where length 1 means a scalar and
+// broadcasts against any other length.
+type exprValue []float64
+
+type exprEnv map[string]exprValue
+
+func exprBool(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// broadcastLen returns the result length for combining a and b, or panics on a mismatch.
+func broadcastLen(a, b exprValue, what string) int {
+	switch {
+	case len(a) == len(b):
+		return len(a)
+	case len(a) == 1:
+		return len(b)
+	case len(b) == 1:
+		return len(a)
+	}
+	panic(fmt.Sprintf("expression: cannot combine widths %d and %d in %s", len(a), len(b), what))
+}
+
+func at(v exprValue, i int) float64 {
+	if len(v) == 1 {
+		return v[0]
+	}
+	return v[i]
+}
+
+func zipExpr(a, b exprValue, what string, f func(x, y float64) float64) exprValue {
+	n := broadcastLen(a, b, what)
+	out := make(exprValue, n)
+	for i := 0; i < n; i++ {
+		out[i] = f(at(a, i), at(b, i))
+	}
+	return out
+}
+
+func mapExpr(a exprValue, f func(x float64) float64) exprValue {
+	out := make(exprValue, len(a))
+	for i, x := range a {
+		out[i] = f(x)
+	}
+	return out
+}
+
+func evalExprNode(node ast.Expr, env exprEnv, s *rng.Sampler) exprValue {
+	switch n := node.(type) {
+	case *ast.BasicLit:
+		v, err := strconv.ParseFloat(n.Value, 64)
+		if err != nil {
+			panic("expression: bad numeric literal " + n.Value)
+		}
+		return exprValue{v}
+	case *ast.Ident:
+		v, ok := env[n.Name]
+		if !ok {
+			panic("expression: unknown name " + n.Name)
+		}
+		return v
+	case *ast.ParenExpr:
+		return evalExprNode(n.X, env, s)
+	case *ast.UnaryExpr:
+		v := evalExprNode(n.X, env, s)
+		switch n.Op {
+		case token.SUB:
+			return mapExpr(v, func(x float64) float64 { return -x })
+		case token.ADD:
+			return v
+		case token.NOT:
+			return mapExpr(v, func(x float64) float64 { return exprBool(x == 0) })
+		}
+	case *ast.IndexExpr:
+		v := evalExprNode(n.X, env, s)
+		idx := evalExprNode(n.Index, env, s)
+		if len(idx) != 1 {
+			panic("expression: index must be a scalar")
+		}
+		i := int(idx[0])
+		if i < 0 || i >= len(v) {
+			panic(fmt.Sprintf("expression: index %d out of range for width %d", i, len(v)))
+		}
+		return exprValue{v[i]}
+	case *ast.BinaryExpr:
+		return evalExprBinary(n, env, s)
+	case *ast.CallExpr:
+		return evalExprCall(n, env, s)
+	}
+	panic("expression: unsupported syntax")
+}
+
+func evalExprBinary(n *ast.BinaryExpr, env exprEnv, s *rng.Sampler) exprValue {
+	// && and || short-circuit only when the left side is a scalar, matching where's rule.
+	if n.Op == token.LAND || n.Op == token.LOR {
+		l := evalExprNode(n.X, env, s)
+		if len(l) == 1 {
+			if n.Op == token.LAND && l[0] == 0 {
+				return exprValue{0}
+			}
+			if n.Op == token.LOR && l[0] != 0 {
+				return exprValue{1}
+			}
+			r := evalExprNode(n.Y, env, s)
+			return mapExpr(r, func(y float64) float64 { return exprBool(y != 0) })
+		}
+		r := evalExprNode(n.Y, env, s)
+		if n.Op == token.LAND {
+			return zipExpr(l, r, "&&", func(x, y float64) float64 { return exprBool(x != 0 && y != 0) })
+		}
+		return zipExpr(l, r, "||", func(x, y float64) float64 { return exprBool(x != 0 || y != 0) })
+	}
+	l := evalExprNode(n.X, env, s)
+	r := evalExprNode(n.Y, env, s)
+	op := n.Op.String()
+	switch n.Op {
+	case token.ADD:
+		return zipExpr(l, r, op, func(x, y float64) float64 { return x + y })
+	case token.SUB:
+		return zipExpr(l, r, op, func(x, y float64) float64 { return x - y })
+	case token.MUL:
+		return zipExpr(l, r, op, func(x, y float64) float64 { return x * y })
+	case token.QUO:
+		return zipExpr(l, r, op, func(x, y float64) float64 { return x / y })
+	case token.REM:
+		return zipExpr(l, r, op, math.Mod)
+	case token.LSS:
+		return zipExpr(l, r, op, func(x, y float64) float64 { return exprBool(x < y) })
+	case token.GTR:
+		return zipExpr(l, r, op, func(x, y float64) float64 { return exprBool(x > y) })
+	case token.LEQ:
+		return zipExpr(l, r, op, func(x, y float64) float64 { return exprBool(x <= y) })
+	case token.GEQ:
+		return zipExpr(l, r, op, func(x, y float64) float64 { return exprBool(x >= y) })
+	case token.EQL:
+		return zipExpr(l, r, op, func(x, y float64) float64 { return exprBool(x == y) })
+	case token.NEQ:
+		return zipExpr(l, r, op, func(x, y float64) float64 { return exprBool(x != y) })
+	}
+	panic("expression: unsupported operator " + op)
+}
+
+func evalExprCall(n *ast.CallExpr, env exprEnv, s *rng.Sampler) exprValue {
+	ident, ok := n.Fun.(*ast.Ident)
+	if !ok {
+		panic("expression: unsupported call target")
+	}
+	name := ident.Name
+	need := func(k int) {
+		if len(n.Args) != k {
+			panic(fmt.Sprintf("expression: %s takes %d arguments, got %d", name, k, len(n.Args)))
+		}
+	}
+	arg := func(i int) exprValue { return evalExprNode(n.Args[i], env, s) }
+
+	// where is evaluated lazily when the condition is scalar, so a guarded branch neither
+	// divides by zero nor consumes randomness.
+	if name == "where" {
+		need(3)
+		cond := arg(0)
+		if len(cond) == 1 {
+			if cond[0] != 0 {
+				return arg(1)
+			}
+			return arg(2)
+		}
+		a, b := arg(1), arg(2)
+		n := len(cond)
+		out := make(exprValue, n)
+		for i := 0; i < n; i++ {
+			if cond[i] != 0 {
+				out[i] = at(a, i)
+			} else {
+				out[i] = at(b, i)
+			}
+		}
+		return out
+	}
+
+	switch name {
+	case "clamp":
+		need(3)
+		x, lo, hi := arg(0), arg(1), arg(2)
+		return zipExpr(zipExpr(x, lo, name, math.Max), hi, name, math.Min)
+	case "min":
+		need(2)
+		return zipExpr(arg(0), arg(1), name, math.Min)
+	case "max":
+		need(2)
+		return zipExpr(arg(0), arg(1), name, math.Max)
+	case "pow":
+		need(2)
+		return zipExpr(arg(0), arg(1), name, math.Pow)
+	case "abs":
+		need(1)
+		return mapExpr(arg(0), math.Abs)
+	case "floor":
+		need(1)
+		return mapExpr(arg(0), math.Floor)
+	case "exp":
+		need(1)
+		return mapExpr(arg(0), math.Exp)
+	case "log":
+		need(1)
+		return mapExpr(arg(0), math.Log)
+	case "sqrt":
+		need(1)
+		return mapExpr(arg(0), math.Sqrt)
+	case "fill":
+		need(2)
+		n, x := arg(0), arg(1)
+		if len(n) != 1 {
+			panic("expression: fill's width must be a scalar")
+		}
+		w := int(n[0])
+		if w < 1 {
+			panic("expression: fill's width must be at least 1")
+		}
+		out := make(exprValue, w)
+		for i := 0; i < w; i++ {
+			out[i] = at(x, i)
+		}
+		return out
+	case "sum":
+		need(1)
+		total := 0.0
+		for _, x := range arg(0) {
+			total += x
+		}
+		return exprValue{total}
+	case "dot":
+		need(2)
+		a, b := arg(0), arg(1)
+		nn := broadcastLen(a, b, name)
+		total := 0.0
+		for i := 0; i < nn; i++ {
+			total += at(a, i) * at(b, i)
+		}
+		return exprValue{total}
+	case "normal":
+		need(2)
+		return drawExpr(arg(0), arg(1), name, func(mu, sigma float64) float64 {
+			return s.Normal(mu, sigma)
+		})
+	case "uniform":
+		need(2)
+		return drawExpr(arg(0), arg(1), name, func(lo, hi float64) float64 {
+			return s.Uniform(lo, hi)
+		})
+	case "exponential":
+		need(1)
+		return mapExpr(arg(0), func(rate float64) float64 { return s.Exponential(rate) })
+	case "poisson":
+		need(1)
+		return mapExpr(arg(0), func(lambda float64) float64 { return s.Poisson(lambda) })
+	case "gamma":
+		need(2)
+		return drawExpr(arg(0), arg(1), name, func(alpha, beta float64) float64 {
+			return s.Gamma(alpha, beta)
+		})
+	case "beta":
+		need(2)
+		return drawExpr(arg(0), arg(1), name, func(a, b float64) float64 {
+			return s.Beta(a, b)
+		})
+	case "binomial":
+		need(2)
+		// pkg/rng deliberately leaves Binomial on distuv (its three-branch algorithm was not
+		// worth reimplementing). Draw it from the Sampler's own generator so there is still
+		// exactly one RNG stream per partition and runs stay reproducible.
+		return drawExpr(arg(0), arg(1), name, func(nn, p float64) float64 {
+			return distuv.Binomial{N: nn, P: p, Src: s.Rand()}.Rand()
+		})
+	}
+	panic("expression: unknown function " + name)
+}
+
+// drawExpr applies a two-parameter draw elementwise, broadcasting the parameters. Each
+// element gets its own independent draw.
+func drawExpr(a, b exprValue, what string, f func(x, y float64) float64) exprValue {
+	n := broadcastLen(a, b, what)
+	out := make(exprValue, n)
+	for i := 0; i < n; i++ {
+		out[i] = f(at(a, i), at(b, i))
+	}
+	return out
+}

--- a/pkg/general/expression.go
+++ b/pkg/general/expression.go
@@ -52,19 +52,51 @@ type ExpressionBinding struct {
 //   - any binding declared earlier.
 //
 // Functions: where, clamp, min, max, abs, floor, exp, log, sqrt, pow, sin, cos, erf, erfc,
-// fill, sum, dot, iid and shared, plus the draws normal, uniform, exponential, poisson,
-// gamma, beta and binomial. Draws take expressions as their parameters, so compound sampling
-// composes naturally: a negative-binomial branching step is just poisson(gamma(shape, rate)).
+// fill, slice, concat, sum, dot, lag, each, iid and shared, plus the draws normal, uniform,
+// exponential, poisson, gamma, beta and binomial. Draws take expressions as their parameters,
+// so compound sampling composes naturally: a negative-binomial branching step is just
+// poisson(gamma(shape, rate)).
 //
 // sin and cos carry seasonality; erfc is the primitive a Gaussian CDF is built from, as
 // 0.5 * erfc(-x / sqrt(2)), which is what a probit link or a threshold-exceedance
 // probability needs.
 //
+// # Reaching past the current element, and past the current row
+//
+// Everything above is elementwise over the current row, which four things in the model
+// catalogue could not be written with. Each has one construct:
+//
+//   - slice(v, start, width) takes a block out of a vector, and concat(a, b, ...) joins
+//     values, for state and params that pack several quantities end to end.
+//   - lag(name, n) reads a partition's committed state n rows back, where a bare field name
+//     or an Upstreams alias only ever gives row 0. The partition must keep that many rows
+//     (its state_history_depth), and lag(x, 0) is x.
+//   - each(n, i, expr) builds a width-n value whose element i is expr evaluated with the lane
+//     index i bound. See below.
+//
+// each is the one construct that is not elementwise, and it is what makes an index shift,
+// a per-lane guard and a per-lane draw order sayable:
+//
+//   - Element i may read element i-1 of something, so a cohort can age: each(60, age,
+//     where(age == 0, births, survivors[age-1] * p)).
+//   - Inside a lane every value is a scalar, so where is lazy there. A lane that is switched
+//     off evaluates nothing and draws nothing — unlike a vector-guarded where, which must
+//     evaluate both branches and so consumes randomness in every lane.
+//   - Lanes run in order, so a lane's draws are taken before the next lane starts. An
+//     elementwise gamma(shape, rate) followed by poisson takes every gamma before any
+//     poisson; each(n, i, poisson(gamma(shape[i], rate[i]))) interleaves them per lane, the
+//     way a loop over areas does.
+//
+// each binds only the index and returns only values, so there is still no assignment and no
+// recursion, and an expression still always terminates. Draws inside it are explicit in the
+// sense below, exactly as they are inside iid.
+//
 // Conditionals are expressions, not statements: where(cond, a, b). When cond is a scalar the
 // untaken branch is not evaluated, so a guard such as where(n > 0, binomial(n, p), 0) is safe
 // and draws no randomness on the guarded path. When cond is a vector both branches must be
 // evaluated to select elementwise, as in NumPy, which means a vector-guarded draw consumes
-// randomness in every lane. Prefer scalar guards where that matters.
+// randomness in every lane. Prefer scalar guards where that matters — and see each below,
+// which makes a per-element guard scalar and so gets laziness back.
 //
 // # How wide a draw is
 //
@@ -80,8 +112,9 @@ type ExpressionBinding struct {
 // So x + normal(0, 1) over a 40-wide x is an error rather than quietly adding the same shock
 // to all forty elements. Draws with a vector parameter need no annotation.
 //
-// This is deliberately not a general-purpose language: there are no loops, no assignment and
-// no recursion, so an expression always terminates and can be read at a glance.
+// This is deliberately not a general-purpose language: there is no assignment and no
+// recursion, and the only repetition is each's bounded comprehension, so an expression always
+// terminates.
 type ExpressionIteration struct {
 	// Fields names the blocks of this partition's state, in layout order.
 	Fields []ExpressionField `yaml:"fields"`
@@ -96,6 +129,7 @@ type ExpressionIteration struct {
 	offsets        []int
 	width          int
 	upstreamIndex  map[string]int
+	fieldIndex     map[string]int
 	parsedBindings []parsedExprBinding
 	parsedOutputs  []ast.Expr
 	sampler        *rng.Sampler
@@ -128,6 +162,7 @@ func (e *ExpressionIteration) Configure(
 			len(e.Outputs), len(e.Fields)))
 	}
 	e.offsets = make([]int, len(e.Fields))
+	e.fieldIndex = make(map[string]int, len(e.Fields))
 	e.width = 0
 	for i, f := range e.Fields {
 		if f.Name == "" {
@@ -138,6 +173,7 @@ func (e *ExpressionIteration) Configure(
 		}
 		e.offsets[i] = e.width
 		e.width += e.fieldWidth(i)
+		e.fieldIndex[f.Name] = i
 	}
 	e.out = make([]float64, e.width)
 
@@ -201,7 +237,29 @@ func (e *ExpressionIteration) Iterate(
 	env["step"] = exprValue{float64(timestepsHistory.CurrentStepNumber)}
 	env["pi"] = exprValue{math.Pi}
 
-	ctx := &exprCtx{env: env, sampler: e.sampler}
+	// Resolved lazily rather than copied into env like the current row: a partition may hold
+	// a deep history, and almost no expression reads past row 0.
+	lag := func(name string, row int) exprValue {
+		read := func(index int, from, width int) exprValue {
+			history := stateHistories[index]
+			if row < 0 || row >= history.StateHistoryDepth {
+				panic(fmt.Sprintf(
+					"expression: lag(%s, %d) is outside the %d rows %s keeps; raise its "+
+						"state_history_depth", name, row, history.StateHistoryDepth, name))
+			}
+			return exprValue(history.Values.RawRowView(row)[from : from+width])
+		}
+		if index, ok := e.upstreamIndex[name]; ok {
+			return read(index, 0, stateHistories[index].StateWidth)
+		}
+		if i, ok := e.fieldIndex[name]; ok {
+			return read(partitionIndex, e.offsets[i], e.fieldWidth(i))
+		}
+		panic("expression: lag needs an upstream alias or one of this partition's own " +
+			"fields, got " + name)
+	}
+
+	ctx := &exprCtx{env: env, sampler: e.sampler, lag: lag}
 	for _, b := range e.parsedBindings {
 		env[b.name] = ctx.eval(b.expr)
 	}
@@ -231,15 +289,16 @@ type exprValue []float64
 type exprEnv map[string]exprValue
 
 // exprCtx carries the evaluation environment. drawsAreExplicit records whether evaluation is
-// inside an iid or shared call, which is where a scalar-parameter draw is unambiguous.
+// inside an iid, shared or each call, which is where a scalar-parameter draw is unambiguous.
 type exprCtx struct {
 	env              exprEnv
 	sampler          *rng.Sampler
+	lag              func(name string, row int) exprValue
 	drawsAreExplicit bool
 }
 
 func (c *exprCtx) explicit() *exprCtx {
-	return &exprCtx{env: c.env, sampler: c.sampler, drawsAreExplicit: true}
+	return &exprCtx{env: c.env, sampler: c.sampler, lag: c.lag, drawsAreExplicit: true}
 }
 
 func exprBool(b bool) float64 {
@@ -446,6 +505,67 @@ func (c *exprCtx) evalCall(n *ast.CallExpr) exprValue {
 		// sample is meant to apply across a whole field.
 		need(1)
 		return c.explicit().eval(n.Args[0])
+	case "each":
+		// iid with the lane index in scope: a vector of width count whose element i is the
+		// expression evaluated with that i bound.
+		//
+		// This is the one construct that is not elementwise, and it buys three things nothing
+		// else can. Element i may read element i-1 of something (a cohort ages), so an index
+		// shift becomes sayable. Everything inside a lane is a scalar, so where is lazy per
+		// lane and a skipped lane draws nothing. And lanes run in order, so a draw per lane
+		// interleaves the way a Go loop does rather than taking every gamma before any
+		// poisson. It is a bounded comprehension with no assignment and no recursion, so an
+		// expression still always terminates.
+		need(3)
+		countValue := arg(0)
+		if len(countValue) != 1 {
+			panic("expression: each's count must be a scalar")
+		}
+		count := int(countValue[0])
+		if count < 1 {
+			panic("expression: each's count must be at least 1")
+		}
+		index, ok := n.Args[1].(*ast.Ident)
+		if !ok {
+			panic("expression: each's second argument must be a name to bind the lane " +
+				"index to, as in each(40, i, ...)")
+		}
+		inner := c.explicit()
+		shadowed, wasBound := inner.env[index.Name]
+		out := make(exprValue, count)
+		for i := 0; i < count; i++ {
+			inner.env[index.Name] = exprValue{float64(i)}
+			v := inner.eval(n.Args[2])
+			if len(v) != 1 {
+				panic(fmt.Sprintf(
+					"expression: each expects a scalar-valued expression per lane, got "+
+						"width %d", len(v)))
+			}
+			out[i] = v[0]
+		}
+		// The env is shared with the enclosing scope, so the binding must not outlive the loop.
+		if wasBound {
+			inner.env[index.Name] = shadowed
+		} else {
+			delete(inner.env, index.Name)
+		}
+		return out
+	case "lag":
+		// A read of a partition's committed state further back than the current row, which is
+		// all a bare name or an upstreams alias ever gives.
+		need(2)
+		name, ok := n.Args[0].(*ast.Ident)
+		if !ok {
+			panic("expression: lag's first argument must be an upstream alias or a field name")
+		}
+		rowValue := arg(1)
+		if len(rowValue) != 1 {
+			panic("expression: lag's row must be a scalar")
+		}
+		if c.lag == nil {
+			panic("expression: lag is unavailable here")
+		}
+		return c.lag(name.Name, int(rowValue[0]))
 	}
 
 	switch name {
@@ -505,6 +625,35 @@ func (c *exprCtx) evalCall(n *ast.CallExpr) exprValue {
 		out := make(exprValue, w)
 		for i := 0; i < w; i++ {
 			out[i] = at(x, i)
+		}
+		return out
+	case "slice":
+		// A block of a vector, for state and params that pack several quantities end to end:
+		// the nine coefficients of a channel inside one flat thirty-six-wide param, say.
+		need(3)
+		v, fromValue, widthValue := arg(0), arg(1), arg(2)
+		if len(fromValue) != 1 || len(widthValue) != 1 {
+			panic("expression: slice's start and width must be scalars")
+		}
+		from, width := int(fromValue[0]), int(widthValue[0])
+		if width < 1 {
+			panic("expression: slice's width must be at least 1")
+		}
+		if from < 0 || from+width > len(v) {
+			panic(fmt.Sprintf(
+				"expression: slice(%d, %d) is outside a width-%d value", from, width, len(v)))
+		}
+		return append(make(exprValue, 0, width), v[from:from+width]...)
+	case "concat":
+		// The other half of slice: assemble a field from pieces that are computed
+		// differently, such as a cohort's boundary buckets against its interior.
+		if len(n.Args) < 2 {
+			panic("expression: concat takes at least 2 arguments, got " +
+				strconv.Itoa(len(n.Args)))
+		}
+		out := make(exprValue, 0, len(n.Args))
+		for i := range n.Args {
+			out = append(out, arg(i)...)
 		}
 		return out
 	case "sum":

--- a/pkg/general/expression.go
+++ b/pkg/general/expression.go
@@ -48,12 +48,17 @@ type ExpressionBinding struct {
 //   - each entry of the partition's params, by key;
 //   - each alias in Upstreams, holding that partition's current state (index it as alias[i]);
 //   - dt, the timestep increment; t, the current cumulative time; step, the step number;
+//   - pi;
 //   - any binding declared earlier.
 //
-// Functions: where, clamp, min, max, abs, floor, exp, log, sqrt, pow, fill, sum, dot, iid and
-// shared, plus the draws normal, uniform, exponential, poisson, gamma, beta and binomial.
-// Draws take expressions as their parameters, so compound sampling composes naturally: a
-// negative-binomial branching step is just poisson(gamma(shape, rate)).
+// Functions: where, clamp, min, max, abs, floor, exp, log, sqrt, pow, sin, cos, erf, erfc,
+// fill, sum, dot, iid and shared, plus the draws normal, uniform, exponential, poisson,
+// gamma, beta and binomial. Draws take expressions as their parameters, so compound sampling
+// composes naturally: a negative-binomial branching step is just poisson(gamma(shape, rate)).
+//
+// sin and cos carry seasonality; erfc is the primitive a Gaussian CDF is built from, as
+// 0.5 * erfc(-x / sqrt(2)), which is what a probit link or a threshold-exceedance
+// probability needs.
 //
 // Conditionals are expressions, not statements: where(cond, a, b). When cond is a scalar the
 // untaken branch is not evaluated, so a guard such as where(n > 0, binomial(n, p), 0) is safe
@@ -194,6 +199,7 @@ func (e *ExpressionIteration) Iterate(
 	env["dt"] = exprValue{timestepsHistory.NextIncrement}
 	env["t"] = exprValue{timestepsHistory.Values.AtVec(0)}
 	env["step"] = exprValue{float64(timestepsHistory.CurrentStepNumber)}
+	env["pi"] = exprValue{math.Pi}
 
 	ctx := &exprCtx{env: env, sampler: e.sampler}
 	for _, b := range e.parsedBindings {
@@ -471,6 +477,21 @@ func (c *exprCtx) evalCall(n *ast.CallExpr) exprValue {
 	case "sqrt":
 		need(1)
 		return mapExpr(arg(0), math.Sqrt)
+	case "sin":
+		need(1)
+		return mapExpr(arg(0), math.Sin)
+	case "cos":
+		need(1)
+		return mapExpr(arg(0), math.Cos)
+	case "erf":
+		need(1)
+		return mapExpr(arg(0), math.Erf)
+	case "erfc":
+		// The primitive a Gaussian CDF is built from: 0.5 * erfc(-x / sqrt(2)). Kept as
+		// erfc rather than offering the CDF directly so it matches math.Erfc exactly, which
+		// is what lets a model expressed here agree with compiled Go to rounding.
+		need(1)
+		return mapExpr(arg(0), math.Erfc)
 	case "fill":
 		need(2)
 		nv, x := arg(0), arg(1)

--- a/pkg/general/expression.go
+++ b/pkg/general/expression.go
@@ -52,10 +52,10 @@ type ExpressionBinding struct {
 //   - any binding declared earlier.
 //
 // Functions: where, clamp, min, max, abs, floor, exp, log, sqrt, pow, sin, cos, erf, erfc,
-// fill, slice, concat, sum, dot, lag, each, iid and shared, plus the draws normal, uniform,
-// exponential, poisson, gamma, beta and binomial. Draws take expressions as their parameters,
-// so compound sampling composes naturally: a negative-binomial branching step is just
-// poisson(gamma(shape, rate)).
+// fill, width, slice, concat, sum, dot, lag, each, iid and shared, plus the draws normal,
+// uniform, exponential, poisson, gamma, beta and binomial. Draws take expressions as their
+// parameters, so compound sampling composes naturally: a negative-binomial branching step is
+// just poisson(gamma(shape, rate)).
 //
 // sin and cos carry seasonality; erfc is the primitive a Gaussian CDF is built from, as
 // 0.5 * erfc(-x / sqrt(2)), which is what a probit link or a threshold-exceedance
@@ -67,7 +67,8 @@ type ExpressionBinding struct {
 // catalogue could not be written with. Each has one construct:
 //
 //   - slice(v, start, width) takes a block out of a vector, and concat(a, b, ...) joins
-//     values, for state and params that pack several quantities end to end.
+//     values, for state and params that pack several quantities end to end. width(v) is how
+//     many elements v has, for a spec that adapts to a param's length rather than fixing it.
 //   - lag(name, n) reads a partition's committed state n rows back, where a bare field name
 //     or an Upstreams alias only ever gives row 0. The partition must keep that many rows
 //     (its state_history_depth), and lag(x, 0) is x.
@@ -321,6 +322,18 @@ func broadcastLen(a, b exprValue, what string) int {
 	panic(fmt.Sprintf("expression: cannot combine widths %d and %d in %s", len(a), len(b), what))
 }
 
+// toIndex converts a computed index or count to an int, rejecting the values Go leaves
+// undefined. This is not pedantry: int(NaN) does not panic and is not portable — on arm64 it
+// is 0, so a NaN index sails through a bounds check and silently reads element 0, while on
+// amd64 it is the most negative int and the same expression panics. An expression that
+// answers differently per architecture is worse than one that fails.
+func toIndex(x float64, what string) int {
+	if math.IsNaN(x) || math.IsInf(x, 0) {
+		panic(fmt.Sprintf("expression: %s is %v, which is not a whole number", what, x))
+	}
+	return int(x)
+}
+
 func at(v exprValue, i int) float64 {
 	if len(v) == 1 {
 		return v[0]
@@ -377,7 +390,7 @@ func (c *exprCtx) eval(node ast.Expr) exprValue {
 		if len(idx) != 1 {
 			panic("expression: index must be a scalar")
 		}
-		i := int(idx[0])
+		i := toIndex(idx[0], "an index")
 		if i < 0 || i >= len(v) {
 			panic(fmt.Sprintf("expression: index %d out of range for width %d", i, len(v)))
 		}
@@ -485,7 +498,7 @@ func (c *exprCtx) evalCall(n *ast.CallExpr) exprValue {
 		if len(nv) != 1 {
 			panic("expression: iid's count must be a scalar")
 		}
-		count := int(nv[0])
+		count := toIndex(nv[0], "iid's count")
 		if count < 1 {
 			panic("expression: iid's count must be at least 1")
 		}
@@ -521,7 +534,7 @@ func (c *exprCtx) evalCall(n *ast.CallExpr) exprValue {
 		if len(countValue) != 1 {
 			panic("expression: each's count must be a scalar")
 		}
-		count := int(countValue[0])
+		count := toIndex(countValue[0], "each's count")
 		if count < 1 {
 			panic("expression: each's count must be at least 1")
 		}
@@ -565,7 +578,7 @@ func (c *exprCtx) evalCall(n *ast.CallExpr) exprValue {
 		if c.lag == nil {
 			panic("expression: lag is unavailable here")
 		}
-		return c.lag(name.Name, int(rowValue[0]))
+		return c.lag(name.Name, toIndex(rowValue[0], "lag's row"))
 	}
 
 	switch name {
@@ -618,7 +631,7 @@ func (c *exprCtx) evalCall(n *ast.CallExpr) exprValue {
 		if len(nv) != 1 {
 			panic("expression: fill's width must be a scalar")
 		}
-		w := int(nv[0])
+		w := toIndex(nv[0], "fill's width")
 		if w < 1 {
 			panic("expression: fill's width must be at least 1")
 		}
@@ -635,7 +648,8 @@ func (c *exprCtx) evalCall(n *ast.CallExpr) exprValue {
 		if len(fromValue) != 1 || len(widthValue) != 1 {
 			panic("expression: slice's start and width must be scalars")
 		}
-		from, width := int(fromValue[0]), int(widthValue[0])
+		from := toIndex(fromValue[0], "slice's start")
+		width := toIndex(widthValue[0], "slice's width")
 		if width < 1 {
 			panic("expression: slice's width must be at least 1")
 		}
@@ -656,6 +670,12 @@ func (c *exprCtx) evalCall(n *ast.CallExpr) exprValue {
 			out = append(out, arg(i)...)
 		}
 		return out
+	case "width":
+		// How many elements a value has, for a spec that must adapt to a param's length
+		// rather than hard-code it. Without it the only way to ask is a trick, and the
+		// obvious spelling of that trick, sum(0 * x + 1), is silently wrong: 0 * NaN is NaN.
+		need(1)
+		return exprValue{float64(len(arg(0)))}
 	case "sum":
 		need(1)
 		total := 0.0

--- a/pkg/general/expression.go
+++ b/pkg/general/expression.go
@@ -14,63 +14,66 @@ import (
 	"github.com/umbralcalc/stochadex/pkg/simulator"
 )
 
-// ExpressionField names a contiguous block of a partition's state vector so that
-// expressions can refer to it by name instead of by index. Fields are laid out in the
-// order given, so a partition with fields {"soc", 1} and {"charge", 1} has state
-// [soc, charge], and one with {"infectious", 40} and {"cumulative", 40} has an
-// 80-wide state of two 40-wide blocks.
+// ExpressionField names a contiguous block of a partition's state so that expressions can
+// refer to it by name instead of by index. Fields are laid out in the order given, so a
+// partition with fields soc and charge has state [soc, charge], and one with a 40-wide
+// infectious and a 40-wide cumulative has an 80-wide state of two 40-wide blocks.
 type ExpressionField struct {
+	// Name is how expressions refer to this block.
 	Name string `yaml:"name"`
-	// Width defaults to 1 when zero.
+	// Width is the number of state elements in the block, defaulting to 1.
 	Width int `yaml:"width,omitempty"`
 }
 
 // ExpressionBinding is one named intermediate value in the evaluation DAG. Bindings are
 // evaluated in order, and each may refer to any binding declared before it.
 type ExpressionBinding struct {
+	// Name is how later expressions refer to this value.
 	Name string `yaml:"name"`
+	// Expr is the expression computing it.
 	Expr string `yaml:"expr"`
 }
 
 // ExpressionIteration is a declarative Iteration: the per-step update is given as string
-// expressions rather than Go code, so a whole partition can be specified as data (and hence
+// expressions rather than as Go, so a whole partition can be specified as data (and hence
 // from YAML, or by an agent) with no compilation step.
 //
-// The update is a small DAG: Bindings are named intermediates evaluated in order, then one
+// The update is a small DAG. Bindings are named intermediates evaluated in order, then one
 // Outputs expression per field produces that field's next value. Everything is evaluated
 // elementwise over vectors, with length-1 values broadcasting, so the same expression works
 // for a scalar partition and a 10,000-element one.
 //
 // Names available to expressions:
-//   - each of this partition's own Fields, holding its current (most recent) value;
-//   - each entry of Params, by key;
-//   - each alias in Upstreams, holding that partition's current state vector (index it with
-//     alias[i]);
-//   - "dt" (the timestep increment), "t" (the current cumulative time) and "step" (the
-//     current step number);
-//   - any Binding declared earlier.
+//   - each of this partition's own fields, holding its current value;
+//   - each entry of the partition's params, by key;
+//   - each alias in Upstreams, holding that partition's current state (index it as alias[i]);
+//   - dt, the timestep increment; t, the current cumulative time; step, the step number;
+//   - any binding declared earlier.
 //
-// Functions: where, clamp, min, max, abs, floor, exp, log, sqrt, pow, fill, sum, dot, and
-// the stochastic draws normal, uniform, exponential, poisson, gamma, beta and binomial.
-// Draws take expressions as their parameters, so compound sampling composes naturally — a
+// Functions: where, clamp, min, max, abs, floor, exp, log, sqrt, pow, fill, sum, dot, iid and
+// shared, plus the draws normal, uniform, exponential, poisson, gamma, beta and binomial.
+// Draws take expressions as their parameters, so compound sampling composes naturally: a
 // negative-binomial branching step is just poisson(gamma(shape, rate)).
+//
+// Conditionals are expressions, not statements: where(cond, a, b). When cond is a scalar the
+// untaken branch is not evaluated, so a guard such as where(n > 0, binomial(n, p), 0) is safe
+// and draws no randomness on the guarded path. When cond is a vector both branches must be
+// evaluated to select elementwise, as in NumPy, which means a vector-guarded draw consumes
+// randomness in every lane. Prefer scalar guards where that matters.
 //
 // # How wide a draw is
 //
-// A draw produces one independent sample per element of its broadcast parameters. So
-// poisson(rates) with a 40-wide rates param gives 40 independent draws, which is the usual
-// modelling form. But normal(0, 1) has only scalar parameters, so it is a SINGLE draw — and
-// if that is then combined with a wide value it broadcasts, meaning the same sample lands in
-// every element. `x + normal(0, 1)` over a 40-wide x adds one shared shock to all 40, which
-// is rarely what is meant. For independent noise per element either give the draw a
-// vector-valued parameter (the natural form: a per-element sigma), or widen it explicitly
-// with fill: `x + normal(fill(40, 0), 1)`, or `x + normal(0 * x, 1)` to match x's width.
+// A draw produces one independent sample per element of its broadcast parameters, so
+// poisson(rates) over a 40-wide rates gives 40 independent draws. When every parameter is a
+// scalar the width is instead ambiguous: one sample reused across a field and forty
+// independent ones are both reasonable readings, and both are things people mean. Rather than
+// pick silently, a scalar-parameter draw is rejected unless the intent is stated:
 //
-// Conditionals are expressions, not statements: where(cond, a, b). When cond is a scalar the
-// untaken branch is NOT evaluated, so guards like where(n > 0, binomial(n, p), 0) are safe
-// and draw no randomness on the guarded path. When cond is a vector both branches must be
-// evaluated to select elementwise (as in NumPy), which means a vector-guarded draw consumes
-// randomness in every lane. Prefer scalar guards where that matters.
+//	iid(40, normal(0, 1))     forty independent samples
+//	shared(normal(0, 1))      one sample, free to broadcast across a field
+//
+// So x + normal(0, 1) over a 40-wide x is an error rather than quietly adding the same shock
+// to all forty elements. Draws with a vector parameter need no annotation.
 //
 // This is deliberately not a general-purpose language: there are no loops, no assignment and
 // no recursion, so an expression always terminates and can be read at a glance.
@@ -78,12 +81,11 @@ type ExpressionIteration struct {
 	// Fields names the blocks of this partition's state, in layout order.
 	Fields []ExpressionField `yaml:"fields"`
 	// Upstreams maps an alias used in expressions to another partition's name, making that
-	// partition's current state readable. Resolving names to indices happens in Configure.
+	// partition's current state readable.
 	Upstreams map[string]string `yaml:"upstreams,omitempty"`
 	// Bindings are ordered named intermediates.
 	Bindings []ExpressionBinding `yaml:"bindings,omitempty"`
-	// Outputs holds one expression per entry of Fields, in the same order, each evaluating
-	// to that field's width (or to a scalar, which is broadcast across it).
+	// Outputs holds one expression per entry of Fields, in the same order.
 	Outputs []string `yaml:"outputs"`
 
 	offsets        []int
@@ -100,10 +102,17 @@ type parsedExprBinding struct {
 	expr ast.Expr
 }
 
+func (e *ExpressionIteration) fieldWidth(i int) int {
+	if w := e.Fields[i].Width; w != 0 {
+		return w
+	}
+	return 1
+}
+
 // Configure resolves the state layout, resolves upstream partition names to indices, parses
-// every expression once, and seeds the draw sampler from the partition's seed. It panics on
-// a malformed specification: a partition that cannot be built is a hard configuration error,
-// not something to discover mid-run.
+// every expression once, and seeds the draw sampler from the partition's seed. It panics on a
+// malformed specification: a partition that cannot be built is a configuration error, not
+// something to discover mid-run.
 func (e *ExpressionIteration) Configure(
 	partitionIndex int,
 	settings *simulator.Settings,
@@ -119,15 +128,11 @@ func (e *ExpressionIteration) Configure(
 		if f.Name == "" {
 			panic("expression: field at index " + strconv.Itoa(i) + " has no name")
 		}
-		w := f.Width
-		if w == 0 {
-			w = 1
-		}
-		if w < 0 {
+		if f.Width < 0 {
 			panic("expression: field " + f.Name + " has negative width")
 		}
 		e.offsets[i] = e.width
-		e.width += w
+		e.width += e.fieldWidth(i)
 	}
 	e.out = make([]float64, e.width)
 
@@ -168,7 +173,7 @@ func (e *ExpressionIteration) Configure(
 }
 
 // Iterate evaluates the bindings in order and then each field's output expression,
-// concatenating the results into the next state vector.
+// concatenating the results into the next state.
 func (e *ExpressionIteration) Iterate(
 	params *simulator.Params,
 	partitionIndex int,
@@ -178,11 +183,7 @@ func (e *ExpressionIteration) Iterate(
 	env := make(exprEnv, len(e.Fields)+len(params.Map)+len(e.upstreamIndex)+3)
 	state := stateHistories[partitionIndex].Values.RawRowView(0)
 	for i, f := range e.Fields {
-		w := f.Width
-		if w == 0 {
-			w = 1
-		}
-		env[f.Name] = exprValue(state[e.offsets[i] : e.offsets[i]+w])
+		env[f.Name] = exprValue(state[e.offsets[i] : e.offsets[i]+e.fieldWidth(i)])
 	}
 	for name, values := range params.Map {
 		env[name] = exprValue(values)
@@ -194,15 +195,13 @@ func (e *ExpressionIteration) Iterate(
 	env["t"] = exprValue{timestepsHistory.Values.AtVec(0)}
 	env["step"] = exprValue{float64(timestepsHistory.CurrentStepNumber)}
 
+	ctx := &exprCtx{env: env, sampler: e.sampler}
 	for _, b := range e.parsedBindings {
-		env[b.name] = evalExprNode(b.expr, env, e.sampler)
+		env[b.name] = ctx.eval(b.expr)
 	}
 	for i, o := range e.parsedOutputs {
-		w := e.Fields[i].Width
-		if w == 0 {
-			w = 1
-		}
-		v := evalExprNode(o, env, e.sampler)
+		w := e.fieldWidth(i)
+		v := ctx.eval(o)
 		switch len(v) {
 		case w:
 			copy(e.out[e.offsets[i]:], v)
@@ -219,11 +218,23 @@ func (e *ExpressionIteration) Iterate(
 	return e.out
 }
 
-// exprValue is the single value type: a vector, where length 1 means a scalar and
-// broadcasts against any other length.
+// exprValue is the single value type: a vector, where length 1 means a scalar and broadcasts
+// against any other length.
 type exprValue []float64
 
 type exprEnv map[string]exprValue
+
+// exprCtx carries the evaluation environment. drawsAreExplicit records whether evaluation is
+// inside an iid or shared call, which is where a scalar-parameter draw is unambiguous.
+type exprCtx struct {
+	env              exprEnv
+	sampler          *rng.Sampler
+	drawsAreExplicit bool
+}
+
+func (c *exprCtx) explicit() *exprCtx {
+	return &exprCtx{env: c.env, sampler: c.sampler, drawsAreExplicit: true}
+}
 
 func exprBool(b bool) float64 {
 	if b {
@@ -269,7 +280,7 @@ func mapExpr(a exprValue, f func(x float64) float64) exprValue {
 	return out
 }
 
-func evalExprNode(node ast.Expr, env exprEnv, s *rng.Sampler) exprValue {
+func (c *exprCtx) eval(node ast.Expr) exprValue {
 	switch n := node.(type) {
 	case *ast.BasicLit:
 		v, err := strconv.ParseFloat(n.Value, 64)
@@ -278,15 +289,15 @@ func evalExprNode(node ast.Expr, env exprEnv, s *rng.Sampler) exprValue {
 		}
 		return exprValue{v}
 	case *ast.Ident:
-		v, ok := env[n.Name]
+		v, ok := c.env[n.Name]
 		if !ok {
 			panic("expression: unknown name " + n.Name)
 		}
 		return v
 	case *ast.ParenExpr:
-		return evalExprNode(n.X, env, s)
+		return c.eval(n.X)
 	case *ast.UnaryExpr:
-		v := evalExprNode(n.X, env, s)
+		v := c.eval(n.X)
 		switch n.Op {
 		case token.SUB:
 			return mapExpr(v, func(x float64) float64 { return -x })
@@ -296,8 +307,8 @@ func evalExprNode(node ast.Expr, env exprEnv, s *rng.Sampler) exprValue {
 			return mapExpr(v, func(x float64) float64 { return exprBool(x == 0) })
 		}
 	case *ast.IndexExpr:
-		v := evalExprNode(n.X, env, s)
-		idx := evalExprNode(n.Index, env, s)
+		v := c.eval(n.X)
+		idx := c.eval(n.Index)
 		if len(idx) != 1 {
 			panic("expression: index must be a scalar")
 		}
@@ -307,17 +318,17 @@ func evalExprNode(node ast.Expr, env exprEnv, s *rng.Sampler) exprValue {
 		}
 		return exprValue{v[i]}
 	case *ast.BinaryExpr:
-		return evalExprBinary(n, env, s)
+		return c.evalBinary(n)
 	case *ast.CallExpr:
-		return evalExprCall(n, env, s)
+		return c.evalCall(n)
 	}
 	panic("expression: unsupported syntax")
 }
 
-func evalExprBinary(n *ast.BinaryExpr, env exprEnv, s *rng.Sampler) exprValue {
+func (c *exprCtx) evalBinary(n *ast.BinaryExpr) exprValue {
 	// && and || short-circuit only when the left side is a scalar, matching where's rule.
 	if n.Op == token.LAND || n.Op == token.LOR {
-		l := evalExprNode(n.X, env, s)
+		l := c.eval(n.X)
 		if len(l) == 1 {
 			if n.Op == token.LAND && l[0] == 0 {
 				return exprValue{0}
@@ -325,17 +336,20 @@ func evalExprBinary(n *ast.BinaryExpr, env exprEnv, s *rng.Sampler) exprValue {
 			if n.Op == token.LOR && l[0] != 0 {
 				return exprValue{1}
 			}
-			r := evalExprNode(n.Y, env, s)
-			return mapExpr(r, func(y float64) float64 { return exprBool(y != 0) })
+			return mapExpr(c.eval(n.Y), func(y float64) float64 { return exprBool(y != 0) })
 		}
-		r := evalExprNode(n.Y, env, s)
+		r := c.eval(n.Y)
 		if n.Op == token.LAND {
-			return zipExpr(l, r, "&&", func(x, y float64) float64 { return exprBool(x != 0 && y != 0) })
+			return zipExpr(l, r, "&&", func(x, y float64) float64 {
+				return exprBool(x != 0 && y != 0)
+			})
 		}
-		return zipExpr(l, r, "||", func(x, y float64) float64 { return exprBool(x != 0 || y != 0) })
+		return zipExpr(l, r, "||", func(x, y float64) float64 {
+			return exprBool(x != 0 || y != 0)
+		})
 	}
-	l := evalExprNode(n.X, env, s)
-	r := evalExprNode(n.Y, env, s)
+	l := c.eval(n.X)
+	r := c.eval(n.Y)
 	op := n.Op.String()
 	switch n.Op {
 	case token.ADD:
@@ -364,7 +378,7 @@ func evalExprBinary(n *ast.BinaryExpr, env exprEnv, s *rng.Sampler) exprValue {
 	panic("expression: unsupported operator " + op)
 }
 
-func evalExprCall(n *ast.CallExpr, env exprEnv, s *rng.Sampler) exprValue {
+func (c *exprCtx) evalCall(n *ast.CallExpr) exprValue {
 	ident, ok := n.Fun.(*ast.Ident)
 	if !ok {
 		panic("expression: unsupported call target")
@@ -375,11 +389,12 @@ func evalExprCall(n *ast.CallExpr, env exprEnv, s *rng.Sampler) exprValue {
 			panic(fmt.Sprintf("expression: %s takes %d arguments, got %d", name, k, len(n.Args)))
 		}
 	}
-	arg := func(i int) exprValue { return evalExprNode(n.Args[i], env, s) }
+	arg := func(i int) exprValue { return c.eval(n.Args[i]) }
 
-	// where is evaluated lazily when the condition is scalar, so a guarded branch neither
-	// divides by zero nor consumes randomness.
-	if name == "where" {
+	switch name {
+	case "where":
+		// Lazy on a scalar condition, so a guarded branch neither divides by zero nor
+		// consumes randomness.
 		need(3)
 		cond := arg(0)
 		if len(cond) == 1 {
@@ -389,9 +404,8 @@ func evalExprCall(n *ast.CallExpr, env exprEnv, s *rng.Sampler) exprValue {
 			return arg(2)
 		}
 		a, b := arg(1), arg(2)
-		n := len(cond)
-		out := make(exprValue, n)
-		for i := 0; i < n; i++ {
+		out := make(exprValue, len(cond))
+		for i := range cond {
 			if cond[i] != 0 {
 				out[i] = at(a, i)
 			} else {
@@ -399,6 +413,33 @@ func evalExprCall(n *ast.CallExpr, env exprEnv, s *rng.Sampler) exprValue {
 			}
 		}
 		return out
+	case "iid":
+		// Evaluate the expression n times over, giving n independent samples.
+		need(2)
+		nv := arg(0)
+		if len(nv) != 1 {
+			panic("expression: iid's count must be a scalar")
+		}
+		count := int(nv[0])
+		if count < 1 {
+			panic("expression: iid's count must be at least 1")
+		}
+		inner := c.explicit()
+		out := make(exprValue, count)
+		for i := 0; i < count; i++ {
+			v := inner.eval(n.Args[1])
+			if len(v) != 1 {
+				panic(fmt.Sprintf(
+					"expression: iid expects a scalar-valued expression, got width %d", len(v)))
+			}
+			out[i] = v[0]
+		}
+		return out
+	case "shared":
+		// One evaluation whose result may broadcast: the explicit way to say that a single
+		// sample is meant to apply across a whole field.
+		need(1)
+		return c.explicit().eval(n.Args[0])
 	}
 
 	switch name {
@@ -432,11 +473,11 @@ func evalExprCall(n *ast.CallExpr, env exprEnv, s *rng.Sampler) exprValue {
 		return mapExpr(arg(0), math.Sqrt)
 	case "fill":
 		need(2)
-		n, x := arg(0), arg(1)
-		if len(n) != 1 {
+		nv, x := arg(0), arg(1)
+		if len(nv) != 1 {
 			panic("expression: fill's width must be a scalar")
 		}
-		w := int(n[0])
+		w := int(nv[0])
 		if w < 1 {
 			panic("expression: fill's width must be at least 1")
 		}
@@ -463,46 +504,61 @@ func evalExprCall(n *ast.CallExpr, env exprEnv, s *rng.Sampler) exprValue {
 		return exprValue{total}
 	case "normal":
 		need(2)
-		return drawExpr(arg(0), arg(1), name, func(mu, sigma float64) float64 {
-			return s.Normal(mu, sigma)
-		})
+		return c.draw2(name, arg(0), arg(1), c.sampler.Normal)
 	case "uniform":
 		need(2)
-		return drawExpr(arg(0), arg(1), name, func(lo, hi float64) float64 {
-			return s.Uniform(lo, hi)
+		return c.draw2(name, arg(0), arg(1), c.sampler.Uniform)
+	case "gamma":
+		need(2)
+		return c.draw2(name, arg(0), arg(1), c.sampler.Gamma)
+	case "beta":
+		need(2)
+		return c.draw2(name, arg(0), arg(1), c.sampler.Beta)
+	case "binomial":
+		need(2)
+		// pkg/rng leaves Binomial on distuv, whose three-branch algorithm was not worth
+		// reimplementing. Draw from the sampler's own generator so a partition still has
+		// exactly one stream and runs stay reproducible.
+		return c.draw2(name, arg(0), arg(1), func(nn, p float64) float64 {
+			return distuv.Binomial{N: nn, P: p, Src: c.sampler.Rand()}.Rand()
 		})
 	case "exponential":
 		need(1)
-		return mapExpr(arg(0), func(rate float64) float64 { return s.Exponential(rate) })
+		return c.draw1(name, arg(0), c.sampler.Exponential)
 	case "poisson":
 		need(1)
-		return mapExpr(arg(0), func(lambda float64) float64 { return s.Poisson(lambda) })
-	case "gamma":
-		need(2)
-		return drawExpr(arg(0), arg(1), name, func(alpha, beta float64) float64 {
-			return s.Gamma(alpha, beta)
-		})
-	case "beta":
-		need(2)
-		return drawExpr(arg(0), arg(1), name, func(a, b float64) float64 {
-			return s.Beta(a, b)
-		})
-	case "binomial":
-		need(2)
-		// pkg/rng deliberately leaves Binomial on distuv (its three-branch algorithm was not
-		// worth reimplementing). Draw it from the Sampler's own generator so there is still
-		// exactly one RNG stream per partition and runs stay reproducible.
-		return drawExpr(arg(0), arg(1), name, func(nn, p float64) float64 {
-			return distuv.Binomial{N: nn, P: p, Src: s.Rand()}.Rand()
-		})
+		return c.draw1(name, arg(0), c.sampler.Poisson)
 	}
 	panic("expression: unknown function " + name)
 }
 
-// drawExpr applies a two-parameter draw elementwise, broadcasting the parameters. Each
-// element gets its own independent draw.
-func drawExpr(a, b exprValue, what string, f func(x, y float64) float64) exprValue {
-	n := broadcastLen(a, b, what)
+// checkDrawWidth rejects a draw whose parameters are all scalars unless the caller has said
+// which reading is meant. See the type doc under "How wide a draw is".
+func (c *exprCtx) checkDrawWidth(name string, width int) {
+	if width == 1 && !c.drawsAreExplicit {
+		panic(fmt.Sprintf(
+			"expression: %s has only scalar parameters, so its width is ambiguous; "+
+				"write iid(n, %s(...)) for n independent samples, or shared(%s(...)) for "+
+				"one sample reused across the field",
+			name, name, name))
+	}
+}
+
+// draw1 applies a one-parameter draw elementwise; each element is an independent sample.
+func (c *exprCtx) draw1(name string, a exprValue, f func(x float64) float64) exprValue {
+	c.checkDrawWidth(name, len(a))
+	return mapExpr(a, f)
+}
+
+// draw2 applies a two-parameter draw elementwise, broadcasting the parameters; each element
+// is an independent sample.
+func (c *exprCtx) draw2(
+	name string,
+	a, b exprValue,
+	f func(x, y float64) float64,
+) exprValue {
+	n := broadcastLen(a, b, name)
+	c.checkDrawWidth(name, n)
 	out := make(exprValue, n)
 	for i := 0; i < n; i++ {
 		out[i] = f(at(a, i), at(b, i))

--- a/pkg/general/expression_constructs_settings.yaml
+++ b/pkg/general/expression_constructs_settings.yaml
@@ -1,0 +1,18 @@
+iterations:
+- name: cohort
+  params:
+    births: [5.0]
+    survival: [0.8]
+  init_state_values: [10.0, 8.0, 6.0, 4.0]
+  seed: 3
+  state_width: 4
+  state_history_depth: 4
+- name: reader
+  params:
+    coefficients: [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+  init_state_values: [0.0, 0.0]
+  seed: 4
+  state_width: 2
+  state_history_depth: 2
+init_time_value: 0.0
+timesteps_history_depth: 1

--- a/pkg/general/expression_eval_test.go
+++ b/pkg/general/expression_eval_test.go
@@ -1,0 +1,536 @@
+package general
+
+import (
+	"go/parser"
+	"strings"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+	"gonum.org/v1/gonum/stat/distuv"
+
+	"github.com/umbralcalc/stochadex/pkg/rng"
+	"github.com/umbralcalc/stochadex/pkg/simulator"
+)
+
+// The evaluator's surface: every operator, every function, and every way of getting it wrong.
+// These are contract tests rather than coverage filler — an expression is a model, so an
+// operator that quietly disagrees with Go is a model that quietly disagrees with its twin.
+
+// evalScalar evaluates a one-output expression over scalar params and returns the result.
+func evalScalar(t *testing.T, expr string, params map[string][]float64) float64 {
+	t.Helper()
+	return evalOnce(t, &ExpressionIteration{
+		Fields:  []ExpressionField{{Name: "self"}},
+		Outputs: []string{expr},
+	}, []float64{0}, params)[0]
+}
+
+func TestExpressionOperators(t *testing.T) {
+	// a and b are chosen so that no two operators agree on them, which is what makes a
+	// mis-wired operator fail rather than coincide.
+	params := map[string][]float64{"a": {7}, "b": {3}}
+	for _, c := range []struct {
+		expr string
+		want float64
+	}{
+		{"a + b", 10},
+		{"a - b", 4},
+		{"a * b", 21},
+		{"a / b", 7.0 / 3.0},
+		{"a % b", 1},
+		{"-a", -7},
+		{"+a", 7},
+		{"!(a - 7)", 1}, // not of zero is one
+		{"!a", 0},
+		{"a < b", 0},
+		{"b < a", 1},
+		{"a > b", 1},
+		{"a <= b", 0},
+		{"b <= b", 1},
+		{"a >= b", 1},
+		{"b >= a", 0},
+		{"a == b", 0},
+		{"b == b", 1},
+		{"a != b", 1},
+		{"b != b", 0},
+		// Go's precedence, because the expressions are parsed by Go.
+		{"2 + 3 * 4", 14},
+		{"(2 + 3) * 4", 20},
+		{"-a + b", -4},
+		{"a - b - b", 1}, // left-associative, not 7-(3-3)
+	} {
+		t.Run(c.expr, func(t *testing.T) {
+			if got := evalScalar(t, c.expr, params); got != c.want {
+				t.Errorf("%s: got %v, want %v", c.expr, got, c.want)
+			}
+		})
+	}
+}
+
+func TestExpressionLogicalOperators(t *testing.T) {
+	t.Run("scalar and or short-circuit", func(t *testing.T) {
+		// The untaken side is never evaluated, so an undefined name on it is not an error.
+		// This is what makes a guard such as n > 0 && p(n) safe.
+		for _, c := range []struct {
+			expr string
+			want float64
+		}{
+			{"0 && nope", 0},
+			{"1 || nope", 1},
+			{"1 && 1", 1},
+			{"1 && 0", 0},
+			{"0 || 0", 0},
+			{"0 || 1", 1},
+			// The right side is normalised to 0/1 rather than passed through.
+			{"1 && 5", 1},
+			{"0 || 5", 1},
+		} {
+			t.Run(c.expr, func(t *testing.T) {
+				if got := evalScalar(t, c.expr, map[string][]float64{}); got != c.want {
+					t.Errorf("%s: got %v, want %v", c.expr, got, c.want)
+				}
+			})
+		}
+	})
+
+	t.Run("vector and or select elementwise", func(t *testing.T) {
+		// With a vector on the left there is nothing to short-circuit to, so both sides are
+		// evaluated and combined lane by lane.
+		got := evalOnce(t, &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v", Width: 4}},
+			Outputs: []string{"(v > 0) && (v < 3)"},
+		}, []float64{-1, 1, 2, 5}, map[string][]float64{})
+		for i, want := range []float64{0, 1, 1, 0} {
+			if got[i] != want {
+				t.Fatalf("&&: got %v, want [0 1 1 0]", got)
+			}
+		}
+		got = evalOnce(t, &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v", Width: 4}},
+			Outputs: []string{"(v < 0) || (v > 3)"},
+		}, []float64{-1, 1, 2, 5}, map[string][]float64{})
+		for i, want := range []float64{1, 0, 0, 1} {
+			if got[i] != want {
+				t.Fatalf("||: got %v, want [1 0 0 1]", got)
+			}
+		}
+	})
+}
+
+func TestExpressionFunctions(t *testing.T) {
+	params := map[string][]float64{"a": {7}, "b": {3}, "neg": {-2.5}}
+	for _, c := range []struct {
+		expr string
+		want float64
+	}{
+		{"clamp(a, 0, 5)", 5},
+		{"clamp(a, 8, 10)", 8},
+		{"clamp(a, 0, 10)", 7},
+		{"min(a, b)", 3},
+		{"max(a, b)", 7},
+		{"pow(b, 2)", 9},
+		{"abs(neg)", 2.5},
+		{"floor(neg)", -3},
+		{"floor(a / b)", 2},
+		{"exp(0)", 1},
+		{"log(1)", 0},
+		{"sqrt(9)", 3},
+	} {
+		t.Run(c.expr, func(t *testing.T) {
+			if got := evalScalar(t, c.expr, params); got != c.want {
+				t.Errorf("%s: got %v, want %v", c.expr, got, c.want)
+			}
+		})
+	}
+
+	t.Run("clamp with a low above its high pins to the low", func(t *testing.T) {
+		// max-then-min, matching the Go the twins are compared against. Documented because it
+		// is an order the caller can observe when the bounds cross.
+		if got := evalScalar(t, "clamp(5, 10, 0)", map[string][]float64{}); got != 0 {
+			t.Errorf("got %v, want 0 (min applied last)", got)
+		}
+	})
+
+	t.Run("elementwise over vectors, not just scalars", func(t *testing.T) {
+		got := evalOnce(t, &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v", Width: 3}},
+			Outputs: []string{"clamp(abs(v), 0, 2)"},
+		}, []float64{-5, 1, 3}, map[string][]float64{})
+		for i, want := range []float64{2, 1, 2} {
+			if got[i] != want {
+				t.Fatalf("got %v, want [2 1 2]", got)
+			}
+		}
+	})
+}
+
+func TestExpressionBroadcasting(t *testing.T) {
+	// Length-1 broadcasts against any length, from either side, and a genuine mismatch is an
+	// error rather than a silent truncation to the shorter.
+	t.Run("a scalar broadcasts from either side", func(t *testing.T) {
+		got := evalOnce(t, &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v", Width: 3}},
+			Outputs: []string{"k - v + (v - k)"},
+		}, []float64{1, 2, 3}, map[string][]float64{"k": {10}})
+		for i := range got {
+			if got[i] != 0 {
+				t.Fatalf("scalar-vector and vector-scalar disagree: %v", got)
+			}
+		}
+	})
+
+	t.Run("mismatched widths are rejected, naming both", func(t *testing.T) {
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatal("expected a panic combining widths 3 and 2")
+			}
+			msg := stringifyPanic(r)
+			if !strings.Contains(msg, "3") || !strings.Contains(msg, "2") {
+				t.Errorf("panic should name both widths, got: %q", msg)
+			}
+		}()
+		evalOnce(t, &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v", Width: 3}},
+			Outputs: []string{"v + pair"},
+		}, []float64{1, 2, 3}, map[string][]float64{"pair": {1, 2}})
+	})
+}
+
+func TestExpressionBindings(t *testing.T) {
+	// Every model twin leans on bindings, and nothing in this package covered them.
+	t.Run("are evaluated in order and are visible to later ones", func(t *testing.T) {
+		e := &ExpressionIteration{
+			Fields: []ExpressionField{{Name: "x"}},
+			Bindings: []ExpressionBinding{
+				{Name: "doubled", Expr: "x * 2"},
+				{Name: "plus_one", Expr: "doubled + 1"},
+				{Name: "squared", Expr: "plus_one * plus_one"},
+			},
+			Outputs: []string{"squared"},
+		}
+		// x=3 -> 6 -> 7 -> 49
+		if got := evalOnce(t, e, []float64{3}, map[string][]float64{})[0]; got != 49 {
+			t.Fatalf("got %v, want 49", got)
+		}
+	})
+
+	t.Run("a binding may shadow a param", func(t *testing.T) {
+		e := &ExpressionIteration{
+			Fields:   []ExpressionField{{Name: "x"}},
+			Bindings: []ExpressionBinding{{Name: "k", Expr: "99"}},
+			Outputs:  []string{"k"},
+		}
+		if got := evalOnce(t, e, []float64{0}, map[string][]float64{"k": {1}})[0]; got != 99 {
+			t.Fatalf("the binding should win over the param, got %v", got)
+		}
+	})
+
+	t.Run("a forward reference is an unknown name", func(t *testing.T) {
+		// Bindings are ordered, not a solved graph, so referring ahead is an error rather
+		// than working by accident.
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatal("expected a panic for a forward reference")
+			}
+			msg := stringifyPanic(r)
+			if !strings.Contains(msg, "unknown name") || !strings.Contains(msg, "later") {
+				t.Errorf("panic should report the forward name as unknown, got: %q", msg)
+			}
+		}()
+		evalOnce(t, &ExpressionIteration{
+			Fields: []ExpressionField{{Name: "x"}},
+			Bindings: []ExpressionBinding{
+				{Name: "early", Expr: "later + 1"},
+				{Name: "later", Expr: "1"},
+			},
+			Outputs: []string{"early"},
+		}, []float64{0}, map[string][]float64{})
+	})
+
+	t.Run("bindings are eager, unlike a scalar where's branches", func(t *testing.T) {
+		// Load-bearing, and the reason every twin puts a guarded draw inside the where rather
+		// than in a binding the where then selects: a binding that draws, draws every step,
+		// even when nothing reads it. Proven by the stream position rather than by the
+		// discarded value, which is invisible by construction.
+		withBinding := evalOnce(t, &ExpressionIteration{
+			Fields:   []ExpressionField{{Name: "x"}},
+			Bindings: []ExpressionBinding{{Name: "unread", Expr: "shared(normal(0, 1))"}},
+			Outputs:  []string{"where(x > 100, unread, 0) + shared(normal(0, 1))"},
+		}, []float64{1}, map[string][]float64{})
+
+		withoutBinding := evalOnce(t, &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "x"}},
+			Outputs: []string{"where(x > 100, 0, 0) + shared(normal(0, 1))"},
+		}, []float64{1}, map[string][]float64{})
+
+		sampler := rng.New(1)
+		first, second := sampler.Normal(0, 1), sampler.Normal(0, 1)
+		if withoutBinding[0] != first {
+			t.Fatalf("without a binding the visible draw should be the stream's first, "+
+				"got %v want %v", withoutBinding[0], first)
+		}
+		if withBinding[0] != second {
+			t.Fatalf("the unread binding did not draw: the visible draw is %v, and it should "+
+				"be the stream's second (%v) because the binding consumed the first (%v)",
+				withBinding[0], second, first)
+		}
+	})
+}
+
+func TestExpressionDrawsMatchTheSampler(t *testing.T) {
+	// Every draw must be exactly pkg/rng's, in the order written: that identity is the whole
+	// basis on which a declarative twin is compared to compiled Go.
+	for _, c := range []struct {
+		name, expr string
+		want       func(s *rng.Sampler) float64
+	}{
+		{"normal", "iid(1, normal(2, 3))", func(s *rng.Sampler) float64 {
+			return s.Normal(2, 3)
+		}},
+		{"uniform", "iid(1, uniform(1, 5))", func(s *rng.Sampler) float64 {
+			return s.Uniform(1, 5)
+		}},
+		{"exponential", "iid(1, exponential(2))", func(s *rng.Sampler) float64 {
+			return s.Exponential(2)
+		}},
+		{"poisson", "iid(1, poisson(4))", func(s *rng.Sampler) float64 {
+			return s.Poisson(4)
+		}},
+		{"gamma", "iid(1, gamma(2, 3))", func(s *rng.Sampler) float64 {
+			return s.Gamma(2, 3)
+		}},
+		{"beta", "iid(1, beta(2, 3))", func(s *rng.Sampler) float64 {
+			return s.Beta(2, 3)
+		}},
+		{"binomial", "iid(1, binomial(10, 0.5))", func(s *rng.Sampler) float64 {
+			return distuv.Binomial{N: 10, P: 0.5, Src: s.Rand()}.Rand()
+		}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			got := evalScalar(t, c.expr, map[string][]float64{})
+			// evalOnce seeds every partition with 1.
+			if want := c.want(rng.New(1)); got != want {
+				t.Errorf("%s: got %v, want %v — the draw is not the sampler's", c.name, got, want)
+			}
+		})
+	}
+
+	t.Run("a vector parameter draws once per element, in order", func(t *testing.T) {
+		got := evalOnce(t, &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v", Width: 3}},
+			Outputs: []string{"poisson(rates)"},
+		}, []float64{0, 0, 0}, map[string][]float64{"rates": {1, 5, 20}})
+		sampler := rng.New(1)
+		for i, rate := range []float64{1, 5, 20} {
+			if want := sampler.Poisson(rate); got[i] != want {
+				t.Fatalf("element %d: got %v, want %v", i, got[i], want)
+			}
+		}
+	})
+}
+
+func TestExpressionRejectsMalformedExpressions(t *testing.T) {
+	for _, c := range []struct {
+		name, expr, wantIn string
+	}{
+		{"unknown name", "nope + 1", "unknown name"},
+		{"unknown function", "wibble(1)", "unknown function"},
+		{"unsupported call target", "pkg.fn(1)", "unsupported call target"},
+		{"unsupported syntax", "self.field", "unsupported syntax"},
+		{"unsupported operator", "self << 1", "unsupported operator"},
+		{"a string is not a number", `"hello"`, "bad numeric literal"},
+		{"wrong arity", "sqrt(1, 2)", "takes 1 arguments"},
+		{"concat needs two", "concat(1)", "at least 2"},
+		{"index must be scalar", "pair[pair]", "index must be a scalar"},
+		{"index out of range", "pair[9]", "out of range"},
+		{"iid count must be scalar", "sum(iid(pair, 1))", "count must be a scalar"},
+		{"iid count below one", "sum(iid(0, 1))", "at least 1"},
+		{"iid lane must be scalar", "sum(iid(2, fill(3, 1)))", "scalar-valued expression"},
+		{"each count must be scalar", "sum(each(pair, i, 1))", "count must be a scalar"},
+		{"fill width must be scalar", "sum(fill(pair, 1))", "width must be a scalar"},
+		{"fill width below one", "sum(fill(0, 1))", "at least 1"},
+		{"slice bounds must be scalar", "sum(slice(pair, pair, 1))", "must be scalars"},
+		{"slice width below one", "sum(slice(pair, 0, 0))", "at least 1"},
+		{"lag needs a name", "lag(1 + 1, 0)", "must be an upstream alias"},
+		{"lag row must be scalar", "lag(self, pair)", "row must be a scalar"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			defer func() {
+				r := recover()
+				if r == nil {
+					t.Fatalf("expected a panic for %s", c.name)
+				}
+				if msg := stringifyPanic(r); !strings.Contains(msg, c.wantIn) {
+					t.Errorf("panic should mention %q, got: %q", c.wantIn, msg)
+				}
+			}()
+			evalScalar(t, c.expr, map[string][]float64{"pair": {1, 2}})
+		})
+	}
+}
+
+func TestExpressionConfigureRejectsBadSpecs(t *testing.T) {
+	settings := &simulator.Settings{
+		Iterations: []simulator.IterationSettings{{Name: "p", Seed: 1}},
+	}
+	for _, c := range []struct {
+		name   string
+		e      *ExpressionIteration
+		wantIn string
+	}{
+		{"negative field width", &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v", Width: -1}},
+			Outputs: []string{"1"},
+		}, "negative width"},
+		{"unparseable binding", &ExpressionIteration{
+			Fields:   []ExpressionField{{Name: "v"}},
+			Bindings: []ExpressionBinding{{Name: "b", Expr: "1 +"}},
+			Outputs:  []string{"1"},
+		}, "parsing binding b"},
+		{"unparseable output names its field", &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "the_field"}},
+			Outputs: []string{"1 +"},
+		}, "the_field"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			defer func() {
+				r := recover()
+				if r == nil {
+					t.Fatalf("expected a panic for %s", c.name)
+				}
+				if msg := stringifyPanic(r); !strings.Contains(msg, c.wantIn) {
+					t.Errorf("panic should mention %q, got: %q", c.wantIn, msg)
+				}
+			}()
+			c.e.Configure(0, settings)
+		})
+	}
+}
+
+func TestExpressionOutputWidthMustFitItsField(t *testing.T) {
+	t.Run("a width that is neither the field's nor 1 is rejected", func(t *testing.T) {
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatal("expected a panic for a mis-sized output")
+			}
+			msg := stringifyPanic(r)
+			if !strings.Contains(msg, "v") || !strings.Contains(msg, "width 2") {
+				t.Errorf("panic should name the field and the width, got: %q", msg)
+			}
+		}()
+		evalOnce(t, &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v", Width: 3}},
+			Outputs: []string{"fill(2, 1)"},
+		}, []float64{0, 0, 0}, map[string][]float64{})
+	})
+}
+
+func TestExpressionLagReadsAnUpstream(t *testing.T) {
+	// The own-field path is covered elsewhere; this is the alias path, which is what
+	// trywizard's match_state actually uses.
+	e := &ExpressionIteration{
+		Fields:    []ExpressionField{{Name: "x"}},
+		Upstreams: map[string]string{"other": "source"},
+		Outputs:   []string{"lag(other, 2)[1]"},
+	}
+	settings := &simulator.Settings{
+		Iterations: []simulator.IterationSettings{
+			{Name: "p", Seed: 1},
+			{Name: "source", Seed: 2},
+		},
+	}
+	e.Configure(0, settings)
+	params := simulator.NewParams(map[string][]float64{})
+	histories := []*simulator.StateHistory{
+		{
+			Values:            mat.NewDense(1, 1, []float64{0}),
+			StateWidth:        1,
+			StateHistoryDepth: 1,
+		},
+		{
+			Values:            mat.NewDense(3, 2, []float64{1, 10, 2, 20, 3, 30}),
+			StateWidth:        2,
+			StateHistoryDepth: 3,
+		},
+	}
+	got := e.Iterate(&params, 0, histories, &simulator.CumulativeTimestepsHistory{
+		Values:            mat.NewVecDense(1, []float64{0}),
+		NextIncrement:     1,
+		CurrentStepNumber: 1,
+	})
+	if got[0] != 30 {
+		t.Fatalf("lag(other, 2)[1]: got %v, want 30", got[0])
+	}
+}
+
+func TestExpressionLagWithoutHistoriesSaysSo(t *testing.T) {
+	// Iterate always supplies the resolver, so this guard is unreachable through the public
+	// surface and is tested directly rather than left as an untested assertion. It exists so
+	// that a future evaluation path which forgets to wire it fails by saying what is missing,
+	// instead of dereferencing a nil func.
+	t.Run("a context with no history resolver reports it", func(t *testing.T) {
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatal("expected a panic when lag has no resolver")
+			}
+			if msg := stringifyPanic(r); !strings.Contains(msg, "lag is unavailable") {
+				t.Errorf("panic should say lag is unavailable, got: %q", msg)
+			}
+		}()
+		parsed, err := parser.ParseExpr("lag(x, 1)")
+		if err != nil {
+			t.Fatalf("parsing: %v", err)
+		}
+		ctx := &exprCtx{env: exprEnv{"x": exprValue{1}}, sampler: rng.New(1)}
+		ctx.eval(parsed)
+	})
+}
+
+func TestExpressionDoesNotMutateWhatItReads(t *testing.T) {
+	// The environment aliases the params map and the state history rather than copying them,
+	// so any function that wrote through its argument would corrupt the caller. The harness
+	// checks params; this pins the state too, and says which value moved.
+	e := &ExpressionIteration{
+		Fields: []ExpressionField{{Name: "v", Width: 3}},
+		Bindings: []ExpressionBinding{
+			{Name: "scaled", Expr: "v * k"},
+			{Name: "shifted", Expr: "concat(slice(v, 1, 2), 0)"},
+		},
+		Outputs: []string{"scaled + shifted + iid(3, normal(0, 1))"},
+	}
+	settings := &simulator.Settings{
+		Iterations: []simulator.IterationSettings{{Name: "p", Seed: 1}},
+	}
+	e.Configure(0, settings)
+
+	state := []float64{1, 2, 3}
+	params := simulator.NewParams(map[string][]float64{"k": {10}, "spare": {4, 5}})
+	histories := []*simulator.StateHistory{{
+		Values:            mat.NewDense(1, 3, state),
+		StateWidth:        3,
+		StateHistoryDepth: 1,
+	}}
+	e.Iterate(&params, 0, histories, &simulator.CumulativeTimestepsHistory{
+		Values:            mat.NewVecDense(1, []float64{0}),
+		NextIncrement:     1,
+		CurrentStepNumber: 1,
+	})
+
+	for i, want := range []float64{1, 2, 3} {
+		if got := histories[0].Values.At(0, i); got != want {
+			t.Errorf("state element %d was mutated: got %v, want %v", i, got, want)
+		}
+	}
+	if got := params.Map["k"][0]; got != 10 {
+		t.Errorf("param k was mutated: got %v, want 10", got)
+	}
+	for i, want := range []float64{4, 5} {
+		if got := params.Map["spare"][i]; got != want {
+			t.Errorf("param spare element %d was mutated: got %v, want %v", i, got, want)
+		}
+	}
+}

--- a/pkg/general/expression_settings.yaml
+++ b/pkg/general/expression_settings.yaml
@@ -1,0 +1,18 @@
+iterations:
+- name: driver
+  params:
+    growth: [0.1]
+  init_state_values: [1.0, 2.0]
+  seed: 0
+  state_width: 2
+  state_history_depth: 1
+- name: responder
+  params:
+    scale: [2.0]
+    weights: [1.0, 0.5, 0.25]
+  init_state_values: [0.0, 0.0, 0.0, 5.0]
+  seed: 1
+  state_width: 4
+  state_history_depth: 1
+init_time_value: 0.0
+timesteps_history_depth: 1

--- a/pkg/general/expression_test.go
+++ b/pkg/general/expression_test.go
@@ -456,6 +456,78 @@ func TestExpressionEach(t *testing.T) {
 	})
 }
 
+func TestExpressionNonFiniteIndex(t *testing.T) {
+	// Found while writing business-survival's twin, whose first width probe was NaN-poisoned.
+	// int(NaN) neither panics nor is portable: on arm64 it is 0, so a NaN index passes a
+	// bounds check and silently reads element 0; on amd64 it is the most negative int and the
+	// same expression panics. An answer that depends on the architecture is worse than a
+	// failure, and these cards claim to be architecture-stable.
+	for _, c := range []struct {
+		name, expr string
+	}{
+		{"index", "v[bad]"},
+		{"iid count", "sum(iid(bad, 1))"},
+		{"each count", "sum(each(bad, i, 1))"},
+		{"each lane index", "sum(each(2, i, v[i * bad]))"},
+		{"fill width", "sum(fill(bad, 1))"},
+		{"slice start", "sum(slice(v, bad, 1))"},
+		{"slice width", "sum(slice(v, 0, bad))"},
+	} {
+		for _, bad := range []struct {
+			label string
+			value float64
+		}{
+			{"NaN", math.NaN()},
+			{"+Inf", math.Inf(1)},
+			{"-Inf", math.Inf(-1)},
+		} {
+			t.Run(c.name+" of "+bad.label, func(t *testing.T) {
+				defer func() {
+					if recover() == nil {
+						t.Fatalf("a %s %s was accepted rather than rejected", bad.label, c.name)
+					}
+				}()
+				evalOnce(t, &ExpressionIteration{
+					Fields:  []ExpressionField{{Name: "v", Width: 3}},
+					Outputs: []string{c.expr},
+				}, []float64{111, 222, 333}, map[string][]float64{"bad": {bad.value}})
+			})
+		}
+	}
+}
+
+func TestExpressionWidth(t *testing.T) {
+	t.Run("reports how many elements a value has", func(t *testing.T) {
+		e := &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v", Width: 3}},
+			Outputs: []string{"width(rates) + width(v) * 10 + width(k) * 100"},
+		}
+		got := evalOnce(t, e, []float64{0, 0, 0}, map[string][]float64{
+			"rates": {1, 2, 3, 4, 5}, "k": {7},
+		})
+		// A scalar is width 1, not width 0.
+		if want := 5.0 + 30 + 100; got[0] != want {
+			t.Fatalf("got %v, want %v", got[0], want)
+		}
+	})
+
+	t.Run("the obvious hand-rolled alternative is the one that is wrong", func(t *testing.T) {
+		// Why this exists rather than leaving people to spell it themselves: sum(0*x + 1)
+		// reads like a width probe and silently is not, because 0 * NaN is NaN. Any real
+		// vector carrying a NaN turns the probe into NaN, and a NaN index is undefined.
+		e := &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v"}},
+			Outputs: []string{"width(x)"},
+		}
+		got := evalOnce(t, e, []float64{0}, map[string][]float64{
+			"x": {1, math.NaN(), 3},
+		})
+		if got[0] != 3 {
+			t.Fatalf("width must not care what the values are, got %v", got[0])
+		}
+	})
+}
+
 func TestExpressionLag(t *testing.T) {
 	// trywizard's match_state ages yellow cards out by differencing against a partition's
 	// state ten rows back. A bare name and an upstreams alias both give row 0 only.

--- a/pkg/general/expression_test.go
+++ b/pkg/general/expression_test.go
@@ -7,6 +7,8 @@ import (
 
 	"gonum.org/v1/gonum/mat"
 
+	"github.com/umbralcalc/stochadex/pkg/rng"
+
 	"github.com/umbralcalc/stochadex/pkg/simulator"
 )
 
@@ -296,6 +298,243 @@ func TestExpressionSemantics(t *testing.T) {
 				t.Fatalf("got %v, want all 7s", got)
 			}
 		}
+	})
+}
+
+// Each of these closes a gap the catalogue proved was real: a model existed that could not be
+// stated as data without it. The subtests name the model that asked.
+
+func TestExpressionStructuredAccess(t *testing.T) {
+	t.Run("slice addresses a block inside a flat vector", func(t *testing.T) {
+		// trywizard packs a channel's coefficients at a stride offset inside one flat param,
+		// and had to write 36 terms out longhand by scalar index to reach them.
+		e := &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v", Width: 3}},
+			Outputs: []string{"slice(coefficients, 3, 3) * 2"},
+		}
+		got := evalOnce(t, e, []float64{0, 0, 0}, map[string][]float64{
+			"coefficients": {1, 2, 3, 4, 5, 6, 7, 8, 9},
+		})
+		for i, want := range []float64{8, 10, 12} {
+			if got[i] != want {
+				t.Fatalf("got %v, want [8 10 12]", got)
+			}
+		}
+	})
+
+	t.Run("concat assembles a field from differently-computed pieces", func(t *testing.T) {
+		e := &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v", Width: 4}},
+			Outputs: []string{"concat(99, slice(v, 0, 2) + 1, 77)"},
+		}
+		got := evalOnce(t, e, []float64{1, 2, 3, 4}, map[string][]float64{})
+		for i, want := range []float64{99, 2, 3, 77} {
+			if got[i] != want {
+				t.Fatalf("got %v, want [99 2 3 77]", got)
+			}
+		}
+	})
+
+	t.Run("slice and concat reject an out-of-range block", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatal("expected a panic for a slice past the end")
+			} else if !strings.Contains(stringifyPanic(r), "outside a width-3") {
+				t.Errorf("panic should say what it ran off the end of, got: %q", r)
+			}
+		}()
+		evalOnce(t, &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v", Width: 3}},
+			Outputs: []string{"slice(v, 2, 2)"},
+		}, []float64{1, 2, 3}, map[string][]float64{})
+	})
+}
+
+func TestExpressionEach(t *testing.T) {
+	t.Run("an index shift ages a cohort", func(t *testing.T) {
+		// business-survival's shape, and the reason it had no declarative twin: element i of
+		// the next state reads element i-1 of the current one, with an absorbing top bucket
+		// taking both the inflow from below and its own survivors. Elementwise cannot say it.
+		e := &ExpressionIteration{
+			Fields: []ExpressionField{{Name: "cohort", Width: 5}},
+			Outputs: []string{
+				"each(5, age, where(age == 0, births," +
+					"where(age == 4, cohort[3] * survival + cohort[4] * survival," +
+					"cohort[age - 1] * survival)))",
+			},
+		}
+		got := evalOnce(t, e, []float64{100, 80, 60, 40, 20}, map[string][]float64{
+			"births": {10}, "survival": {0.5},
+		})
+		// age 0 takes births; 1..3 take half of the bucket below; 4 is absorbing, taking half
+		// of bucket 3 plus half of its own.
+		for i, want := range []float64{10, 50, 40, 30, 30} {
+			if got[i] != want {
+				t.Fatalf("got %v, want [10 50 40 30 30]", got)
+			}
+		}
+	})
+
+	t.Run("a skipped lane draws nothing", func(t *testing.T) {
+		// measles skips inactive areas entirely. A vector-guarded where must evaluate both
+		// branches, so it draws in every lane; inside each, the guard is scalar and lazy.
+		// Two lanes are active, so exactly two draws are taken and the third lane's identical
+		// specification cannot have consumed one.
+		mk := func(output string) *ExpressionIteration {
+			return &ExpressionIteration{
+				Fields:  []ExpressionField{{Name: "v"}},
+				Outputs: []string{output},
+			}
+		}
+		// Lanes 0 and 2 active: the values drawn must be the first two of the stream.
+		gated := evalOnce(t, mk("sum(each(3, i, where(active[i] > 0, normal(0, 1), 0)))"),
+			[]float64{0}, map[string][]float64{"active": {1, 0, 1}})
+		// The same stream, drawn without any gating at all.
+		ungated := evalOnce(t, mk("sum(iid(2, normal(0, 1)))"),
+			[]float64{0}, map[string][]float64{})
+		if gated[0] != ungated[0] {
+			t.Fatalf("the inactive lane consumed randomness: gated=%v ungated=%v",
+				gated[0], ungated[0])
+		}
+	})
+
+	t.Run("draws interleave in lane order", func(t *testing.T) {
+		// The other half of the measles blocker: an elementwise gamma takes all its draws
+		// before any poisson, where a Go loop interleaves them per area. Inside each, a lane
+		// takes its gamma and its poisson before the next lane starts, so the stream matches.
+		interleaved := evalOnce(t, &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v", Width: 2}},
+			Outputs: []string{"each(2, i, gamma(shape, rate) + uniform(0, 1))"},
+		}, []float64{0, 0}, map[string][]float64{"shape": {2}, "rate": {1}})
+
+		// Reproduce the same stream by hand, in the order a per-lane loop would take it.
+		sampler := rng.New(1)
+		want := make([]float64, 2)
+		for i := range want {
+			want[i] = sampler.Gamma(2, 1) + sampler.Uniform(0, 1)
+		}
+		for i := range want {
+			if interleaved[i] != want[i] {
+				t.Fatalf("lane %d: got %v, want %v — draws are not interleaving per lane",
+					i, interleaved[i], want[i])
+			}
+		}
+	})
+
+	t.Run("each binds the index without leaking it", func(t *testing.T) {
+		e := &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v"}},
+			Outputs: []string{"sum(each(3, i, i)) + i"},
+		}
+		got := evalOnce(t, e, []float64{0}, map[string][]float64{"i": {100}})
+		// each's i shadows the param inside the loop (0+1+2), and the param is intact after.
+		if got[0] != 103 {
+			t.Fatalf("got %v, want 103 (3 from the loop plus the outer i of 100)", got[0])
+		}
+	})
+
+	t.Run("a lane must produce a scalar, and the index must be a name", func(t *testing.T) {
+		for _, c := range []struct {
+			name, expr string
+		}{
+			{"vector-valued lane", "each(2, i, fill(3, i))"},
+			{"index is not a name", "each(2, 7, 1)"},
+			{"count below one", "each(0, i, 1)"},
+		} {
+			t.Run(c.name, func(t *testing.T) {
+				defer func() {
+					if recover() == nil {
+						t.Fatalf("expected a panic for %s", c.name)
+					}
+				}()
+				evalOnce(t, &ExpressionIteration{
+					Fields:  []ExpressionField{{Name: "v"}},
+					Outputs: []string{c.expr},
+				}, []float64{0}, map[string][]float64{})
+			})
+		}
+	})
+}
+
+func TestExpressionLag(t *testing.T) {
+	// trywizard's match_state ages yellow cards out by differencing against a partition's
+	// state ten rows back. A bare name and an upstreams alias both give row 0 only.
+	newHistory := func(rows [][]float64) *simulator.StateHistory {
+		flat := make([]float64, 0, len(rows)*len(rows[0]))
+		for _, r := range rows {
+			flat = append(flat, r...)
+		}
+		return &simulator.StateHistory{
+			Values:            mat.NewDense(len(rows), len(rows[0]), flat),
+			StateWidth:        len(rows[0]),
+			StateHistoryDepth: len(rows),
+		}
+	}
+
+	evalWithHistory := func(t *testing.T, e *ExpressionIteration) []float64 {
+		t.Helper()
+		settings := &simulator.Settings{
+			Iterations: []simulator.IterationSettings{{Name: "p", Seed: 1}},
+		}
+		e.Configure(0, settings)
+		params := simulator.NewParams(map[string][]float64{})
+		histories := []*simulator.StateHistory{
+			newHistory([][]float64{{5, 50}, {4, 40}, {3, 30}}),
+		}
+		return e.Iterate(&params, 0, histories, &simulator.CumulativeTimestepsHistory{
+			Values:            mat.NewVecDense(1, []float64{0}),
+			NextIncrement:     1,
+			CurrentStepNumber: 1,
+		})
+	}
+
+	t.Run("reads a field's own state further back than the current row", func(t *testing.T) {
+		got := evalWithHistory(t, &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "a"}, {Name: "b"}},
+			Outputs: []string{"lag(a, 2)", "lag(b, 1)"},
+		})
+		if got[0] != 3 || got[1] != 40 {
+			t.Fatalf("got %v, want [3 40]", got)
+		}
+	})
+
+	t.Run("lag at row 0 is the current row", func(t *testing.T) {
+		got := evalWithHistory(t, &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "a"}, {Name: "b"}},
+			Outputs: []string{"lag(a, 0) - a", "lag(b, 0) - b"},
+		})
+		if got[0] != 0 || got[1] != 0 {
+			t.Fatalf("lag(x, 0) must equal x, got %v", got)
+		}
+	})
+
+	t.Run("reading past the kept history says so", func(t *testing.T) {
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatal("expected a panic for a lag past the history")
+			}
+			msg := stringifyPanic(r)
+			if !strings.Contains(msg, "state_history_depth") {
+				t.Errorf("panic should name the fix, got: %q", msg)
+			}
+		}()
+		evalWithHistory(t, &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "a"}, {Name: "b"}},
+			Outputs: []string{"lag(a, 3)", "b"},
+		})
+	})
+
+	t.Run("an unknown name is rejected", func(t *testing.T) {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("expected a panic for lagging a name that is not a field or alias")
+			}
+		}()
+		evalWithHistory(t, &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "a"}, {Name: "b"}},
+			Outputs: []string{"lag(some_param, 1)", "b"},
+		})
 	})
 }
 

--- a/pkg/general/expression_test.go
+++ b/pkg/general/expression_test.go
@@ -245,6 +245,46 @@ func TestExpressionSemantics(t *testing.T) {
 		}
 	})
 
+	t.Run("seasonality and a Gaussian CDF are expressible", func(t *testing.T) {
+		// These exist because the catalogue asked for them: a seasonal driver needs sin, and
+		// a threshold-exceedance probability needs the normal CDF, which is 0.5*erfc(-x/√2).
+		// They must agree with the Go math package exactly, since that is what a declarative
+		// model is compared against.
+		e := &ExpressionIteration{
+			Fields: []ExpressionField{{Name: "season"}, {Name: "p"}},
+			Outputs: []string{
+				"amplitude * sin(2 * pi * t / period + phase)",
+				"0.5 * erfc(-(x - threshold) / (sigma * sqrt(2)))",
+			},
+		}
+		got := evalOnce(t, e, []float64{0, 0}, map[string][]float64{
+			"amplitude": {2}, "period": {12}, "phase": {0.3},
+			"x": {1.4}, "threshold": {0.9}, "sigma": {0.7},
+		})
+		wantSeason := 2 * math.Sin(2*math.Pi*3.0/12+0.3)
+		wantP := 0.5 * math.Erfc(-(1.4-0.9)/(0.7*math.Sqrt2))
+		if got[0] != wantSeason {
+			t.Errorf("season: got %v, want %v", got[0], wantSeason)
+		}
+		if got[1] != wantP {
+			t.Errorf("exceedance probability: got %v, want %v", got[1], wantP)
+		}
+	})
+
+	t.Run("cos and erf match the Go math package elementwise", func(t *testing.T) {
+		e := &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v", Width: 3}},
+			Outputs: []string{"cos(v) + erf(v)"},
+		}
+		in := []float64{-1.25, 0.0, 2.5}
+		got := evalOnce(t, e, in, map[string][]float64{})
+		for i, x := range in {
+			if want := math.Cos(x) + math.Erf(x); got[i] != want {
+				t.Errorf("element %d: got %v, want %v", i, got[i], want)
+			}
+		}
+	})
+
 	t.Run("a scalar output broadcasts across its field", func(t *testing.T) {
 		e := &ExpressionIteration{
 			Fields:  []ExpressionField{{Name: "v", Width: 3}},

--- a/pkg/general/expression_test.go
+++ b/pkg/general/expression_test.go
@@ -2,12 +2,24 @@ package general
 
 import (
 	"math"
+	"strings"
 	"testing"
 
 	"gonum.org/v1/gonum/mat"
 
 	"github.com/umbralcalc/stochadex/pkg/simulator"
 )
+
+// stringifyPanic renders a recovered panic value for substring assertions.
+func stringifyPanic(v any) string {
+	switch value := v.(type) {
+	case error:
+		return value.Error()
+	case string:
+		return value
+	}
+	return ""
+}
 
 // driverExpr advances a two-scalar partition; responderExpr reads it, exercising a vector
 // field, scalar broadcasting, upstream indexing and a reduction.
@@ -170,36 +182,60 @@ func TestExpressionSemantics(t *testing.T) {
 		}
 	})
 
-	t.Run("a draw's width comes from its parameters", func(t *testing.T) {
-		// Scalar parameters mean ONE sample, which then broadcasts across the field: the
-		// documented sharp edge. Widening (fill, or a vector-valued parameter) is what
-		// gives independent noise per element.
-		shared := evalOnce(t, &ExpressionIteration{
-			Fields:  []ExpressionField{{Name: "v", Width: 4}},
-			Outputs: []string{"normal(0, 1)"},
-		}, []float64{0, 0, 0, 0}, map[string][]float64{})
-		for i := 1; i < 4; i++ {
-			if shared[i] != shared[0] {
-				t.Fatalf("scalar-parameter draw should broadcast one sample, got %v", shared)
+	t.Run("an unannotated scalar-parameter draw is rejected", func(t *testing.T) {
+		// The whole point: silently adding the same shock to every element of a wide field
+		// is a modelling bug, and both readings are things people mean, so the ambiguity is
+		// refused rather than guessed at.
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatal("expected a panic for an ambiguous scalar-parameter draw")
 			}
-		}
+			msg := stringifyPanic(r)
+			if !strings.Contains(msg, "iid(") || !strings.Contains(msg, "shared(") {
+				t.Errorf("panic should name both fixes, got: %q", msg)
+			}
+		}()
+		evalOnce(t, &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v", Width: 4}},
+			Outputs: []string{"v + normal(0, 1)"},
+		}, []float64{0, 0, 0, 0}, map[string][]float64{})
+	})
+
+	t.Run("iid gives independent samples, shared gives one", func(t *testing.T) {
 		independent := evalOnce(t, &ExpressionIteration{
 			Fields:  []ExpressionField{{Name: "v", Width: 4}},
-			Outputs: []string{"normal(fill(4, 0), sigmas)"},
-		}, []float64{0, 0, 0, 0}, map[string][]float64{"sigmas": {1, 1, 1, 1}})
+			Outputs: []string{"iid(4, normal(0, 1))"},
+		}, []float64{0, 0, 0, 0}, map[string][]float64{})
 		if independent[0] == independent[1] && independent[1] == independent[2] {
-			t.Fatalf("widened draw should be independent per element, got %v", independent)
+			t.Fatalf("iid should sample independently per element, got %v", independent)
+		}
+		one := evalOnce(t, &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v", Width: 4}},
+			Outputs: []string{"v + shared(normal(0, 1))"},
+		}, []float64{0, 0, 0, 0}, map[string][]float64{})
+		for i := 1; i < 4; i++ {
+			if one[i] != one[0] {
+				t.Fatalf("shared should reuse one sample across the field, got %v", one)
+			}
+		}
+	})
+
+	t.Run("a vector-parameter draw needs no annotation", func(t *testing.T) {
+		got := evalOnce(t, &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v", Width: 3}},
+			Outputs: []string{"poisson(rates)"},
+		}, []float64{0, 0, 0}, map[string][]float64{"rates": {5, 5, 5}})
+		if len(got) != 3 {
+			t.Fatalf("got width %d, want 3", len(got))
 		}
 	})
 
 	t.Run("compound draws compose (poisson of a gamma)", func(t *testing.T) {
 		// The negative-binomial branching shape the measles model needs.
 		e := &ExpressionIteration{
-			Fields: []ExpressionField{{Name: "n"}},
-			Bindings: []ExpressionBinding{
-				{Name: "lambda", Expr: "gamma(shape, rate)"},
-			},
-			Outputs: []string{"poisson(lambda)"},
+			Fields:  []ExpressionField{{Name: "n"}},
+			Outputs: []string{"iid(1, poisson(gamma(shape, rate)))"},
 		}
 		got := evalOnce(t, e, []float64{0}, map[string][]float64{
 			"shape": {20}, "rate": {2},

--- a/pkg/general/expression_test.go
+++ b/pkg/general/expression_test.go
@@ -85,6 +85,62 @@ func TestExpressionIteration(t *testing.T) {
 	)
 }
 
+// cohortExpr ages a four-bucket cohort with an absorbing top and a guarded draw at the
+// intake; readerExpr reads it through slice, a lag past the current row, and width. Together
+// they put every construct that is not elementwise through the run harnesses.
+func cohortExpr() *ExpressionIteration {
+	return &ExpressionIteration{
+		Fields: []ExpressionField{{Name: "bucket", Width: 4}},
+		Outputs: []string{
+			"each(4, age, where(age == 0, poisson(births)," +
+				"where(age == 3, bucket[2] * survival + bucket[3] * survival," +
+				"bucket[age - 1] * survival)))",
+		},
+	}
+}
+
+func readerExpr() *ExpressionIteration {
+	return &ExpressionIteration{
+		Fields:    []ExpressionField{{Name: "total"}, {Name: "aged"}},
+		Upstreams: map[string]string{"coh": "cohort"},
+		// Three of the six coefficients, with the top bucket deliberately unweighted.
+		Bindings: []ExpressionBinding{
+			{Name: "weights", Expr: "concat(slice(coefficients, 0, 3), 0)"},
+		},
+		Outputs: []string{
+			"dot(weights, coh)",
+			"sum(lag(coh, 2)) + width(coefficients)",
+		},
+	}
+}
+
+func TestExpressionConstructsRunWithHarnesses(t *testing.T) {
+	// The harnesses are what catch what a unit test cannot: NaNs, a wrong state width, a
+	// mutated params map, and statefulness residue, the last by running the whole simulation
+	// twice and comparing. That last one is the reason this exists — each binds its lane index
+	// into an environment it shares with the enclosing scope, so a restore that leaked would
+	// show up here and nowhere else.
+	t.Run("each, lag, slice, concat and width survive the harnesses", func(t *testing.T) {
+		settings := simulator.LoadSettingsFromYaml("./expression_constructs_settings.yaml")
+		iterations := []simulator.Iteration{cohortExpr(), readerExpr()}
+		for i, iteration := range iterations {
+			iteration.Configure(i, settings)
+		}
+		implementations := &simulator.Implementations{
+			Iterations:      iterations,
+			OutputCondition: &simulator.EveryStepOutputCondition{},
+			OutputFunction:  &simulator.NilOutputFunction{},
+			TerminationCondition: &simulator.NumberOfStepsTerminationCondition{
+				MaxNumberOfSteps: 100,
+			},
+			TimestepFunction: &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+		}
+		if err := simulator.RunWithHarnesses(settings, implementations); err != nil {
+			t.Errorf("test harness failed: %v", err)
+		}
+	})
+}
+
 // evalOnce configures a one-partition expression iteration over the given state and params
 // and returns a single Iterate result, for testing evaluation semantics directly.
 func evalOnce(

--- a/pkg/general/expression_test.go
+++ b/pkg/general/expression_test.go
@@ -1,0 +1,257 @@
+package general
+
+import (
+	"math"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+
+	"github.com/umbralcalc/stochadex/pkg/simulator"
+)
+
+// driverExpr advances a two-scalar partition; responderExpr reads it, exercising a vector
+// field, scalar broadcasting, upstream indexing and a reduction.
+func driverExpr() *ExpressionIteration {
+	return &ExpressionIteration{
+		Fields:  []ExpressionField{{Name: "a"}, {Name: "b"}},
+		Outputs: []string{"a + growth", "b * (1 + growth)"},
+	}
+}
+
+func responderExpr() *ExpressionIteration {
+	return &ExpressionIteration{
+		Fields:    []ExpressionField{{Name: "v", Width: 3}, {Name: "total"}},
+		Upstreams: map[string]string{"drv": "driver"},
+		Outputs:   []string{"v + scale * drv[0]", "dot(v, weights)"},
+	}
+}
+
+func TestExpressionIteration(t *testing.T) {
+	t.Run(
+		"test that the expression iteration runs",
+		func(t *testing.T) {
+			settings := simulator.LoadSettingsFromYaml("./expression_settings.yaml")
+			iterations := []simulator.Iteration{driverExpr(), responderExpr()}
+			for i, iteration := range iterations {
+				iteration.Configure(i, settings)
+			}
+			implementations := &simulator.Implementations{
+				Iterations:      iterations,
+				OutputCondition: &simulator.EveryStepOutputCondition{},
+				OutputFunction:  &simulator.NilOutputFunction{},
+				TerminationCondition: &simulator.NumberOfStepsTerminationCondition{
+					MaxNumberOfSteps: 100,
+				},
+				TimestepFunction: &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+			}
+			simulator.NewPartitionCoordinator(settings, implementations).Run()
+		},
+	)
+	t.Run(
+		"test that the expression iteration runs with harnesses",
+		func(t *testing.T) {
+			settings := simulator.LoadSettingsFromYaml("./expression_settings.yaml")
+			iterations := []simulator.Iteration{driverExpr(), responderExpr()}
+			for i, iteration := range iterations {
+				iteration.Configure(i, settings)
+			}
+			implementations := &simulator.Implementations{
+				Iterations:      iterations,
+				OutputCondition: &simulator.EveryStepOutputCondition{},
+				OutputFunction:  &simulator.NilOutputFunction{},
+				TerminationCondition: &simulator.NumberOfStepsTerminationCondition{
+					MaxNumberOfSteps: 100,
+				},
+				TimestepFunction: &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+			}
+			if err := simulator.RunWithHarnesses(settings, implementations); err != nil {
+				t.Errorf("test harness failed: %v", err)
+			}
+		},
+	)
+}
+
+// evalOnce configures a one-partition expression iteration over the given state and params
+// and returns a single Iterate result, for testing evaluation semantics directly.
+func evalOnce(
+	t *testing.T,
+	e *ExpressionIteration,
+	state []float64,
+	params map[string][]float64,
+) []float64 {
+	t.Helper()
+	settings := &simulator.Settings{
+		Iterations: []simulator.IterationSettings{{Name: "p", Seed: 1}},
+	}
+	e.Configure(0, settings)
+	p := simulator.NewParams(params)
+	histories := []*simulator.StateHistory{{
+		Values:            mat.NewDense(1, len(state), state),
+		StateWidth:        len(state),
+		StateHistoryDepth: 1,
+	}}
+	ts := &simulator.CumulativeTimestepsHistory{
+		Values:            mat.NewVecDense(1, []float64{3.0}),
+		NextIncrement:     0.5,
+		CurrentStepNumber: 7,
+	}
+	return e.Iterate(&p, 0, histories, ts)
+}
+
+func TestExpressionSemantics(t *testing.T) {
+	t.Run("broadcasts scalars across a vector field and reduces", func(t *testing.T) {
+		e := &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v", Width: 3}, {Name: "s"}},
+			Outputs: []string{"v * k + 1", "sum(v) + dot(v, w)"},
+		}
+		got := evalOnce(t, e, []float64{1, 2, 3, 0}, map[string][]float64{
+			"k": {10}, "w": {1, 2, 3},
+		})
+		// v*10+1 = [11,21,31]; sum(v)=6; dot(v,w)=1+4+9=14 -> 20
+		want := []float64{11, 21, 31, 20}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("got %v, want %v", got, want)
+			}
+		}
+	})
+
+	t.Run("exposes dt, t and step", func(t *testing.T) {
+		e := &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "x"}},
+			Outputs: []string{"dt * 100 + t * 10 + step"},
+		}
+		got := evalOnce(t, e, []float64{0}, map[string][]float64{})
+		if want := 0.5*100 + 3.0*10 + 7.0; got[0] != want {
+			t.Fatalf("got %v, want %v", got[0], want)
+		}
+	})
+
+	t.Run("scalar where does not evaluate the untaken branch", func(t *testing.T) {
+		// If the guard were eager, `undefined_name` would panic. Laziness is what makes
+		// guards like where(n > 0, binomial(n, p), 0) safe.
+		e := &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "x"}},
+			Outputs: []string{"where(x > 100, undefined_name, 42)"},
+		}
+		got := evalOnce(t, e, []float64{1}, map[string][]float64{})
+		if got[0] != 42 {
+			t.Fatalf("got %v, want 42", got[0])
+		}
+	})
+
+	t.Run("vector where selects elementwise", func(t *testing.T) {
+		e := &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v", Width: 3}},
+			Outputs: []string{"where(v > 1, v * 10, 0)"},
+		}
+		got := evalOnce(t, e, []float64{0, 2, 3}, map[string][]float64{})
+		want := []float64{0, 20, 30}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("got %v, want %v", got, want)
+			}
+		}
+	})
+
+	t.Run("draws are reproducible for a given seed", func(t *testing.T) {
+		mk := func() *ExpressionIteration {
+			return &ExpressionIteration{
+				Fields:  []ExpressionField{{Name: "v", Width: 4}},
+				Outputs: []string{"normal(fill(4, 0), 1)"},
+			}
+		}
+		a := evalOnce(t, mk(), []float64{0, 0, 0, 0}, map[string][]float64{})
+		b := evalOnce(t, mk(), []float64{0, 0, 0, 0}, map[string][]float64{})
+		for i := range a {
+			if a[i] != b[i] {
+				t.Fatalf("same seed gave different streams: %v vs %v", a, b)
+			}
+		}
+	})
+
+	t.Run("a draw's width comes from its parameters", func(t *testing.T) {
+		// Scalar parameters mean ONE sample, which then broadcasts across the field: the
+		// documented sharp edge. Widening (fill, or a vector-valued parameter) is what
+		// gives independent noise per element.
+		shared := evalOnce(t, &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v", Width: 4}},
+			Outputs: []string{"normal(0, 1)"},
+		}, []float64{0, 0, 0, 0}, map[string][]float64{})
+		for i := 1; i < 4; i++ {
+			if shared[i] != shared[0] {
+				t.Fatalf("scalar-parameter draw should broadcast one sample, got %v", shared)
+			}
+		}
+		independent := evalOnce(t, &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v", Width: 4}},
+			Outputs: []string{"normal(fill(4, 0), sigmas)"},
+		}, []float64{0, 0, 0, 0}, map[string][]float64{"sigmas": {1, 1, 1, 1}})
+		if independent[0] == independent[1] && independent[1] == independent[2] {
+			t.Fatalf("widened draw should be independent per element, got %v", independent)
+		}
+	})
+
+	t.Run("compound draws compose (poisson of a gamma)", func(t *testing.T) {
+		// The negative-binomial branching shape the measles model needs.
+		e := &ExpressionIteration{
+			Fields: []ExpressionField{{Name: "n"}},
+			Bindings: []ExpressionBinding{
+				{Name: "lambda", Expr: "gamma(shape, rate)"},
+			},
+			Outputs: []string{"poisson(lambda)"},
+		}
+		got := evalOnce(t, e, []float64{0}, map[string][]float64{
+			"shape": {20}, "rate": {2},
+		})
+		if got[0] < 0 || math.IsNaN(got[0]) {
+			t.Fatalf("expected a non-negative count, got %v", got[0])
+		}
+	})
+
+	t.Run("a scalar output broadcasts across its field", func(t *testing.T) {
+		e := &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v", Width: 3}},
+			Outputs: []string{"7"},
+		}
+		got := evalOnce(t, e, []float64{0, 0, 0}, map[string][]float64{})
+		for i := range got {
+			if got[i] != 7 {
+				t.Fatalf("got %v, want all 7s", got)
+			}
+		}
+	})
+}
+
+func TestExpressionConfigErrors(t *testing.T) {
+	settings := &simulator.Settings{
+		Iterations: []simulator.IterationSettings{{Name: "p", Seed: 1}},
+	}
+	assertPanics := func(name string, e *ExpressionIteration) {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Fatalf("expected a panic for %s", name)
+				}
+			}()
+			e.Configure(0, settings)
+		})
+	}
+	assertPanics("outputs not matching fields", &ExpressionIteration{
+		Fields:  []ExpressionField{{Name: "a"}, {Name: "b"}},
+		Outputs: []string{"a"},
+	})
+	assertPanics("unparseable expression", &ExpressionIteration{
+		Fields:  []ExpressionField{{Name: "a"}},
+		Outputs: []string{"a +"},
+	})
+	assertPanics("unknown upstream partition", &ExpressionIteration{
+		Fields:    []ExpressionField{{Name: "a"}},
+		Upstreams: map[string]string{"x": "nope"},
+		Outputs:   []string{"a"},
+	})
+	assertPanics("unnamed field", &ExpressionIteration{
+		Fields:  []ExpressionField{{Name: ""}},
+		Outputs: []string{"1"},
+	})
+}

--- a/pkg/simulator/loaders_test.go
+++ b/pkg/simulator/loaders_test.go
@@ -17,7 +17,35 @@ func TestLoadPartitionConfig(t *testing.T) {
 	t.Run(
 		"test partition config is loaded properly",
 		func(t *testing.T) {
-			_ = LoadPartitionConfigFromYaml("./test_partition_config.yaml")
+			config := LoadPartitionConfigFromYaml("./test_partition_config.yaml")
+
+			// Discarding the result would let a key that loads into nothing pass, which is
+			// how this fixture kept two keys from a superseded schema: yaml ignores what it
+			// does not recognise, so the wiring below silently did not load at all.
+			upstream, ok := config.ParamsFromUpstream["other_test_params"]
+			if !ok {
+				t.Fatalf("upstream wiring did not load: got %v", config.ParamsFromUpstream)
+			}
+			if upstream.Upstream != "from_this_partition" {
+				t.Errorf("upstream: got %q, want from_this_partition", upstream.Upstream)
+			}
+			if len(upstream.Indices) != 6 {
+				t.Errorf("upstream indices: got %v, want six of them", upstream.Indices)
+			}
+			if got := config.ParamsAsPartitions["some_partition_params"]; len(got) != 2 {
+				t.Errorf("params as partitions: got %v, want two entries", got)
+			}
+			if got := config.Params.Map["test_params"]; len(got) != 3 {
+				t.Errorf("params: got %v, want three entries", got)
+			}
+			// Width is the init state's, never declared: a state_width key sat here for
+			// years reading as though it set something.
+			if len(config.InitStateValues) != 7 {
+				t.Errorf("state width: got %d, want 7", len(config.InitStateValues))
+			}
+			if config.Seed != 12345 {
+				t.Errorf("seed: got %d, want 12345", config.Seed)
+			}
 		},
 	)
 }

--- a/pkg/simulator/test_partition_config.yaml
+++ b/pkg/simulator/test_partition_config.yaml
@@ -1,15 +1,17 @@
+# The upstream wiring was once split across params_from_upstream_partition and
+# params_from_indices; it is now the single params_from_upstream below. This fixture kept the
+# old spelling long after the fields went away — yaml ignores a key it does not know, so both
+# loaded silently and did nothing, and the test asserted too little to notice.
 name: test
-iteration: "iterationTest"
 params:
   test_params: [0, 1, 2]
   more_test_params: [3, 4, 5, 6]
 params_as_partitions:
   some_partition_params: [other_partition, another_partition]
-params_from_upstream_partition:
-  other_test_params: from_this_partition
-params_from_indices:
-  other_test_params: [0, 1, 2, 3, 4, 5]
+params_from_upstream:
+  other_test_params:
+    upstream: from_this_partition
+    indices: [0, 1, 2, 3, 4, 5]
 init_state_values: [0, 0, 0, 0, 0, 0, 0]
 seed: 12345
-state_width: 7
 state_history_depth: 1

--- a/test/custom_iterations_test.go
+++ b/test/custom_iterations_test.go
@@ -84,7 +84,9 @@ func TestCustomIterations(t *testing.T) {
 			yRefs := []analysis.DataRef{{PartitionName: "custom_partition"}}
 
 			// Create a scatter plot from partitions in a simulator.StateTimeStorage
-			_ = analysis.NewScatterPlotFromPartition(storage, xRef, yRefs)
+			if plot := analysis.NewScatterPlotFromPartition(storage, xRef, yRefs); plot == nil {
+				t.Error("expected a scatter plot")
+			}
 		},
 	)
 }

--- a/test/evolution_strategy_optimisation_test.go
+++ b/test/evolution_strategy_optimisation_test.go
@@ -125,7 +125,9 @@ func TestEvolutionStrategyOptimisation(t *testing.T) {
 			}
 
 			// Create a scatter plot from partitions in a simulator.StateTimeStorage
-			_ = analysis.NewScatterPlotFromPartition(storage, xRef, yRefs)
+			if plot := analysis.NewScatterPlotFromPartition(storage, xRef, yRefs); plot == nil {
+				t.Error("expected a scatter plot")
+			}
 
 			// Reference the mean update plotting data for the y-axis
 			yRefs = []analysis.DataRef{
@@ -133,7 +135,9 @@ func TestEvolutionStrategyOptimisation(t *testing.T) {
 			}
 
 			// Create a line plot from partitions in a simulator.StateTimeStorage
-			_ = analysis.NewLinePlotFromPartition(storage, xRef, yRefs, nil)
+			if plot := analysis.NewLinePlotFromPartition(storage, xRef, yRefs, nil); plot == nil {
+				t.Error("expected a line plot")
+			}
 		},
 	)
 }

--- a/test/from_csv_test.go
+++ b/test/from_csv_test.go
@@ -1,22 +1,68 @@
 package main
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/umbralcalc/stochadex/pkg/analysis"
 )
 
+// data/test_csv.csv is a fixed fixture rather than something the suite regenerates, and that
+// is deliberate: because it never moves, it pins the on-disk CSV format. A change to the
+// column layout, to how floats are rendered, or to how rows map onto partitions shows up here
+// as a failure, rather than as a quietly-rewritten file that still round-trips against itself.
+// Reading it back is the assertion, so it has to actually be asserted.
 func TestFromCsv(t *testing.T) {
 	t.Run(
 		"integration test: from CSV",
 		func(t *testing.T) {
+			// The header is checked by hand because NewStateTimeStorageFromCsv skips it and
+			// indexes columns by position — nothing it returns can witness a renamed or
+			// reordered column, so without this the header could drift unnoticed.
+			header, err := os.ReadFile("data/test_csv.csv")
+			if err != nil {
+				t.Fatalf("the fixture did not open: %v", err)
+			}
+			line, _, _ := strings.Cut(string(header), "\n")
+			if got, want := line, "time,0,1,2,3"; got != want {
+				t.Errorf("got header %q, want %q", got, want)
+			}
+
 			// Read in CSV data directly into a simulator.StateTimeStorage
-			storage, _ := analysis.NewStateTimeStorageFromCsv(
+			storage, err := analysis.NewStateTimeStorageFromCsv(
 				"data/test_csv.csv",
 				0,
 				map[string][]int{"generated_data": {1, 2, 3, 4}},
 				true,
 			)
+			if err != nil {
+				t.Fatalf("the fixture did not load: %v", err)
+			}
+
+			values := storage.GetValues("generated_data")
+			if len(values) != 1001 {
+				t.Fatalf("got %d rows, want 1001 (the initial state plus 1000)", len(values))
+			}
+			if len(values[0]) != 4 {
+				t.Fatalf("got a width of %d, want 4", len(values[0]))
+			}
+
+			// Times come from column 0, in order.
+			times := storage.GetTimes()
+			if len(times) != 1001 || times[0] != 0 || times[len(times)-1] != 1000 {
+				t.Errorf("got %d times spanning %v to %v, want 1001 spanning 0 to 1000",
+					len(times), times[0], times[len(times)-1])
+			}
+
+			// Values read back at full precision, which is what catches a change in how floats
+			// are written or parsed rather than merely in the shape of a row.
+			if got, want := values[15][0], 0.57021; got != want {
+				t.Errorf("generated_data at t=15: got %v, want %v", got, want)
+			}
+			if got, want := values[1000][2], -10.847508; got != want {
+				t.Errorf("generated_data at t=1000: got %v, want %v", got, want)
+			}
 
 			// Reference the plotting data for the x-axis
 			xRef := analysis.DataRef{Plotting: &analysis.DataPlotting{IsTime: true}}
@@ -25,7 +71,9 @@ func TestFromCsv(t *testing.T) {
 			yRefs := []analysis.DataRef{{PartitionName: "generated_data"}}
 
 			// Create a scatter plot from partitions in a simulator.StateTimeStorage
-			_ = analysis.NewScatterPlotFromPartition(storage, xRef, yRefs)
+			if plot := analysis.NewScatterPlotFromPartition(storage, xRef, yRefs); plot == nil {
+				t.Error("expected a plot from the loaded fixture")
+			}
 		},
 	)
 }

--- a/test/from_dataframes_test.go
+++ b/test/from_dataframes_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"slices"
 	"testing"
 
 	"github.com/go-echarts/go-echarts/v2/charts"
@@ -11,19 +12,60 @@ import (
 	"github.com/umbralcalc/stochadex/pkg/simulator"
 )
 
+// data/test_df.csv is a fixed fixture rather than something the suite regenerates, and that is
+// deliberate: because it never moves, it pins the on-disk CSV format. A change to the column
+// layout or to how the time column is rendered shows up here as a failure, rather than as a
+// quietly-rewritten file that still round-trips against itself. Reading it back is the
+// assertion, so it has to actually be asserted.
 func TestFromDataframes(t *testing.T) {
 	t.Run(
 		"integration test: from dataframes",
 		func(t *testing.T) {
 			// Create a dataframe from the file
-			file, _ := os.Open("data/test_df.csv")
+			file, err := os.Open("data/test_df.csv")
+			if err != nil {
+				t.Fatalf("the fixture did not open: %v", err)
+			}
+			defer file.Close()
 			df := dataframe.ReadCSV(file)
+
+			// The columns are read by name, so a renamed or dropped one silently yields a
+			// partition of NaNs rather than an error.
+			if got, want := df.Names(), []string{"time", "0", "1", "2", "3"}; !slices.Equal(got, want) {
+				t.Fatalf("got columns %v, want %v", got, want)
+			}
 
 			// Create new state time storage for the data
 			storage := simulator.NewStateTimeStorage()
 
 			// Add the dataframe data to the storage as a partition
 			analysis.SetPartitionFromDataFrame(storage, "poisson_data", df, true)
+
+			values := storage.GetValues("poisson_data")
+			if len(values) != 1001 {
+				t.Fatalf("got %d rows, want 1001 (the initial state plus 1000)", len(values))
+			}
+			if len(values[0]) != 4 {
+				t.Fatalf("got a width of %d, want 4", len(values[0]))
+			}
+
+			// The times are UNIX timestamps a thousand seconds apart, taken from the time
+			// column because overwriteTime is set.
+			times := storage.GetTimes()
+			if len(times) != 1001 || times[0] != 1667980544.0 ||
+				times[len(times)-1] != 1668980544.0 {
+				t.Errorf("got %d times spanning %v to %v, want 1001 spanning 1667980544 to 1668980544",
+					len(times), times[0], times[len(times)-1])
+			}
+
+			// Values read back at full precision, which is what catches a change in how the
+			// columns are parsed rather than merely in the shape of a row.
+			if got, want := values[15][2], 13.0; got != want {
+				t.Errorf("poisson_data column 2 at row 15: got %v, want %v", got, want)
+			}
+			if got, want := values[1000][0], 708.0; got != want {
+				t.Errorf("poisson_data column 0 at row 1000: got %v, want %v", got, want)
+			}
 
 			// Reference the plotting data for the x-axis
 			xRef := analysis.DataRef{Plotting: &analysis.DataPlotting{IsTime: true}}

--- a/test/grouped_aggregations_test.go
+++ b/test/grouped_aggregations_test.go
@@ -91,7 +91,9 @@ func TestGroupedAggregations(t *testing.T) {
 			yRefs := []analysis.DataRef{{PartitionName: "grouped_sum"}}
 
 			// Create a scatter plot from partitions in a simulator.StateTimeStorage
-			_ = analysis.NewScatterPlotFromPartition(storage, xRef, yRefs)
+			if plot := analysis.NewScatterPlotFromPartition(storage, xRef, yRefs); plot == nil {
+				t.Error("expected a scatter plot")
+			}
 
 		},
 	)

--- a/test/likelihood_comparison_test.go
+++ b/test/likelihood_comparison_test.go
@@ -14,12 +14,30 @@ func TestLikelihoodComparison(t *testing.T) {
 		"integration test: likelihood comparison",
 		func(t *testing.T) {
 			// Read in CSV data directly into a simulator.StateTimeStorage
-			storage, _ := analysis.NewStateTimeStorageFromCsv(
+			storage, err := analysis.NewStateTimeStorageFromCsv(
 				"data/test_csv.csv",
 				0,
 				map[string][]int{"generated_data": {1, 2, 3, 4}},
 				true,
 			)
+			if err != nil {
+				t.Fatalf("the fixture did not load: %v", err)
+			}
+
+			// The comparison below runs against this data, so the fixture has to have landed
+			// before any of it means anything.
+			data := storage.GetValues("generated_data")
+			if len(data) != 1001 || len(data[0]) != 4 {
+				t.Fatalf("got %d rows of width %d, want 1001 of width 4", len(data), len(data[0]))
+			}
+			dataTimes := storage.GetTimes()
+			if dataTimes[0] != 0 || dataTimes[len(dataTimes)-1] != 1000 {
+				t.Fatalf("got times spanning %v to %v, want 0 to 1000",
+					dataTimes[0], dataTimes[len(dataTimes)-1])
+			}
+			if got, want := data[1000][2], -10.847508; got != want {
+				t.Fatalf("generated_data at t=1000: got %v, want %v", got, want)
+			}
 
 			// Configure a partition for computing the exponentially-weighted rolling mean
 			meanPartition := analysis.NewVectorMeanPartition(
@@ -116,7 +134,9 @@ func TestLikelihoodComparison(t *testing.T) {
 			}}
 
 			// Create a line plot from partitions in a simulator.StateTimeStorage
-			_ = analysis.NewLinePlotFromPartition(storage, xRef, yRefs, nil)
+			if plot := analysis.NewLinePlotFromPartition(storage, xRef, yRefs, nil); plot == nil {
+				t.Error("expected a line plot")
+			}
 		},
 	)
 }

--- a/test/likelihood_mean_function_fit_test.go
+++ b/test/likelihood_mean_function_fit_test.go
@@ -13,7 +13,21 @@ func TestLikelihoodMeanFunctionFit(t *testing.T) {
 		"integration test: likelihood mean function fit",
 		func(t *testing.T) {
 			// Create a simulator.StateTimeStorage from a log entries file
-			storage, _ := analysis.NewStateTimeStorageFromJsonLogEntries("./data/test.log")
+			storage, err := analysis.NewStateTimeStorageFromJsonLogEntries("./data/test.log")
+			if err != nil {
+				t.Fatalf("the fixture did not load: %v", err)
+			}
+
+			// The fit below runs against this data, so the fixture has to have landed before
+			// any of it means anything.
+			data := storage.GetValues("first_wiener_process")
+			if len(data) != 201 || len(data[0]) != 4 {
+				t.Fatalf("got %d entries of width %d, want 201 of width 4",
+					len(data), len(data[0]))
+			}
+			if got, want := data[15][0], 1.22168049752109; got != want {
+				t.Fatalf("first_wiener_process at t=15: got %v, want %v", got, want)
+			}
 
 			// Configure a partition to dynamically fit the mean of the data values
 			fitPartition := analysis.NewLikelihoodMeanFunctionFitPartition(
@@ -67,7 +81,9 @@ func TestLikelihoodMeanFunctionFit(t *testing.T) {
 			}
 
 			// Create a scatter plot from partitions in a simulator.StateTimeStorage
-			_ = analysis.NewScatterPlotFromPartition(storage, xRef, yRefs)
+			if plot := analysis.NewScatterPlotFromPartition(storage, xRef, yRefs); plot == nil {
+				t.Error("expected a scatter plot")
+			}
 		},
 	)
 }

--- a/test/loading_logs_test.go
+++ b/test/loading_logs_test.go
@@ -6,12 +6,49 @@ import (
 	"github.com/umbralcalc/stochadex/pkg/analysis"
 )
 
+// data/test.log is a fixed fixture rather than something the suite regenerates, and that is
+// deliberate: because it never moves, it pins the on-disk log format. A change to the JSON
+// keys, to how floats are rendered, or to how entries group into partitions shows up here as a
+// failure, rather than as a quietly-rewritten file that still round-trips against itself.
+// Reading it back is the assertion, so it has to actually be asserted — this test discarded
+// the error and passed against an empty file.
 func TestLoadingLogs(t *testing.T) {
 	t.Run(
 		"integration test: loading logs",
 		func(t *testing.T) {
 			// Create a simulator.StateTimeStorage from a log entries file
-			storage, _ := analysis.NewStateTimeStorageFromJsonLogEntries("./data/test.log")
+			storage, err := analysis.NewStateTimeStorageFromJsonLogEntries("./data/test.log")
+			if err != nil {
+				t.Fatalf("the fixture did not load: %v", err)
+			}
+
+			// The partition names come from the log's partition_name key, so a renamed or
+			// dropped key loses them.
+			first := storage.GetValues("first_wiener_process")
+			second := storage.GetValues("second_wiener_process")
+			if len(first) != 201 || len(second) != 201 {
+				t.Fatalf("got %d and %d entries, want 201 each (the initial state plus 200)",
+					len(first), len(second))
+			}
+			if len(first[0]) != 4 || len(second[0]) != 2 {
+				t.Fatalf("got widths %d and %d, want 4 and 2", len(first[0]), len(second[0]))
+			}
+
+			// Times are the log's own, in order.
+			times := storage.GetTimes()
+			if len(times) != 201 || times[0] != 0 || times[len(times)-1] != 200 {
+				t.Errorf("got %d times spanning %v to %v, want 201 spanning 0 to 200",
+					len(times), times[0], times[len(times)-1])
+			}
+
+			// Values read back at full precision, which is what catches a change in how floats
+			// are written or parsed rather than merely in the shape of an entry.
+			if got, want := first[15][0], 1.22168049752109; got != want {
+				t.Errorf("first_wiener_process at t=15: got %v, want %v", got, want)
+			}
+			if got, want := first[200][3], -42.7235171584224; got != want {
+				t.Errorf("first_wiener_process at t=200: got %v, want %v", got, want)
+			}
 
 			// Reference the plotting data for the x-axis
 			xRef := analysis.DataRef{Plotting: &analysis.DataPlotting{IsTime: true}}
@@ -20,7 +57,9 @@ func TestLoadingLogs(t *testing.T) {
 			yRefs := []analysis.DataRef{{PartitionName: "first_wiener_process"}}
 
 			// Create a scatter plot from partitions in a simulator.StateTimeStorage
-			_ = analysis.NewScatterPlotFromPartition(storage, xRef, yRefs)
+			if plot := analysis.NewScatterPlotFromPartition(storage, xRef, yRefs); plot == nil {
+				t.Error("expected a plot from the loaded fixture")
+			}
 		},
 	)
 }

--- a/test/postgres_writing_and_querying_test.go
+++ b/test/postgres_writing_and_querying_test.go
@@ -68,12 +68,32 @@ func TestPostgresWritingAndQuerying(t *testing.T) {
 			analysis.WriteStateTimeStorageToPostgresDb(db, storage)
 
 			// Create a simulator.StateTimeStorage using data from a DB table
-			storage, _ = analysis.NewStateTimeStorageFromPostgresDb(
+			storage, err := analysis.NewStateTimeStorageFromPostgresDb(
 				db,
 				[]string{"gamma_compound_poisson", "group_numbers"},
 				0.0,
 				1000.0,
 			)
+			if err != nil {
+				t.Fatalf("the data did not read back from the DB: %v", err)
+			}
+
+			// Read back what was just written. The table keys on (partition_name, time), so a
+			// re-run overwrites rather than accumulates and these counts stay put.
+			jumps := storage.GetValues("gamma_compound_poisson")
+			groups := storage.GetValues("group_numbers")
+			if len(jumps) != 1001 || len(groups) != 1001 {
+				t.Fatalf("got %d and %d rows, want 1001 each (the initial state plus 1000)",
+					len(jumps), len(groups))
+			}
+			if len(jumps[0]) != 3 || len(groups[0]) != 3 {
+				t.Fatalf("got widths %d and %d, want 3 and 3", len(jumps[0]), len(groups[0]))
+			}
+			times := storage.GetTimes()
+			if len(times) != 1001 || times[0] != 0 || times[len(times)-1] != 1000 {
+				t.Errorf("got %d times spanning %v to %v, want 1001 spanning 0 to 1000",
+					len(times), times[0], times[len(times)-1])
+			}
 
 			// Reference the plotting data for the x-axis
 			xRef := analysis.DataRef{Plotting: &analysis.DataPlotting{IsTime: true}}
@@ -82,7 +102,9 @@ func TestPostgresWritingAndQuerying(t *testing.T) {
 			yRefs := []analysis.DataRef{{PartitionName: "gamma_compound_poisson"}}
 
 			// Create a scatter plot from partitions in a simulator.StateTimeStorage
-			_ = analysis.NewScatterPlotFromPartition(storage, xRef, yRefs)
+			if plot := analysis.NewScatterPlotFromPartition(storage, xRef, yRefs); plot == nil {
+				t.Error("expected a plot from the data read back from the DB")
+			}
 		},
 	)
 }

--- a/test/rolling_vector_aggregations_test.go
+++ b/test/rolling_vector_aggregations_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"slices"
 	"testing"
 
 	"github.com/go-gota/gota/dataframe"
@@ -33,7 +34,11 @@ func TestRollingVectorAggregations(t *testing.T) {
 		"integration test: rolling vector aggregations",
 		func(t *testing.T) {
 			// Initialise a csv file reader
-			file, _ := os.Open("data/test_df.csv")
+			file, err := os.Open("data/test_df.csv")
+			if err != nil {
+				t.Fatalf("the fixture did not open: %v", err)
+			}
+			defer file.Close()
 
 			// Create a dataframe from the file
 			df := dataframe.ReadCSV(file)
@@ -43,6 +48,25 @@ func TestRollingVectorAggregations(t *testing.T) {
 
 			// Add the dataframe data to the storage as a partition
 			analysis.SetPartitionFromDataFrame(storage, "poisson_data", df, true)
+
+			// The aggregations below run over this data, so the fixture has to have landed
+			// before any of it means anything — the columns are read by name and a renamed or
+			// dropped one silently yields NaNs rather than an error.
+			if got, want := df.Names(), []string{"time", "0", "1", "2", "3"}; !slices.Equal(got, want) {
+				t.Fatalf("got columns %v, want %v", got, want)
+			}
+			data := storage.GetValues("poisson_data")
+			if len(data) != 1001 || len(data[0]) != 4 {
+				t.Fatalf("got %d rows of width %d, want 1001 of width 4", len(data), len(data[0]))
+			}
+			dataTimes := storage.GetTimes()
+			if dataTimes[0] != 1667980544.0 || dataTimes[len(dataTimes)-1] != 1668980544.0 {
+				t.Fatalf("got times spanning %v to %v, want 1667980544 to 1668980544",
+					dataTimes[0], dataTimes[len(dataTimes)-1])
+			}
+			if got, want := data[1000][0], 708.0; got != want {
+				t.Fatalf("poisson_data column 0 at row 1000: got %v, want %v", got, want)
+			}
 
 			// Configure a partition for differencing of the Poisson data
 			diffPartition := &simulator.PartitionConfig{

--- a/test/saving_logs_advanced_test.go
+++ b/test/saving_logs_advanced_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"path/filepath"
 	"testing"
 
+	"github.com/umbralcalc/stochadex/pkg/analysis"
 	"github.com/umbralcalc/stochadex/pkg/continuous"
 	"github.com/umbralcalc/stochadex/pkg/simulator"
 )
@@ -11,6 +13,10 @@ func TestSavingLogsAdvanced(t *testing.T) {
 	t.Run(
 		"integration test: saving logs advanced",
 		func(t *testing.T) {
+			// Written to a temporary path, not to ./data/test.log — see the note in
+			// saving_logs_standard_test.go.
+			logFile := filepath.Join(t.TempDir(), "test.log")
+
 			// Manually setup a simulation config
 			generator := simulator.NewConfigGenerator()
 
@@ -39,8 +45,7 @@ func TestSavingLogsAdvanced(t *testing.T) {
 			})
 
 			// Create a higher performance logging channel
-			logChannel := simulator.NewJsonLogChannelOutputFunction("./data/test.log")
-			defer logChannel.Close()
+			logChannel := simulator.NewJsonLogChannelOutputFunction(logFile)
 
 			// Manually configure the extra simulation run specs
 			generator.SetSimulation(&simulator.SimulationConfig{
@@ -60,6 +65,20 @@ func TestSavingLogsAdvanced(t *testing.T) {
 
 			// Run the simulation
 			coordinator.Run()
+
+			// Closed explicitly rather than deferred: this channel buffers, so the log is not
+			// complete until the flush, and the read below would race it.
+			logChannel.Close()
+
+			// Read it back. Nothing else looks at this output now, so without this the test
+			// would pass whether or not a single line was written.
+			storage, err := analysis.NewStateTimeStorageFromJsonLogEntries(logFile)
+			if err != nil {
+				t.Fatalf("the log did not read back: %v", err)
+			}
+			if got := len(storage.GetValues("first_wiener_process")); got != 201 {
+				t.Errorf("got %d logged steps, want 201 (the initial state plus 200)", got)
+			}
 		},
 	)
 }

--- a/test/saving_logs_standard_test.go
+++ b/test/saving_logs_standard_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"path/filepath"
 	"testing"
 
+	"github.com/umbralcalc/stochadex/pkg/analysis"
 	"github.com/umbralcalc/stochadex/pkg/continuous"
 	"github.com/umbralcalc/stochadex/pkg/simulator"
 )
@@ -11,6 +13,13 @@ func TestSavingLogsStandard(t *testing.T) {
 	t.Run(
 		"integration test: saving logs standard",
 		func(t *testing.T) {
+			// Written to a temporary path, not to ./data/test.log. That file is a committed
+			// fixture the loading tests read, and writing to it here left the working tree
+			// dirty after every run and coupled these tests by execution order — the readers
+			// only saw the fixture rather than this output because Go happens to order test
+			// files alphabetically.
+			logFile := filepath.Join(t.TempDir(), "test.log")
+
 			// Manually setup a simulation config
 			generator := simulator.NewConfigGenerator()
 
@@ -41,7 +50,7 @@ func TestSavingLogsStandard(t *testing.T) {
 			// Manually configure the extra simulation run specs
 			generator.SetSimulation(&simulator.SimulationConfig{
 				OutputCondition: &simulator.EveryStepOutputCondition{},
-				OutputFunction:  simulator.NewJsonLogOutputFunction("./data/test.log"),
+				OutputFunction:  simulator.NewJsonLogOutputFunction(logFile),
 				TerminationCondition: &simulator.NumberOfStepsTerminationCondition{
 					MaxNumberOfSteps: 200,
 				},
@@ -56,6 +65,19 @@ func TestSavingLogsStandard(t *testing.T) {
 
 			// Run the simulation
 			coordinator.Run()
+
+			// Read it back. Nothing else looks at this output now, so without this the test
+			// would pass whether or not a single line was written.
+			storage, err := analysis.NewStateTimeStorageFromJsonLogEntries(logFile)
+			if err != nil {
+				t.Fatalf("the log did not read back: %v", err)
+			}
+			if got := len(storage.GetValues("first_wiener_process")); got != 201 {
+				t.Errorf("got %d logged steps, want 201 (the initial state plus 200)", got)
+			}
+			if got := len(storage.GetValues("second_wiener_process")[0]); got != 2 {
+				t.Errorf("got a width of %d for the second process, want 2", got)
+			}
 		},
 	)
 }

--- a/test/simulation_inference_test.go
+++ b/test/simulation_inference_test.go
@@ -14,12 +14,30 @@ func TestSimulationInference(t *testing.T) {
 		"integration test: simulation inference",
 		func(t *testing.T) {
 			// Read in CSV data directly into a simulator.StateTimeStorage
-			storage, _ := analysis.NewStateTimeStorageFromCsv(
+			storage, err := analysis.NewStateTimeStorageFromCsv(
 				"data/test_csv.csv",
 				0,
 				map[string][]int{"generated_data": {1, 2, 3, 4}},
 				true,
 			)
+			if err != nil {
+				t.Fatalf("the fixture did not load: %v", err)
+			}
+
+			// Everything below infers from this data, so the fixture has to have landed before
+			// any of it means anything.
+			data := storage.GetValues("generated_data")
+			if len(data) != 1001 || len(data[0]) != 4 {
+				t.Fatalf("got %d rows of width %d, want 1001 of width 4", len(data), len(data[0]))
+			}
+			dataTimes := storage.GetTimes()
+			if dataTimes[0] != 0 || dataTimes[len(dataTimes)-1] != 1000 {
+				t.Fatalf("got times spanning %v to %v, want 0 to 1000",
+					dataTimes[0], dataTimes[len(dataTimes)-1])
+			}
+			if got, want := data[15][0], 0.57021; got != want {
+				t.Fatalf("generated_data at t=15: got %v, want %v", got, want)
+			}
 
 			// Configure a partition for computing the exponentially-weighted rolling mean
 			meanPartition := analysis.NewVectorMeanPartition(
@@ -166,19 +184,25 @@ func TestSimulationInference(t *testing.T) {
 			}}
 
 			// Create a line plot from partitions in a simulator.StateTimeStorage
-			_ = analysis.NewLinePlotFromPartition(storage, xRef, yRefs, nil)
+			if plot := analysis.NewLinePlotFromPartition(storage, xRef, yRefs, nil); plot == nil {
+				t.Error("expected a line plot")
+			}
 
 			// Reference the posterior samples plotting data for the y-axis
 			yRefs = []analysis.DataRef{{PartitionName: "posterior_sampler"}}
 
 			// Create a scatter plot from partitions in a simulator.StateTimeStorage
-			_ = analysis.NewScatterPlotFromPartition(storage, xRef, yRefs)
+			if plot := analysis.NewScatterPlotFromPartition(storage, xRef, yRefs); plot == nil {
+				t.Error("expected a scatter plot")
+			}
 
 			// Reference the rolling mean plotting data (the target params) for the y-axis
 			yRefs = []analysis.DataRef{{PartitionName: "mean"}}
 
 			// Create a line plot from partitions in a simulator.StateTimeStorage
-			_ = analysis.NewLinePlotFromPartition(storage, xRef, yRefs, nil)
+			if plot := analysis.NewLinePlotFromPartition(storage, xRef, yRefs, nil); plot == nil {
+				t.Error("expected a line plot")
+			}
 		},
 	)
 }

--- a/test/to_csv_test.go
+++ b/test/to_csv_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/umbralcalc/stochadex/pkg/analysis"
@@ -14,6 +15,13 @@ func TestToCsv(t *testing.T) {
 	t.Run(
 		"integration test: to CSV",
 		func(t *testing.T) {
+			// Written to a temporary path, not to ./data/test_csv.csv. That file is a
+			// committed fixture the reading tests pin the format against, and writing to it
+			// here coupled the tests by execution order — the readers only saw the fixture
+			// rather than this output because Go happens to order test files alphabetically,
+			// so f comes before t.
+			csvFile := filepath.Join(t.TempDir(), "test_csv.csv")
+
 			// Create a simulator.StateTimeStorage from a simulation run
 			storage := analysis.NewStateTimeStorageFromPartitions(
 				// Instantiate the desired simulation state partitions
@@ -48,8 +56,46 @@ func TestToCsv(t *testing.T) {
 			df := analysis.GetDataFrameFromPartition(storage, "generated_data")
 
 			// Save the dataframe as a CSV for later
-			file, _ := os.Create("data/test_csv.csv")
-			df.WriteCSV(file)
+			file, err := os.Create(csvFile)
+			if err != nil {
+				t.Fatalf("could not create the output file: %v", err)
+			}
+			if err := df.WriteCSV(file); err != nil {
+				t.Fatalf("could not write the dataframe as CSV: %v", err)
+			}
+			if err := file.Close(); err != nil {
+				t.Fatalf("could not close the output file: %v", err)
+			}
+
+			// Read it back. Nothing else looks at this output now, so without this the test
+			// would pass whether or not a single row was written.
+			written, err := analysis.NewStateTimeStorageFromCsv(
+				csvFile,
+				0,
+				map[string][]int{"generated_data": {1, 2, 3, 4}},
+				true,
+			)
+			if err != nil {
+				t.Fatalf("the CSV did not read back: %v", err)
+			}
+			values := written.GetValues("generated_data")
+			if len(values) != 1001 {
+				t.Fatalf("got %d rows, want 1001 (the initial state plus 1000)", len(values))
+			}
+			if len(values[0]) != 4 {
+				t.Fatalf("got a width of %d, want 4", len(values[0]))
+			}
+			times := written.GetTimes()
+			if len(times) != 1001 || times[0] != 0 || times[len(times)-1] != 1000 {
+				t.Errorf("got %d times spanning %v to %v, want 1001 spanning 0 to 1000",
+					len(times), times[0], times[len(times)-1])
+			}
+
+			// The initial state survives the round trip exactly, which is the one row whose
+			// value does not depend on the RNG.
+			if got, want := values[0][1], 8.3; got != want {
+				t.Errorf("generated_data at t=0: got %v, want %v", got, want)
+			}
 
 			// Display the dataframe
 			fmt.Println(df)

--- a/test/to_dataframes_test.go
+++ b/test/to_dataframes_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/go-gota/gota/dataframe"
 	"github.com/umbralcalc/stochadex/pkg/analysis"
 	"github.com/umbralcalc/stochadex/pkg/discrete"
 	"github.com/umbralcalc/stochadex/pkg/simulator"
@@ -14,6 +16,10 @@ func TestToDataframes(t *testing.T) {
 	t.Run(
 		"integration test: to dataframes",
 		func(t *testing.T) {
+			// Written to a temporary path, not to ./data/test_df.csv — see the note in
+			// to_csv_test.go.
+			dfFile := filepath.Join(t.TempDir(), "test_df.csv")
+
 			// Create a simulator.StateTimeStorage from a simulation run
 			storage := analysis.NewStateTimeStorageFromPartitions(
 				// Instantiate the desired simulation state partitions
@@ -45,8 +51,55 @@ func TestToDataframes(t *testing.T) {
 			df := analysis.GetDataFrameFromPartition(storage, "poisson_data")
 
 			// Save the dataframe as a csv for later
-			file, _ := os.Create("data/test_df.csv")
-			df.WriteCSV(file)
+			file, err := os.Create(dfFile)
+			if err != nil {
+				t.Fatalf("could not create the output file: %v", err)
+			}
+			if err := df.WriteCSV(file); err != nil {
+				t.Fatalf("could not write the dataframe as CSV: %v", err)
+			}
+			if err := file.Close(); err != nil {
+				t.Fatalf("could not close the output file: %v", err)
+			}
+
+			// Read it back. Nothing else looks at this output now, so without this the test
+			// would pass whether or not a single row was written.
+			readBack, err := os.Open(dfFile)
+			if err != nil {
+				t.Fatalf("the CSV did not open: %v", err)
+			}
+			defer readBack.Close()
+			written := simulator.NewStateTimeStorage()
+			analysis.SetPartitionFromDataFrame(
+				written, "poisson_data", dataframe.ReadCSV(readBack), true)
+
+			values := written.GetValues("poisson_data")
+			if len(values) != 1001 {
+				t.Fatalf("got %d rows, want 1001 (the initial state plus 1000)", len(values))
+			}
+			if len(values[0]) != 4 {
+				t.Fatalf("got a width of %d, want 4", len(values[0]))
+			}
+
+			// The timestamps are the ones configured above, so they pin the round trip
+			// independently of the RNG.
+			times := written.GetTimes()
+			if len(times) != 1001 || times[0] != 1667980544.0 ||
+				times[len(times)-1] != 1668980544.0 {
+				t.Errorf("got %d times spanning %v to %v, want 1001 spanning 1667980544 to 1668980544",
+					len(times), times[0], times[len(times)-1])
+			}
+
+			// A Poisson counter starts at zero and only ever increases.
+			if got := values[0]; got[0] != 0 || got[1] != 0 || got[2] != 0 || got[3] != 0 {
+				t.Errorf("got an initial state of %v, want all zeros", got)
+			}
+			for i := range values[0] {
+				if values[1000][i] < values[0][i] {
+					t.Errorf("counter %d went backwards: %v then %v",
+						i, values[0][i], values[1000][i])
+				}
+			}
 
 			// Display the dataframe
 			fmt.Println(df)


### PR DESCRIPTION
Adds `general.ExpressionIteration` — a partition specified as **data** rather than Go — wires it into the api config as a root `expressions` field, and gives **every model in the catalogue (9/9) a declarative twin** proven equivalent to its bespoke Go.

The point: the existing `iteration` field is a *Go expression*, so it only becomes real via codegen and a Go toolchain. An expression spec is just data, loaded straight from YAML and evaluated at run time. **A config built only from expressions compiles nothing** — which is what lets a simulation be specified by something that doesn't write Go.

```yaml
expressions:
- partition: walk
  fields: [{name: x}]
  outputs: ["x + drift * dt"]
```

## The design is derived from the catalogue, not guessed

Surveying all 19 bespoke iterations across the 9 domain models:

| Finding | Consequence |
|---|---|
| **18/19** read another partition's state | coupling-by-name is the core primitive |
| **77** `if`/`switch` | collapse into a `where` expression |
| **44** loops over dimensions | vanish into elementwise semantics |
| most iteration struct state | is cached name→index lookups, i.e. the wiring boilerplate this deletes |
| measles' branching sampler, homark's chained binomials | need only draws whose *parameters are expressions*: `poisson(gamma(shape, rate))` |

So: one value type (a vector; length-1 broadcasts), an ordered DAG of named bindings, one output per named field, refs to fields/params/upstreams/`dt`/`t`/`step`, draws via `pkg/rng`. Go's own parser supplies the grammar. No assignment and no recursion, so an expression always terminates.

**The survey was wrong about one thing, and writing the twins is what found it.** It concluded 0/19 iterations read past rows — that the catalogue is Markovian, so history sweeps "aren't needed". `trywizard`'s `match_state` ages yellow cards out by differencing against a partition's state **ten rows back**. Hence `lag`, below.

## Equivalence is exact, not distributional

`pkg/rng.New(seed)` builds the same generator a hand-written iteration constructs (`rand.New(rand.NewPCG(seed, seed))`), so when a spec takes the same draws in the same order, both models run on **the same stream** and equivalence is decidable by value. Deviations across the catalogue run **0 to ~1e-14** — a twin reproduces its card's *numbers*, not merely their directions.

Never asserted bit-identical: compiled Go contracts `a + b*c` into an **FMA**, which rounds differently from the evaluator. That residue is the FMA, not the model — and it is exactly why threshold-based claim binding is the right oracle.

Two mandatory verification layers, because **each is blind where the other sees**:

- **Step-for-step** — randomised inputs through single `Iterate` calls. Catches a mis-stated formula.
- **Whole-suite** — re-run `ObservedBehaviour()` against the declarative build. Catches wrong wiring, params, or state layout.

Proven necessary in both directions: a perturbed coefficient sails through every step test (they feed their own randomised params) and only the suite catches it; and in `antimicrobial-resistance`, **deleting the model's stated causal mechanism passes the entire claim suite** — only the step test catches it.

Where streams can't align, the *oracle* steps down (exact → claim-level → distributional), never the tolerance. Look first for a regime that recovers exactness: AMR compares exactly at `noise_scale = 0`, where both sides multiply their draw by zero.

## Five capability gaps found, all closed

The catalogue asked; nothing here was guessed:

| Gap | Found by | Closed by |
|---|---|---|
| Seasonality; threshold-exceedance probability | `bathing-water-forecaster` | `sin`/`cos`/`erf`/`erfc`, `pi` |
| Index shift — output *i* reads input *i−1*, absorbing boundary | `business-survival` (cohort/Leslie flow) | `each` |
| Lag-*N* history read | `trywizard` | `lag(name, n)` |
| Slicing a block from a flat vector | `trywizard` (9 coeffs at a stride-9 offset) | `slice` + `concat` |
| Draw ordering + lane-wise laziness | `measles-risk-forecaster` | `each` |

The four structural gaps **rhymed** — every one was about *structured access* or *per-lane control of draws*, the axis a strictly elementwise evaluator gives up. So they were one design question, and `each(n, i, expr)` closed two at once: element *i* may read element *i−1* (a cohort ages); inside a lane every value is scalar so `where` is lazy there (a switched-off lane draws nothing); and lanes run in order (a lane's gamma and poisson interleave as a loop's do).

This **reverses** the original scope note. It said `business-survival` resists, and that the answer was to promote a core cohort iteration rather than grow the language. We grew the language, and it's 9/9.

## Promotion triage, rethought

The old rule was a *frequency* test — an extension recurring across entries wants promoting — which can't fire until several stubs exist. "Can the DSL express it?" is decidable on the **first** model:

- **Can** → the bespoke Go is a convenience, not a capability. Promotion is optional and must be earned by a measurement.
- **Cannot** → a real capability gap; one model proves it.

Check what a sampler *actually does* before weakening an oracle: AMR genuinely hand-rolls Knuth (different algorithm, different draw count — unalignable), while `business-survival` merely *looks* like it and is a thin `distuv` wrapper that aligns exactly. They read identically from outside and only one costs the oracle.

## Fixed

- **A NaN index silently read element 0 on arm64 and panicked on amd64.** Go leaves `int(NaN)` undefined. An architecture-dependent wrong answer, in a repo whose cards claim architecture stability. Found by writing a twin, not by running a model.
- **AMR's card overclaimed its mechanism.** It said the selection test "pins down *why* the stewardship lever works". It doesn't: prescribing reaches resistance by direct conversion *and* by competitive release, both selection-gated, so switching selection off can't separate them. Now says *necessary*, not attributed. The claim itself was always true; no generated number moved.

## Breaking

**A config key that nothing reads is now rejected.** `yaml.v2` ignores unknown keys silently, so a typo or a stale key did nothing while looking load-bearing — `state_width` sat in every config in this repo doing exactly that. Strict parsing can't express the rule: the two views share one file and split its keys, so each rejects the other's. Neither is the whole schema; their union is. **A key is dead only when both views reject it** — no second schema to drift.

Also: `models/*/behaviour.go` helpers take a `stubBuilder` so the claim suite is *pointed at* either assembly. `ObservedBehaviour()` keeps its no-arg signature (`cmd/model-index` detects it by AST).

## Test integrity

`pkg/general/expression.go` goes 78% → **100%** statement coverage. `evalBinary` was at 41%, meaning most operators a model is written in had never been evaluated once — and `Bindings`, which every twin is built on, had zero coverage.

Separately, all three `test/data/` fixtures were being **written over by the suite**, so they could only round-trip against themselves and pinned no format at all. The old `TestLoadingLogs` passed against renamed keys, garbage, and an empty file. Writers now use `t.TempDir()`; readers assert format; `-shuffle=on` passes, so the alphabetical ordering the readers silently depended on is gone.

Two findings recorded rather than papered over: the CSV reader indexes columns positionally, so nothing it returns can witness a renamed column (the header is now asserted as raw text); and `test_df.csv` can't catch precision loss by any assertion, because every value in it is a whole number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
