### PR TITLE
Harden and close out the data-drivable config arc (0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ an exact version rather than assume stability across minors.
 
 ## [Unreleased]
 
+## [0.5.1] — 2026-07-19
+
+Closes out the data-drivable config arc (0.5.0): a real fix, two silent-footgun guards, the
+code-generation-path CI gap, and hardening tests. No new capability.
+
 ### Fixed
 - **`general.CumulativeIteration` / `DiscountedCumulativeIteration` now propagate `Configure`
   to the iteration they wrap.** Previously a sampler-based inner iteration (Wiener, OU, …) had

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,29 @@ an exact version rather than assume stability across minors.
 
 ## [Unreleased]
 
+### Fixed
+- **`general.CumulativeIteration` / `DiscountedCumulativeIteration` now propagate `Configure`
+  to the iteration they wrap.** Previously a sampler-based inner iteration (Wiener, OU, …) had
+  its RNG left nil and panicked mid-run; the data-config form `{type: cumulative, iteration:
+  {type: wiener_process}}` made that easy to hit. They now configure the inner, so cumulative
+  wraps any iteration.
+
+### Added
+- **Macro-path guards.** A config that sets both `main.partitions` and `macros:` is rejected
+  (macros run in their own context and ignore `main`), and the `data:` sub-simulation is
+  deadlock-pre-flighted like any other run — so a cyclic data block fails with a located error
+  instead of an opaque hang.
+- **`test/binary_configs_test.go`** runs example configs through the built CLI end-to-end —
+  covering the code-generation path (`go run` of a generated main) that the in-process `pkg/api`
+  tests do not. Replaces the never-in-CI `test/configs_test.sh`. It exposed that
+  `cfg/example_config.yaml` only runs from the repo root (a repo-relative `json_log` output
+  path); the test runs configs from there accordingly.
+- **Behaviour, invariant and regression tests** across the config system: data-spec iterations
+  produce output identical to their Go-expr twins; SMC particle templates substitute and
+  deep-copy per particle; YAML boolean-like names (`y`/`n`/`on`/`off`) survive typed decoding;
+  the in-process/codegen boundary; a 3-partition deadlock ring; and a config Wiener process
+  diffusing as Brownian motion.
+
 ## [0.5.0] — 2026-07-18
 
 The whole engine becomes drivable as data. 0.4.0 made a single partition's *update*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,10 +90,36 @@ Simulations are usually assembled with a `simulator.ConfigGenerator` (`SetPartit
 
 1. **Programmatic Go** — build `Settings` + `Implementations` (or a `ConfigGenerator`)
    directly in Go. Used in unit tests and when embedding stochadex as a library.
-2. **YAML API path** — define the run in YAML (`ApiRunConfig`); iteration types are Go
-   expressions as strings (e.g. `"&continuous.WienerProcessIteration{}"`), with
-   `extra_packages` / `extra_vars` declaring imports and variables. The API generates and
-   runs Go from a template.
+2. **YAML API path** — define the run in YAML (`ApiRunConfig`). Every position that holds a
+   framework component is a **union**: a Go-expression string (e.g.
+   `"&continuous.WienerProcessIteration{}"`, resolved by generating and running Go from a
+   template, with `extra_packages` / `extra_vars` declaring imports and variables) **or** a
+   `{type: ...}` data spec resolved at load with no toolchain (`iteration: {type:
+   wiener_process}`; `timestep_function: {type: constant, stepsize: 1.0}`). A config that names
+   no Go anywhere runs **in-process** — no codegen, no `go run`.
+
+   The registries and tiers (all in `pkg/api`, with the four simulation-component families in
+   `pkg/simulator`):
+   - **Iterations** — `pkg/api/registry.go` (data-only) and `registry_compose.go` (composable,
+     recursive kernel/likelihood/jump/prior/nested-iteration/named-func specs). A partition's
+     bespoke *maths* still goes through `expressions:`; the registry is for the framework's own
+     catalogue. Two drift tests guard it (`registry_test.go`, `registry_coverage_test.go`): every
+     registered name constructs the type it claims, and a `go/ast` scan requires every `Iterate`
+     type to be registered or excluded-with-reason.
+   - **`run:`** — `{mode: batch | ensemble, seeds, concurrency}` (`RunModeConfig`).
+   - **`data:` + `macros:`** (`pkg/api/macros*.go`) — the analysis tier. `data:` (a sub-simulation
+     or a `csv`/`json_log`/`postgres` source) produces a `StateTimeStorage`; each macro expands one
+     of the `pkg/analysis` constructors against it (`posterior_estimation`, `likelihood_comparison`,
+     the aggregations, `scalar_regression_stats`) or runs live (`evolution_strategy_optimisation`,
+     `smc_inference`). Macro inputs are typed spec structs decoded straight from YAML.
+
+**Invariant A restated for this surface (repo boundary).** Inference-*as-forward-simulation* — a
+posterior being stepped as a partition — is in scope here; `posterior_estimation` and the other
+inference macros belong in this engine. Inference *against real data* is the `data:` resource
+(the observed dataset), which a downstream repo supplies. The engine owns the forward and
+inferential model; it does not own the dataset, the calibration loop, or the decision layer.
+`mcts_self_play` stays Go on purpose — its `agents.Environment` is arbitrary game rules (the
+decision layer), not representable as data.
 
 ## Testing conventions
 

--- a/pkg/api/macros.go
+++ b/pkg/api/macros.go
@@ -116,6 +116,11 @@ func (d *DataConfig) buildStorage() (*simulator.StateTimeStorage, error) {
 		return nil, err
 	}
 	generator := run.GetConfigGenerator()
+	// Pre-flight the data: sub-simulation's within-step wiring, so a cyclic data
+	// block fails with a located error rather than an opaque runtime deadlock.
+	if err := CheckForDeadlock(generator); err != nil {
+		return nil, err
+	}
 	partitions := make([]*simulator.PartitionConfig, 0, len(d.Partitions))
 	for _, name := range generator.PartitionNames() {
 		partitions = append(partitions, generator.GetPartition(name))
@@ -154,6 +159,11 @@ func resolveIterations(partitions []simulator.PartitionConfig) error {
 // built lazily on first use — so a live-only config needs no data: block. Running
 // in turn lets a later against-storage macro reference an earlier one's output.
 func runMacros(config *ApiRunConfig) (*simulator.StateTimeStorage, error) {
+	if len(config.Main.Partitions) > 0 {
+		return nil, fmt.Errorf("api: a config sets both main.partitions and macros:; " +
+			"macros run in their own context and ignore main — put data-generating " +
+			"partitions under data:, not main")
+	}
 	var storage *simulator.StateTimeStorage
 	ensureStorage := func() error {
 		if storage != nil {

--- a/pkg/api/macros_inference_test.go
+++ b/pkg/api/macros_inference_test.go
@@ -213,3 +213,24 @@ macros:
 		}
 	}
 }
+
+// TestPosteriorJustVarianceWiring guards that the covariance.just_variance flag
+// survives the spec->Applied translation (it selects a variance-only posterior
+// path in NewPosteriorEstimationPartitions, so silently dropping it would produce
+// a different, wrong estimator).
+func TestPosteriorJustVarianceWiring(t *testing.T) {
+	spec := posteriorEstimationSpec{}
+	spec.Covariance.JustVariance = true
+	spec.Covariance.Default = []float64{1.0, 1.0}
+	spec.Sampler.Distribution.Likelihood = simulator.ComponentSpec{Type: "normal"}
+	spec.Comparison.Model.Likelihood = simulator.ComponentSpec{Type: "normal"}
+	spec.Comparison.Window.Depth = 1
+
+	applied, err := spec.resolveApplied()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !applied.Covariance.JustVariance {
+		t.Error("just_variance was dropped in the spec->Applied translation")
+	}
+}

--- a/pkg/api/macros_test.go
+++ b/pkg/api/macros_test.go
@@ -4,8 +4,10 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/umbralcalc/stochadex/pkg/simulator"
 	"gopkg.in/yaml.v2"
 )
 
@@ -88,6 +90,49 @@ func TestMacroErrors(t *testing.T) {
 		}
 		if _, err := runMacros(&config); err == nil {
 			t.Error("expected an error when macros have no data: block")
+		}
+	})
+}
+
+// TestRunMacrosGuards covers the macro-path validation: main+macros is a mistake,
+// and a cyclic data: sub-simulation is caught before it can hang.
+func TestRunMacrosGuards(t *testing.T) {
+	t.Run("main partitions and macros together is rejected", func(t *testing.T) {
+		config := &ApiRunConfig{
+			Main:   RunConfig{Partitions: []simulator.PartitionConfig{{Name: "p"}}},
+			Macros: []MacroConfig{{Type: "vector_mean", Spec: &vectorMeanSpec{}}},
+		}
+		if _, err := runMacros(config); err == nil {
+			t.Error("expected an error when both main.partitions and macros: are set")
+		}
+	})
+
+	t.Run("a cyclic data: sub-simulation is caught, not hung", func(t *testing.T) {
+		config := &ApiRunConfig{
+			Data: &DataConfig{
+				Steps: 5,
+				Partitions: []simulator.PartitionConfig{
+					{
+						Name:               "a",
+						IterationSpec:      simulator.ComponentSpec{Type: "constant_values"},
+						InitStateValues:    []float64{0.0},
+						StateHistoryDepth:  1,
+						ParamsFromUpstream: map[string]simulator.NamedUpstreamConfig{"in": {Upstream: "b"}},
+					},
+					{
+						Name:               "b",
+						IterationSpec:      simulator.ComponentSpec{Type: "constant_values"},
+						InitStateValues:    []float64{0.0},
+						StateHistoryDepth:  1,
+						ParamsFromUpstream: map[string]simulator.NamedUpstreamConfig{"in": {Upstream: "a"}},
+					},
+				},
+			},
+			Macros: []MacroConfig{{Type: "vector_mean", Spec: &vectorMeanSpec{}}},
+		}
+		_, err := runMacros(config)
+		if err == nil || !strings.Contains(err.Error(), "deadlock") {
+			t.Errorf("expected a deadlock error from the cyclic data: block, got: %v", err)
 		}
 	})
 }

--- a/pkg/api/registry_behaviour_test.go
+++ b/pkg/api/registry_behaviour_test.go
@@ -105,6 +105,18 @@ func TestIterationRegistryBehaviourEquivalence(t *testing.T) {
 			init:   []float64{2.0, -1.0},
 		},
 		{
+			// A nested iteration that needs Configure (a sampler) — guards the
+			// Configure-propagation fix in CumulativeIteration.
+			name: "cumulative wrapping wiener_process",
+			spec: simulator.ComponentSpec{
+				Type:   "cumulative",
+				Fields: map[string]interface{}{"iteration": map[string]interface{}{"type": "wiener_process"}},
+			},
+			goIter: &general.CumulativeIteration{Iteration: &continuous.WienerProcessIteration{}},
+			params: map[string][]float64{"variances": {1.0}},
+			init:   []float64{0.0},
+		},
+		{
 			// A composable one with a nested JumpDistribution.
 			name: "compound_poisson_process with gamma_jump",
 			spec: simulator.ComponentSpec{

--- a/pkg/general/cumulative.go
+++ b/pkg/general/cumulative.go
@@ -17,6 +17,9 @@ func (c *CumulativeIteration) Configure(
 	partitionIndex int,
 	settings *simulator.Settings,
 ) {
+	// Propagate configuration to the wrapped iteration so a sampler-based inner
+	// (Wiener, OU, …) has its RNG and buffers initialised rather than nil.
+	c.Iteration.Configure(partitionIndex, settings)
 }
 
 func (c *CumulativeIteration) Iterate(

--- a/pkg/general/discounted_cumulative.go
+++ b/pkg/general/discounted_cumulative.go
@@ -20,6 +20,9 @@ func (d *DiscountedCumulativeIteration) Configure(
 	partitionIndex int,
 	settings *simulator.Settings,
 ) {
+	// Propagate configuration to the wrapped iteration so a sampler-based inner
+	// (Wiener, OU, …) has its RNG and buffers initialised rather than nil.
+	d.Iteration.Configure(partitionIndex, settings)
 }
 
 func (d *DiscountedCumulativeIteration) Iterate(

--- a/test/binary_configs_test.go
+++ b/test/binary_configs_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestBinaryRunsExampleConfigs exercises the full CLI end-to-end — building the
+// binary and running configs through it — which the in-process pkg/api tests do
+// not do. It covers both paths the binary dispatches to:
+//   - codegen: a config with Go-expression iterations generates a temporary main
+//     and runs it via `go run`;
+//   - in-process: a fully-data config resolves and runs with no toolchain.
+//
+// Configs are run from the repository root (Dir = ".."), because some carry
+// repo-relative output paths (e.g. ./nbs/data/test.log) — the working directory
+// they are meant to be run from. This replaces the old test/configs_test.sh,
+// which was never wired into CI.
+func TestBinaryRunsExampleConfigs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping binary build+run in -short mode")
+	}
+	const repoRoot = ".."
+	binary := filepath.Join(t.TempDir(), "stochadex")
+	build := exec.Command("go", "build", "-o", binary, "./cmd/stochadex")
+	build.Dir = repoRoot
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("building the CLI: %v\n%s", err, out)
+	}
+
+	configs := []struct {
+		path string
+		kind string
+	}{
+		{"cfg/example_config.yaml", "codegen (Go iteration strings)"},
+		{"cfg/example_inference_config.yaml", "codegen (Go strings + embedded)"},
+		{"cfg/example_data_only_config.yaml", "in-process (fully data)"},
+		{"cfg/example_inference_data_config.yaml", "in-process (full inference as data)"},
+	}
+	for _, config := range configs {
+		t.Run(filepath.Base(config.path), func(t *testing.T) {
+			cmd := exec.Command(binary, "--config", config.path)
+			cmd.Dir = repoRoot
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("running %s [%s] through the binary failed: %v\n%s",
+					config.path, config.kind, err, out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow-up to #37 (v0.5.0): close the honest loose ends so the config arc is fully put to bed, and fill the one CI gap the in-process tests left open.

## Fixes
- **`CumulativeIteration` / `DiscountedCumulativeIteration` propagate `Configure`** to the iteration they wrap. A sampler-based inner (Wiener, OU, …) previously had a nil RNG and panicked mid-run — and the data form `{type: cumulative, iteration: {type: wiener_process}}` made that trivial to hit. Now cumulative wraps *any* iteration.

## Guards (silent footguns → clear errors)
- A config setting **both `main.partitions` and `macros:`** is rejected — macros run in their own context and ignore `main`, so this was a silent drop.
- The **`data:` sub-simulation is deadlock-pre-flighted** like any other run, so a cyclic data block fails with a located error instead of hanging.

## Coverage (the real CI gap)
- **`test/binary_configs_test.go`** runs example configs through the *built CLI* end-to-end, covering the **code-generation path** (`go run` of a generated main) that the in-process `pkg/api` tests never exercised. Replaces `test/configs_test.sh`, which was never wired into CI. Writing it exposed a latent fragility — `cfg/example_config.yaml` only runs from the repo root (a repo-relative `json_log` output path) — so the test runs configs from there.
- Behaviour/invariant tests: `cumulative`-wraps-`wiener` equivalence (guards the fix above), `just_variance` posterior wiring, and the two macro-path guards.

## Docs
- `CLAUDE.md` now documents the config-as-data surface (iteration/component registries, `run:`/`data:`/`macros:` tiers, in-process execution) and **restates Invariant A** for it: inference-as-forward-simulation is in scope; the observed dataset is the `data:` resource (downstream's); `mcts_self_play` stays Go (its Environment is the decision layer).

Full suite green except the DB-dependent postgres integration test (needs a live Postgres, same as before). `PLAN.md` intentionally left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)