### PR TITLE
Fix evolution-strategy optimisation (covariance + convergence) [deep dive]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,27 @@ an exact version rather than assume stability across minors.
 
 ## [Unreleased]
 
+### Fixed
+- **Evolution-strategy optimisation now converges on the optimum instead of diverging or
+  stalling.** Three bugs compounded in the rank-based `general.ValuesSortedCollection*`
+  updates behind the `evolution_strategy_optimisation` macro: (1) the covariance was centred
+  on an externally-supplied lagging mean, which folded the per-step mean shift into the
+  estimate as spurious variance and ran it away to 1e6+; it now centres on the elite weighted
+  mean (rank-µ), so the search width contracts as the collection concentrates. (2) At the
+  first step the embedded reward sim has not run, so the sorter ranked the never-sampled
+  initial point by the reward accumulator's init (typically 0), which outranks every real
+  (negative) reward and pinned the mean short of the optimum; the accumulator is now seeded
+  with the sorting sentinel so that placeholder sinks to the bottom. (3) The weighted mean and
+  covariance now skip unfilled (`empty_value`) collection slots during warm-up. A converging
+  example (`cfg/example_evolution_strategy_config.yaml`) and Go + fully-data convergence tests
+  replace the previous plot-exists / runs-without-panic checks.
+
+### Added
+- **`{type: expression}` is registered as an inline iteration.** A partition's bespoke maths
+  can now be written as a data spec (`iteration: {type: expression, fields: [...], outputs:
+  [...]}`) resolving to `general.ExpressionIteration` with no Go toolchain — e.g. an
+  evolution-strategy reward stated as an objective expression directly in YAML.
+
 ## [0.5.1] — 2026-07-19
 
 Closes out the data-drivable config arc (0.5.0): a real fix, two silent-footgun guards, the

--- a/cfg/example_evolution_strategy_config.yaml
+++ b/cfg/example_evolution_strategy_config.yaml
@@ -1,29 +1,44 @@
 # Evolution-strategy optimisation as a LIVE macro (no data: block) — it runs
-# its own optimisation loop as a fresh simulation for 'steps' rounds.
+# its own optimisation loop as a fresh simulation for 'steps' rounds, adapting a
+# sampling mean and covariance to maximise a reward.
+#
+# Here the reward is the negative squared distance from a fixed target, so the
+# known optimum is the target itself: es_mean converges on [3, -2].
+#
+# Tuning notes:
+#   - covariance learning_rate is deliberately slow (0.1): a fast rate collapses
+#     the search width before the mean reaches the optimum and freezes it short.
+#   - the reward is static across the window, so discount_factor: 0.0 keeps the
+#     ranking simplest (a discount would only rescale a constant reward).
 macros:
 - type: evolution_strategy_optimisation
-  steps: 20
+  steps: 1000
   timestep: 1.0
   seed: 12345
-  sampler: {name: test_sampler, default: [0.0, 0.0]}
-  sorting: {name: test_sorting, collection_size: 5, empty_value: -9999.0}
-  mean: {name: test_mean, default: [0.0, 0.0], weights: [0.6, 0.4], learning_rate: 0.5}
-  covariance: {name: test_covariance, default: [1.0, 0.0, 0.0, 1.0], learning_rate: 0.5}
+  sampler: {name: es_sampler, default: [0.0, 0.0]}
+  sorting: {name: es_sorting, collection_size: 10, empty_value: -9999.0}
+  mean: {name: es_mean, default: [0.0, 0.0], weights: [0.5, 0.3, 0.2], learning_rate: 0.5}
+  covariance: {name: es_covariance, default: [4.0, 0.0, 0.0, 4.0], learning_rate: 0.1}
   reward:
-    discount_factor: 0.9
+    discount_factor: 0.0
     partition:
       partition:
         name: reward
-        iteration: {type: constant_values}
-        init_state_values: [1.0]
+        iteration:
+          type: expression
+          fields: [{name: r}]
+          outputs: ["-((sample_values[0]-3)*(sample_values[0]-3) + (sample_values[1]+2)*(sample_values[1]+2))"]
+        params: {sample_values: [0.0, 0.0]}
+        init_state_values: [0.0]
         state_history_depth: 1
         seed: 0
+      outside_upstreams: {sample_values: {upstream: es_sampler}}
   window:
     depth: 5
     partitions:
     - partition:
         name: sim_partition
         iteration: {type: constant_values}
-        init_state_values: [1.0]
+        init_state_values: [0.0]
         state_history_depth: 1
         seed: 0

--- a/pkg/analysis/optimisation.go
+++ b/pkg/analysis/optimisation.go
@@ -149,9 +149,17 @@ func NewEvolutionStrategyOptimisationPartitions(
 			rewardParamsFromUpstream[k] = v
 		}
 	}
-	rewardInitState := make(
-		[]float64, len(rewardPartition.InitStateValues))
-	copy(rewardInitState, rewardPartition.InitStateValues)
+	// Seed the discounted-reward accumulator with the sorting sentinel, not the
+	// user's init. At the first (outer) step the embedded sim has not run, so this
+	// value is what the sorter would rank the never-sampled initial point by; the
+	// user's init reward is typically 0, which for a maximise-me objective outranks
+	// every real (negative) reward and pins the initial point at the top of the
+	// collection, dragging the mean toward it forever. Seeding with empty_value
+	// sinks that placeholder to the bottom (and the mean/covariance updates skip it).
+	rewardInitState := make([]float64, len(rewardPartition.InitStateValues))
+	for i := range rewardInitState {
+		rewardInitState[i] = applied.Sorting.EmptyValue
+	}
 	generator.SetPartition(&simulator.PartitionConfig{
 		Name: "discounted_reward",
 		Iteration: &general.DiscountedCumulativeIteration{
@@ -253,6 +261,7 @@ func NewEvolutionStrategyOptimisationPartitions(
 			"weights":            applied.Mean.Weights,
 			"learning_rate":      {applied.Mean.LearningRate},
 			"values_state_width": {float64(sampleDim)},
+			"empty_value":        {applied.Sorting.EmptyValue},
 		}),
 		ParamsFromUpstream: map[string]simulator.NamedUpstreamConfig{
 			"sorted_collection": {Upstream: applied.Sorting.Name},
@@ -271,6 +280,7 @@ func NewEvolutionStrategyOptimisationPartitions(
 			"weights":            applied.Mean.Weights,
 			"learning_rate":      {applied.Covariance.LearningRate},
 			"values_state_width": {float64(sampleDim)},
+			"empty_value":        {applied.Sorting.EmptyValue},
 		}),
 		ParamsFromUpstream: map[string]simulator.NamedUpstreamConfig{
 			"sorted_collection": {Upstream: applied.Sorting.Name},

--- a/pkg/api/macros_live_test.go
+++ b/pkg/api/macros_live_test.go
@@ -61,27 +61,51 @@ macros:
 }
 
 // TestEvolutionStrategyMacro checks the live evolution-strategy macro runs (with
-// no data: block) and produces a mean-parameter trajectory.
+// no data: block) and, on the fully-data path (an {type: expression} reward), the
+// mean update converges on the reward's known optimum. The objective is the
+// negative squared distance from [3, -2], so the optimum is [3, -2] itself. This
+// exercises the same convergence the Go integration test guards, but end-to-end
+// through YAML: it would fail on the covariance divergence and init-placeholder
+// bugs, or if the covariance contracted before the mean reached the optimum.
 func TestEvolutionStrategyMacro(t *testing.T) {
 	const cfg = `macros:
 - type: evolution_strategy_optimisation
-  steps: 20
+  steps: 1000
   seed: 12345
   sampler: {name: test_sampler, default: [0.0, 0.0]}
-  sorting: {name: test_sorting, collection_size: 5, empty_value: -9999.0}
-  mean: {name: test_mean, default: [0.0, 0.0], weights: [0.6, 0.4], learning_rate: 0.5}
-  covariance: {name: test_covariance, default: [1.0, 0.0, 0.0, 1.0], learning_rate: 0.5}
+  sorting: {name: test_sorting, collection_size: 10, empty_value: -9999.0}
+  mean: {name: test_mean, default: [0.0, 0.0], weights: [0.5, 0.3, 0.2], learning_rate: 0.5}
+  covariance: {name: test_covariance, default: [4.0, 0.0, 0.0, 4.0], learning_rate: 0.1}
   reward:
-    discount_factor: 0.9
+    discount_factor: 0.0
     partition:
-      partition: {name: reward, iteration: {type: constant_values}, init_state_values: [1.0], state_history_depth: 1, seed: 0}
+      partition:
+        name: reward
+        iteration:
+          type: expression
+          fields: [{name: r}]
+          outputs: ["-((sample_values[0]-3)*(sample_values[0]-3) + (sample_values[1]+2)*(sample_values[1]+2))"]
+        params: {sample_values: [0.0, 0.0]}
+        init_state_values: [0.0]
+        state_history_depth: 1
+        seed: 0
+      outside_upstreams: {sample_values: {upstream: test_sampler}}
   window:
     depth: 5
     partitions:
-    - partition: {name: sim_partition, iteration: {type: constant_values}, init_state_values: [1.0], state_history_depth: 1, seed: 0}
+    - partition: {name: sim_partition, iteration: {type: constant_values}, init_state_values: [0.0], state_history_depth: 1, seed: 0}
 `
 	out := runMacroConfig(t, cfg)
-	if len(out["test_mean"]) == 0 {
-		t.Error("evolution strategy produced no test_mean output")
+	means := out["test_mean"]
+	if len(means) == 0 {
+		t.Fatal("evolution strategy produced no test_mean output")
+	}
+	final := means[len(means)-1]
+	target := []float64{3.0, -2.0}
+	for i, want := range target {
+		if math.Abs(final[i]-want) > 1e-2 {
+			t.Errorf("test_mean did not converge: got %v, want %v", final, target)
+			break
+		}
 	}
 }

--- a/pkg/api/registry_behaviour_test.go
+++ b/pkg/api/registry_behaviour_test.go
@@ -117,6 +117,24 @@ func TestIterationRegistryBehaviourEquivalence(t *testing.T) {
 			init:   []float64{0.0},
 		},
 		{
+			// The expressions DSL as an inline iteration (the general fix that lets a
+			// reward/objective be written as maths inside a macro window).
+			name: "expression iteration (inline)",
+			spec: simulator.ComponentSpec{
+				Type: "expression",
+				Fields: map[string]interface{}{
+					"fields":  []interface{}{map[string]interface{}{"name": "x"}},
+					"outputs": []interface{}{"x + rate * dt"},
+				},
+			},
+			goIter: &general.ExpressionIteration{
+				Fields:  []general.ExpressionField{{Name: "x"}},
+				Outputs: []string{"x + rate * dt"},
+			},
+			params: map[string][]float64{"rate": {0.5}},
+			init:   []float64{0.0},
+		},
+		{
 			// A composable one with a nested JumpDistribution.
 			name: "compound_poisson_process with gamma_jump",
 			spec: simulator.ComponentSpec{

--- a/pkg/api/registry_compose.go
+++ b/pkg/api/registry_compose.go
@@ -9,6 +9,7 @@ import (
 	"github.com/umbralcalc/stochadex/pkg/kernels"
 	"github.com/umbralcalc/stochadex/pkg/simulator"
 	"gonum.org/v1/gonum/mat"
+	"gopkg.in/yaml.v2"
 )
 
 // This file is Phase B: composition. A composable iteration has an interface- or
@@ -472,6 +473,25 @@ func registerComposableIterations() {
 			PushAndSort: namedFunc(r, "push_and_sort", pushAndSortFunctions),
 		}
 		return it, r.done()
+	}
+	// expression makes the whole expressions DSL usable as an inline iteration data
+	// spec — anywhere an iteration is expected, including inside a macro's window or
+	// an embedded run, not only via the top-level expressions: block. Its fields
+	// (fields/upstreams/bindings/outputs) are pure data, decoded straight into the
+	// ExpressionIteration. This is what lets a reward/objective be written as maths
+	// (e.g. a negative squared distance) where the block form cannot reach.
+	iterationBuilders["expression"] = func(f map[string]interface{}) (simulator.Iteration, error) {
+		// Re-encode the spec fields and strictly decode them into the typed
+		// ExpressionIteration (fields/upstreams/bindings/outputs), rejecting unknown keys.
+		encoded, err := yaml.Marshal(f)
+		if err != nil {
+			return nil, fmt.Errorf("expression: %w", err)
+		}
+		iteration := &general.ExpressionIteration{}
+		if err := yaml.UnmarshalStrict(encoded, iteration); err != nil {
+			return nil, fmt.Errorf("expression: %w", err)
+		}
+		return iteration, nil
 	}
 }
 

--- a/pkg/api/registry_coverage_test.go
+++ b/pkg/api/registry_coverage_test.go
@@ -16,8 +16,6 @@ import (
 //     positional partition index that is fragile to express as raw data.
 //   - "live-object": holds a live object, channel, RNG source, or bulk [][]float64
 //     data with no data form at all.
-//   - "expression": the ExpressionIteration is reached through the expressions:
-//     tier, not the iteration registry.
 //
 // Drift test 2 asserts every Iterate-implementing type in the candidate packages
 // is either registered (wantIterationType) or listed here. A NEW iteration then
@@ -35,9 +33,6 @@ var excludedIterations = map[string]string{
 	"ValuesWeightedResamplingIteration": "live-object: rand.Source",
 	"DataComparisonGradientIteration":   "live-object: *StateHistory batch + gradient func",
 	"EmbeddedSimulationRunIteration":    "live-object: *Settings/*Implementations",
-
-	// reached through the expressions: tier, not the registry
-	"ExpressionIteration": "expression: reached via the expressions: config tier",
 }
 
 // candidatePackages are the packages whose Iteration implementations are

--- a/pkg/api/registry_test.go
+++ b/pkg/api/registry_test.go
@@ -52,6 +52,7 @@ var wantIterationType = map[string]string{
 	"values_sorting_collection":         "*general.ValuesSortingCollectionIteration",
 	"data_generation":                   "*inference.DataGenerationIteration",
 	"data_comparison":                   "*inference.DataComparisonIteration",
+	"expression":                        "*general.ExpressionIteration",
 	"posterior_mean":                    "*inference.PosteriorMeanIteration",
 	"smc_proposal":                      "*inference.SMCProposalIteration",
 }
@@ -70,6 +71,7 @@ var iterationSpecFixtures = map[string]map[string]interface{}{
 	"values_function":                   {"transform": "params", "reduce": "sum"},
 	"values_collection":                 {"pop_index": "next_non_empty", "push": "param_values"},
 	"values_sorting_collection":         {"push_and_sort": "param_values"},
+	"expression":                        {"fields": []interface{}{map[string]interface{}{"name": "x"}}, "outputs": []interface{}{"x"}},
 	"data_generation":                   {"likelihood": map[string]interface{}{"type": "normal"}},
 	"data_comparison":                   {"likelihood": map[string]interface{}{"type": "normal"}},
 	"posterior_mean":                    {"transform": "mean"},

--- a/pkg/general/values_sorted_collection_covariance.go
+++ b/pkg/general/values_sorted_collection_covariance.go
@@ -47,26 +47,46 @@ func (v *ValuesSortedCollectionCovarianceIteration) Iterate(
 	// elites around their own centroid is the search width that must shrink as the
 	// collection concentrates on the optimum, so the covariance contracts and the
 	// search converges instead of exploding.
+	// Skip unfilled slots (sort-by == empty_value): a sentinel would otherwise
+	// dominate the spread and blow the covariance up before the collection fills.
+	emptyValue, hasEmpty := params.GetOk("empty_value")
+	filled := func(i int) bool {
+		return !hasEmpty || sortedCollection[i*entryWidth] != emptyValue[0]
+	}
 	eliteMean := make([]float64, valuesWidth)
+	totalWeight := 0.0
 	for i := range len(weights) {
+		if !filled(i) {
+			continue
+		}
 		offset := i*entryWidth + 1
 		for j := range valuesWidth {
 			eliteMean[j] += weights[i] * sortedCollection[offset+j]
 		}
+		totalWeight += weights[i]
+	}
+	previousCov := stateHistories[partitionIndex].Values.RawRowView(0)
+	if totalWeight == 0 {
+		return stateHistories[partitionIndex].CopyStateRow(0)
+	}
+	for j := range eliteMean {
+		eliteMean[j] /= totalWeight
 	}
 
 	newCov := mat.NewSymDense(valuesWidth, nil)
 	diff := mat.NewVecDense(valuesWidth, nil)
 
 	for i := range len(weights) {
+		if !filled(i) {
+			continue
+		}
 		offset := i*entryWidth + 1
 		for j := range valuesWidth {
 			diff.SetVec(j, sortedCollection[offset+j]-eliteMean[j])
 		}
-		newCov.SymRankOne(newCov, weights[i], diff)
+		newCov.SymRankOne(newCov, weights[i]/totalWeight, diff)
 	}
 
-	previousCov := stateHistories[partitionIndex].Values.RawRowView(0)
 	covData := newCov.RawSymmetric().Data
 	for j := range covData {
 		covData[j] = (1-learningRate)*previousCov[j] + learningRate*covData[j]

--- a/pkg/general/values_sorted_collection_covariance.go
+++ b/pkg/general/values_sorted_collection_covariance.go
@@ -38,8 +38,22 @@ func (v *ValuesSortedCollectionCovarianceIteration) Iterate(
 	weights := params.Get("weights")
 	learningRate := params.GetIndex("learning_rate", 0)
 	valuesWidth := int(params.GetIndex("values_state_width", 0))
-	mean := params.Get("mean")
 	entryWidth := valuesWidth + 1
+
+	// Centre the covariance on the elite weighted mean (rank-µ), not on an
+	// externally-supplied mean. Centring on a lagging blended mean folds the
+	// per-step mean shift into the covariance as spurious variance, which
+	// compounds and diverges (the estimate runs away to 1e6+). The spread of the
+	// elites around their own centroid is the search width that must shrink as the
+	// collection concentrates on the optimum, so the covariance contracts and the
+	// search converges instead of exploding.
+	eliteMean := make([]float64, valuesWidth)
+	for i := range len(weights) {
+		offset := i*entryWidth + 1
+		for j := range valuesWidth {
+			eliteMean[j] += weights[i] * sortedCollection[offset+j]
+		}
+	}
 
 	newCov := mat.NewSymDense(valuesWidth, nil)
 	diff := mat.NewVecDense(valuesWidth, nil)
@@ -47,7 +61,7 @@ func (v *ValuesSortedCollectionCovarianceIteration) Iterate(
 	for i := range len(weights) {
 		offset := i*entryWidth + 1
 		for j := range valuesWidth {
-			diff.SetVec(j, sortedCollection[offset+j]-mean[j])
+			diff.SetVec(j, sortedCollection[offset+j]-eliteMean[j])
 		}
 		newCov.SymRankOne(newCov, weights[i], diff)
 	}

--- a/pkg/general/values_sorted_collection_mean.go
+++ b/pkg/general/values_sorted_collection_mean.go
@@ -39,10 +39,28 @@ func (v *ValuesSortedCollectionMeanIteration) Iterate(
 	previousMean := stateHistories[partitionIndex].Values.RawRowView(0)
 	newMean := make([]float64, valuesWidth)
 
+	// Skip unfilled collection slots (sort-by == empty_value) so the sentinel
+	// never enters the weighted mean before the collection fills; renormalise the
+	// weights over the filled entries. Absent empty_value this is a no-op (the
+	// weights are used as given). If nothing is filled yet, hold the previous mean.
+	emptyValue, hasEmpty := params.GetOk("empty_value")
+	totalWeight := 0.0
 	for i := range len(weights) {
-		offset := i*entryWidth + 1
+		base := i * entryWidth
+		if hasEmpty && sortedCollection[base] == emptyValue[0] {
+			continue
+		}
 		for j := range valuesWidth {
-			newMean[j] += weights[i] * sortedCollection[offset+j]
+			newMean[j] += weights[i] * sortedCollection[base+1+j]
+		}
+		totalWeight += weights[i]
+	}
+	if hasEmpty {
+		if totalWeight == 0 {
+			return stateHistories[partitionIndex].CopyStateRow(0)
+		}
+		for j := range newMean {
+			newMean[j] /= totalWeight
 		}
 	}
 

--- a/test/evolution_strategy_optimisation_test.go
+++ b/test/evolution_strategy_optimisation_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/umbralcalc/stochadex/pkg/analysis"
 	"github.com/umbralcalc/stochadex/pkg/general"
 	"github.com/umbralcalc/stochadex/pkg/simulator"
+	"gonum.org/v1/gonum/floats"
 )
 
 // NegativeSquaredDistanceIteration computes a scalar reward equal to the
@@ -62,9 +63,12 @@ func TestEvolutionStrategyOptimisation(t *testing.T) {
 						LearningRate: 0.5,
 					},
 					Covariance: analysis.EvolutionStrategyCovariance{
-						Name:         "es_covariance",
-						Default:      []float64{4.0, 0.0, 0.0, 4.0},
-						LearningRate: 0.3,
+						Name:    "es_covariance",
+						Default: []float64{4.0, 0.0, 0.0, 4.0},
+						// A slow covariance learning rate lets the mean reach the
+						// optimum before the search width contracts; a fast rate
+						// collapses the covariance and freezes the mean short of it.
+						LearningRate: 0.1,
 					},
 					Reward: analysis.EvolutionStrategyReward{
 						Partition: analysis.WindowedPartition{
@@ -83,7 +87,10 @@ func TestEvolutionStrategyOptimisation(t *testing.T) {
 								"sample_values": {Upstream: "es_sampler"},
 							},
 						},
-						DiscountFactor: 0.9,
+						// The objective is static (the sample is fixed across the
+						// window), so any discount only rescales a constant reward and
+						// leaves the ranking unchanged — zero keeps it simplest.
+						DiscountFactor: 0.0,
 					},
 					Window: analysis.WindowedPartitions{
 						Partitions: []analysis.WindowedPartition{{
@@ -108,35 +115,24 @@ func TestEvolutionStrategyOptimisation(t *testing.T) {
 			storage := analysis.NewStateTimeStorageFromPartitions(
 				partitions,
 				&simulator.NumberOfStepsTerminationCondition{
-					MaxNumberOfSteps: 100,
+					MaxNumberOfSteps: 1000,
 				},
 				&simulator.ConstantTimestepFunction{Stepsize: 1.0},
 				0.0,
 			)
 
-			// Reference the plotting data for the x-axis
-			xRef := analysis.DataRef{
-				Plotting: &analysis.DataPlotting{IsTime: true},
-			}
-
-			// Reference the sampler plotting data for the y-axis
-			yRefs := []analysis.DataRef{
-				{PartitionName: "es_sampler"},
-			}
-
-			// Create a scatter plot from partitions in a simulator.StateTimeStorage
-			if plot := analysis.NewScatterPlotFromPartition(storage, xRef, yRefs); plot == nil {
-				t.Error("expected a scatter plot")
-			}
-
-			// Reference the mean update plotting data for the y-axis
-			yRefs = []analysis.DataRef{
-				{PartitionName: "es_mean"},
-			}
-
-			// Create a line plot from partitions in a simulator.StateTimeStorage
-			if plot := analysis.NewLinePlotFromPartition(storage, xRef, yRefs, nil); plot == nil {
-				t.Error("expected a line plot")
+			// The mean update should converge on the reward's target: with
+			// the divergence and init-placeholder bugs fixed and the covariance
+			// learning rate slow enough to avoid premature contraction, the
+			// search settles on the optimum rather than stalling short of it.
+			meanHistory := storage.GetValues("es_mean")
+			finalMean := meanHistory[len(meanHistory)-1]
+			target := []float64{3.0, -2.0}
+			if !floats.EqualApprox(finalMean, target, 1e-2) {
+				t.Errorf(
+					"es_mean did not converge on the optimum: got %v, want %v",
+					finalMean, target,
+				)
 			}
 		},
 	)


### PR DESCRIPTION
A focused deep-dive to make `evolution_strategy_optimisation` actually optimise, split out of the skill/recipes work (paused) so the algorithm fix gets dedicated scrutiny.

## What was broken
The rank-based `general.ValuesSortedCollection*` updates behind the macro neither converged nor stayed bounded. Three compounding bugs:

1. **Covariance divergence.** `ValuesSortedCollectionCovarianceIteration` centred the elite covariance on an externally-supplied *lagging* blended mean, folding the per-step mean shift into the estimate as spurious variance → runaway to 1e6+.
2. **Init placeholder pinning the mean.** At the first step the embedded reward sim has not run, so the sorter ranked the never-sampled initial point by the reward accumulator's init (typically `0`). For a maximise-me objective `0` outranks every real (negative) reward, pinning the initial point at the top of the collection and dragging the mean toward it forever — the mean stalled ~halfway to the optimum.
3. **Sentinel pollution during warm-up.** Before the collection fills, its lower slots still hold the `empty_value` sentinel, which leaked into the weighted mean/covariance.

## The fix
1. **Centre the covariance on the elite weighted mean (rank-µ).** The spread of the elites around their own centroid is the search width that must shrink as the collection concentrates → the covariance *contracts* instead of exploding.
2. **Seed the discounted-reward accumulator with the sorting sentinel**, not the user's init, so the first-step placeholder sinks to the bottom of the collection.
3. **Skip `sort-by == empty_value` slots** in the mean and covariance updates (renormalising the weights); both are no-ops when `empty_value` is absent.

With these plus a covariance learning rate slow enough to avoid premature contraction, the mean converges **exactly** on the optimum.

## Also here
- **`{type: expression}` registered as an inline iteration** — a partition's bespoke maths (e.g. an ES reward stated as an objective expression) is now writable as a data spec resolving to `general.ExpressionIteration`, no Go toolchain. Drift tests updated; behaviour-equivalence to the Go type verified.

## Tests
The old checks only asserted "a plot can be built" / "runs without panic". Replaced with **convergence** assertions on the known optimum `[3, -2]` (negative squared distance):
- `test/evolution_strategy_optimisation_test.go` — Go integration path.
- `pkg/api` `TestEvolutionStrategyMacro` — fully-data path end-to-end through YAML (`{type: expression}` reward).
- `cfg/example_evolution_strategy_config.yaml` — rewritten to the converging form.

Full suite green (only the DB-dependent Postgres integration test fails locally, as expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)