### PR TITLE
Release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ an exact version rather than assume stability across minors.
 
 ## [Unreleased]
 
+## [0.5.2] — 2026-07-20
+
+Two convergence fixes to the shipped live-macro examples (evolution-strategy optimisation
+and posterior-estimation inference), each now guarded by a convergence test rather than a
+runs-without-error check, plus the `{type: expression}` inline-iteration registration that
+lets a reward/objective be stated as config maths. No breaking changes.
+
 ### Fixed
 - **Evolution-strategy optimisation now converges on the optimum instead of diverging or
   stalling.** Three bugs compounded in the rank-based `general.ValuesSortedCollection*`


### PR DESCRIPTION
Stamps the `[Unreleased]` CHANGELOG entries into **`[0.5.2]`** (2026-07-20) ahead of tagging.

Contents (both already merged to `main`):
- **Evolution-strategy optimisation converges** (#41) — three compounding rank-update bugs fixed (covariance divergence → elite rank-µ centering; init-placeholder pinning → sentinel-seeded reward accumulator; warm-up sentinel pollution → skip unfilled slots), now guarded by Go + fully-data convergence tests.
- **Posterior-estimation example converges** (#40) — retuned `past_discounting_factor`/proposal covariance so the shipped inference example recovers the data mean; `TestFullInferenceConfigAsData` asserts it.
- **`{type: expression}` registered as an inline iteration** — reward/objective maths writable as a data spec.

No breaking changes. Changelog-only commit; tag `v0.5.2` will point at the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)