### PR TITLE
Fix stale CHANGELOG footer compare-links (0.5.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -532,7 +532,10 @@ treat the intermediates as internal, never shipped API.
   stochastic-process formalism (diffusions, Poisson noise, windowed history for noise
   dependencies) before any Go engine existed. The pivot to Go begins Feb 2023.
 
-[Unreleased]: https://github.com/umbralcalc/stochadex/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/umbralcalc/stochadex/compare/v0.5.2...HEAD
+[0.5.2]: https://github.com/umbralcalc/stochadex/compare/v0.5.1...v0.5.2
+[0.5.1]: https://github.com/umbralcalc/stochadex/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/umbralcalc/stochadex/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/umbralcalc/stochadex/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/umbralcalc/stochadex/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/umbralcalc/stochadex/compare/v0.1.0...v0.2.0


### PR DESCRIPTION
Housekeeping follow-up to the `v0.5.2` tag. The CHANGELOG's footer compare-links had drifted for the whole 0.5.x series: `[Unreleased]` still compared from `v0.4.0`, and there were no link entries for `[0.5.0]`, `[0.5.1]`, or `[0.5.2]`. Points `[Unreleased]` at `v0.5.2` and adds the missing per-version links so every release header resolves.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)