### PR TITLE
Make the posterior_estimation macro converge from a prior [deep dive]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,23 @@ an exact version rather than assume stability across minors.
 
 ## [Unreleased]
 
+### Fixed
+- **The `posterior_estimation` macro can now converge from a prior instead of drifting.**
+  The posterior mean/covariance are loglike-weighted averages of the *sampled* parameters, so
+  the comparison's loglike has to depend on the sample — but the macro's comparison model was
+  wired with fixed parameters and no path to the sampler, so every sample scored identically,
+  the weights were uniform, and the mean random-walked away from the truth (the shipped example
+  drifted *off* the data mean even when started on it). Two changes fix it: (1)
+  `NewLikelihoodComparisonPartition` now routes a comparison-model `params_from_upstream` entry
+  whose upstream is not an inner window partition (i.e. the sampler, which lives in the outer
+  simulation) to an embedded *outside upstream*, so the sampled parameters drive the comparison
+  likelihood each step; (2) `NewPosteriorEstimationPartitions` now requires the comparison to
+  read the sampler — directly via the model's `params_from_upstream` or indirectly via a window
+  partition's `OutsideUpstreams` — and panics with an actionable message otherwise, turning the
+  silent-non-convergence footgun into a loud, located error. The shipped
+  `cfg/example_posterior_macro_config.yaml` is retuned to recover the data mean `[1.8, 5.0]`
+  from an off-truth prior `[0, 0]`, and `TestPosteriorEstimationMacroConverges` asserts it.
+
 ## [0.5.2] — 2026-07-20
 
 Two convergence fixes to the shipped live-macro examples (evolution-strategy optimisation

--- a/cfg/example_posterior_macro_config.yaml
+++ b/cfg/example_posterior_macro_config.yaml
@@ -1,29 +1,43 @@
-# A full online Bayesian posterior estimation as a SINGLE macro — the payoff of
-# the macro tier. `posterior_estimation` expands to the ~6 partitions the
-# hand-wired cfg/example_inference_config.yaml wires by hand (log-norm, mean, cov,
-# sampler, and the windowed likelihood comparison), all from nested data specs.
-# Runs in-process against the data: stream, no Go toolchain.
+# Online Bayesian posterior estimation as a SINGLE macro — the payoff of the
+# macro tier. `posterior_estimation` expands to the ~5 partitions the hand-wired
+# cfg/example_inference_config.yaml wires by hand (log-norm, mean, cov, sampler,
+# and the windowed likelihood comparison), all from nested data specs, and runs
+# in-process against the data: stream with no Go toolchain.
+#
+# It recovers the data-generating mean [1.8, 5.0] from an OFF-TRUTH prior [0, 0]:
+# the posterior mean/covariance are loglike-weighted averages of the sampled
+# parameters, so the comparison model MUST read the sampler (see the
+# params_from_upstream in comparison.model below) — that coupling is what makes
+# the loglike depend on the proposal and the posterior converge rather than drift.
+#
+# Tuning levers (the ones that decide whether it converges):
+#   - sampler proposal width (`default_covariance` / the covariance default): wide
+#     enough (diag 9) for the sampler to explore from the prior to the truth.
+#   - `past_discount`: near 1 (0.999) so evidence accumulates instead of being
+#     forgotten each step (0.5 forgets too fast to ever converge).
+#   - enough `steps` for the weighted mean to concentrate (the high-variance 2nd
+#     coordinate — data covariance 9 — leaves a little honest sampling residual).
 data:
-  steps: 500
+  steps: 2000
   timestep: 1.0
   partitions:
   - name: test_data
     iteration: {type: data_generation, likelihood: {type: normal}}
     params: {mean: [1.8, 5.0], covariance_matrix: [2.5, 0.0, 0.0, 9.0]}
     init_state_values: [1.3, 8.3]
-    state_history_depth: 500
+    state_history_depth: 2000
     seed: 123
 macros:
 - type: posterior_estimation
   log_norm: {name: test_post_log_norm, default: 0.0}
-  mean: {name: test_post_mean, default: [1.8, 5.0]}
-  covariance: {name: test_post_cov, default: [2.5, 0.0, 0.0, 9.0]}
+  mean: {name: test_post_mean, default: [0.0, 0.0]}            # off-truth prior
+  covariance: {name: test_post_cov, default: [9.0, 0.0, 0.0, 9.0]}
   sampler:
     name: test_post_sampler
-    default: [1.8, 5.0]
+    default: [0.0, 0.0]
     distribution:
       likelihood: {type: normal, allow_default_covariance_fallback: true}
-      params: {default_covariance: [2.5, 0.0, 0.0, 9.0], cov_burn_in_steps: [200]}
+      params: {default_covariance: [9.0, 0.0, 0.0, 9.0], cov_burn_in_steps: [200]}
       params_from_upstream:
         mean: {upstream: test_post_mean}
         covariance_matrix: {upstream: test_post_cov}
@@ -31,12 +45,14 @@ macros:
     name: test_likelihood
     model:
       likelihood: {type: normal}
-      params: {mean: [1.8, 5.0], covariance_matrix: [2.5, 0.0, 0.0, 9.0]}
+      params: {covariance_matrix: [2.5, 0.0, 0.0, 9.0]}
+      params_from_upstream:
+        mean: {upstream: test_post_sampler}   # score each SAMPLED mean against the data
     data: {partition_name: test_data}
     window:
       data: [{partition_name: test_data}]
       depth: 200
     window_data_history_depth: {test_data: 200}
-  past_discount: 1.0
+  past_discount: 0.999
   memory_depth: 200
   seed: 1234

--- a/pkg/analysis/inference.go
+++ b/pkg/analysis/inference.go
@@ -77,6 +77,40 @@ func NewPosteriorEstimationPartitions(
 	if applied.MemoryDepth < 1 {
 		panic(fmt.Sprintf("analysis: MemoryDepth must be >= 1, got %d", applied.MemoryDepth))
 	}
+	// The posterior mean/covariance are loglike-weighted averages of the sampled
+	// parameters, so the comparison's loglike MUST depend on the sample. If it does
+	// not, every sample scores identically, the weights are uniform, and the
+	// posterior mean just random-walks away from the truth instead of converging
+	// (the classic silently-degenerate posterior_estimation config). The sample can
+	// reach the loglike two ways, both accepted here: directly, the comparison model
+	// reads the sampler via params_from_upstream (simple case — a normal model feeds
+	// the sample into `mean`); or indirectly, a window partition consumes it as an
+	// OutsideUpstream and the comparison scores that partition's output (the embedded
+	// forward-simulation case — e.g. the sample drives an OU `mus`). The coupling is
+	// model-specific so it cannot be auto-wired; require one of the two and fail loud.
+	samplerRead := false
+	for _, upstream := range applied.Comparison.Model.ParamsFromUpstream {
+		if upstream.Upstream == applied.Sampler.Name {
+			samplerRead = true
+		}
+	}
+	for _, partition := range applied.Comparison.Window.Partitions {
+		for _, upstream := range partition.OutsideUpstreams {
+			if upstream.Upstream == applied.Sampler.Name {
+				samplerRead = true
+			}
+		}
+	}
+	if !samplerRead {
+		panic(fmt.Sprintf(
+			"analysis: posterior comparison must read the sampler %q so the loglike "+
+				"depends on the proposal, else the posterior cannot converge — either "+
+				"the comparison model reads it via params_from_upstream (e.g. {mean: "+
+				"{upstream: %q}}), or a window partition consumes it as an "+
+				"OutsideUpstream",
+			applied.Sampler.Name, applied.Sampler.Name,
+		))
+	}
 	compPartition := NewLikelihoodComparisonPartition(
 		applied.Comparison,
 		storage,

--- a/pkg/analysis/inference_test.go
+++ b/pkg/analysis/inference_test.go
@@ -73,6 +73,9 @@ func TestInference(t *testing.T) {
 						Model: ParameterisedModel{
 							Likelihood: &inference.NormalLikelihoodDistribution{},
 							Params:     params,
+							ParamsFromUpstream: map[string]simulator.NamedUpstreamConfig{
+								"mean": {Upstream: "test_post_sampler"},
+							},
 						},
 						Data: DataRef{PartitionName: "test_data"},
 						Window: WindowedPartitions{
@@ -168,6 +171,9 @@ func TestInference(t *testing.T) {
 						Model: ParameterisedModel{
 							Likelihood: &inference.NormalLikelihoodDistribution{},
 							Params:     params,
+							ParamsFromUpstream: map[string]simulator.NamedUpstreamConfig{
+								"mean": {Upstream: "jv_post_sampler"},
+							},
 						},
 						Data: DataRef{PartitionName: "test_data"},
 						Window: WindowedPartitions{

--- a/pkg/analysis/likelihood.go
+++ b/pkg/analysis/likelihood.go
@@ -152,6 +152,30 @@ func NewLikelihoodComparisonPartition(
 			Upstream: applied.Data.PartitionName,
 			Indices:  applied.Data.ValueIndices,
 		}
+	// Partition the model's upstream wiring into inner and outer. Names that
+	// resolve to a partition inside this embedded window (the replayed data
+	// sources, other window partitions) stay on the inner "comparison"
+	// partition. Names that don't — e.g. a posterior sampler living in the outer
+	// simulation — cannot be resolved by the inner generator, so route them as
+	// outside upstreams (comparison/<param> <- outer partition); the embedded-run
+	// machinery injects the outer value into the inner param each step. This is
+	// what lets posterior_estimation drive the comparison likelihood with the
+	// sampled parameters, so the loglike actually depends on the proposal.
+	innerNames := make(map[string]bool)
+	for _, partition := range applied.Window.Partitions {
+		innerNames[partition.Partition.Name] = true
+	}
+	for _, ref := range applied.Window.Data {
+		innerNames[ref.PartitionName] = true
+	}
+	innerModelUpstreams := make(map[string]simulator.NamedUpstreamConfig)
+	for key, upstream := range applied.Model.ParamsFromUpstream {
+		if innerNames[upstream.Upstream] {
+			innerModelUpstreams[key] = upstream
+		} else {
+			simParamsFromUpstream["comparison/"+key] = upstream
+		}
+	}
 	generator.SetPartition(&simulator.PartitionConfig{
 		Name: "comparison",
 		Iteration: &inference.DataComparisonIteration{
@@ -159,7 +183,7 @@ func NewLikelihoodComparisonPartition(
 		},
 		Params:             applied.Model.Params,
 		ParamsAsPartitions: applied.Model.ParamsAsPartitions,
-		ParamsFromUpstream: applied.Model.ParamsFromUpstream,
+		ParamsFromUpstream: innerModelUpstreams,
 		InitStateValues:    []float64{0.0},
 		StateHistoryDepth:  1,
 		Seed:               0,

--- a/pkg/api/macros_inference_test.go
+++ b/pkg/api/macros_inference_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -38,7 +39,9 @@ macros:
     name: test_likelihood
     model:
       likelihood: {type: normal}
-      params: {mean: [1.8, 5.0], covariance_matrix: [2.5, 0.0, 0.0, 9.0]}
+      params: {covariance_matrix: [2.5, 0.0, 0.0, 9.0]}
+      params_from_upstream:
+        mean: {upstream: test_post_sampler}
     data: {partition_name: test_data}
     window:
       data: [{partition_name: test_data}]
@@ -87,8 +90,11 @@ func directPosteriorStorage() *simulator.StateTimeStorage {
 				Model: analysis.ParameterisedModel{
 					Likelihood: &inference.NormalLikelihoodDistribution{},
 					Params: simulator.NewParams(map[string][]float64{
-						"mean": {1.8, 5.0}, "covariance_matrix": {2.5, 0, 0, 9.0},
+						"covariance_matrix": {2.5, 0, 0, 9.0},
 					}),
+					ParamsFromUpstream: map[string]simulator.NamedUpstreamConfig{
+						"mean": {Upstream: "test_post_sampler"},
+					},
 				},
 				Data:                   analysis.DataRef{PartitionName: "test_data"},
 				Window:                 analysis.WindowedPartitions{Data: []analysis.DataRef{{PartitionName: "test_data"}}, Depth: 200},
@@ -129,6 +135,37 @@ func TestPosteriorEstimationMacroEquivalence(t *testing.T) {
 					name, i, gotFinal[i], wantFinal[i])
 			}
 		}
+	}
+}
+
+// TestPosteriorEstimationMacroConverges guards the shipped example end-to-end:
+// the posterior_estimation macro recovers the data-generating mean [1.8, 5.0]
+// from an off-truth prior [0, 0]. This is the behaviour the sampler->comparison
+// coupling exists to enable — without it the comparison loglike is independent of
+// the proposal, the weights are uniform, and the mean drifts instead of
+// converging (the previously-shipped degenerate config). The tolerance leaves
+// room for honest sampling residual on the high-variance (covariance 9) second
+// coordinate.
+func TestPosteriorEstimationMacroConverges(t *testing.T) {
+	storage, err := runMacros(LoadApiRunConfigFromYaml(
+		"../../cfg/example_posterior_macro_config.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	means := storage.GetValues("test_post_mean")
+	if len(means) == 0 {
+		t.Fatal("no test_post_mean output recorded")
+	}
+	final := means[len(means)-1]
+	target := []float64{1.8, 5.0}
+	var sumSq float64
+	for i := range target {
+		d := final[i] - target[i]
+		sumSq += d * d
+	}
+	if l2 := math.Sqrt(sumSq); l2 > 0.5 {
+		t.Errorf("posterior mean did not converge: got %v, want ~%v (L2 %.3f > 0.5)",
+			final, target, l2)
 	}
 }
 


### PR DESCRIPTION
A deep-dive to make the `posterior_estimation` macro actually perform inference, split out of the skill/recipes work (paused) so the fix gets dedicated scrutiny — the sibling of the evolution-strategy convergence fix (#41).

## What was broken
The `posterior_estimation` macro **could not converge from a prior** — a silently-degenerate config. The posterior mean/covariance are loglike-weighted averages of the *sampled* parameters (`PosteriorMeanIteration`: `mean += Σ wᵢ·paramᵢ`, `wᵢ ∝ exp(loglikeᵢ)`), so the comparison's loglike must depend on the sample. But the macro's comparison model was wired with **fixed** parameters and no path to the sampler, so every sample scored identically, the weights were uniform, and the mean random-walked. The shipped `cfg/example_posterior_macro_config.yaml` drifted *off* the data mean `[1.8, 5.0]` (to `~[0.5, 3.4]`) even when started **on** it.

## The fix
1. **Route the sampler into the comparison** (`NewLikelihoodComparisonPartition`). The comparison is an embedded windowed sim; a model `params_from_upstream` entry whose upstream is not an inner window partition — i.e. the sampler, which lives in the *outer* simulation — is now routed as an embedded **outside upstream** (`comparison/<param> ← sampler`), injected into the inner comparison each step. This is the same mechanism window-data already uses for `latest_data_values`.
2. **Require the coupling** (`NewPosteriorEstimationPartitions`). The comparison must read the sampler — directly via the model's `params_from_upstream`, or indirectly via a window partition's `OutsideUpstreams` (the embedded forward-simulation topology, e.g. sample → OU `mus`). If neither, it panics with an actionable, located message instead of silently not converging. The coupling is model-specific, so it can't be auto-wired.

## Result
`cfg/example_posterior_macro_config.yaml` retuned to recover `[1.8, 5.0]` from an off-truth prior `[0, 0]` (final `~[1.85, 4.74]`; the residual is honest sampling noise on the high-variance 2nd coordinate). `TestPosteriorEstimationMacroConverges` asserts convergence (L2 < 0.5); `TestPosteriorEstimationMacroEquivalence` still holds (translation faithful); existing posterior tests updated to wire the sampler.

Full suite green (Postgres integration test excluded — needs a live DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)