### PR TITLE
Validate scalar_regression_stats (noisy recovery + skill recipe)

### DIFF
--- a/.claude/skills/stochadex-model/SKILL.md
+++ b/.claude/skills/stochadex-model/SKILL.md
@@ -207,6 +207,12 @@ macro *names* only, so change the numbers and the objective/model, but keep the 
 - **`recipes/smc_inference.yaml`** — particle-filter inference; the inner per-particle model is a
   template (`{particle}` is instantiated per particle) and it recovers the observed stream's mean.
   **Levers:** `num_particles` (more = tighter posterior), `num_rounds`, and the `priors` ranges.
+- **`recipes/scalar_regression_stats.yaml`** — closed-form OLS of scalar `y` on scalar `x`;
+  recovers slope 2.5 and intercept 1.0 of a noisy line. No convergence levers (it's closed-form —
+  more `steps` just tighten the estimate). **The gotcha is the output layout:** with `intercept:
+  true`, `mode: cumulative` the state is width 9 `[n, Sx, Sy, Sxx, Sxy, Syy, alpha, beta, sigma2]`,
+  so index 6 is the intercept, 7 the slope, 8 the residual variance — read the slot, don't hunt
+  for the number.
 
 ## Running and debugging
 

--- a/.claude/skills/stochadex-model/recipes/scalar_regression_stats.yaml
+++ b/.claude/skills/stochadex-model/recipes/scalar_regression_stats.yaml
@@ -1,0 +1,27 @@
+# Ordinary least squares as a macro: recover the slope and intercept of a noisy
+# linear relation. x ramps deterministically; y = 2.5 x + 1 + N(0, 1.5). The
+# closed-form OLS recovers slope ~2.5 and intercept ~1.0 from the noise.
+#
+# Output layout — the one non-obvious thing. With intercept, cumulative mode, the
+# `ols` state is width 9: [n, Sx, Sy, Sxx, Sxy, Syy, alpha, beta, sigma2]. So
+# index 6 is the intercept (alpha), index 7 the slope (beta), index 8 the residual
+# variance (sigma2 ~ 1.5^2). (No intercept drops alpha; `window` mode keeps a
+# rolling buffer ahead of the same tail — see analysis/regression.go for the exact
+# layouts.) There are no convergence levers here: OLS is closed-form, so more
+# `steps` just tightens the estimate against the noise.
+data:
+  steps: 400
+  timestep: 1.0
+  partitions:
+  - {name: x, init_state_values: [0.0], state_history_depth: 1, seed: 0}
+  - {name: y, init_state_values: [0.0], state_history_depth: 1, seed: 71}
+  expressions:
+  - {partition: x, fields: [{name: v}], outputs: ["0.05 * t"]}
+  - {partition: y, fields: [{name: v}], outputs: ["2.5 * (0.05 * t) + 1.0 + shared(normal(0, 1.5))"]}
+macros:
+- type: scalar_regression_stats
+  name: ols
+  y: {partition_name: y}
+  x: {partition_name: x}
+  intercept: true
+  mode: cumulative

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,15 @@ an exact version rather than assume stability across minors.
   transitively validate the shipped recipes. Verified end-to-end by a fresh-agent falsifier
   (an agent given only the skill authored unseen custom, optimisation, and inference configs
   that all ran and converged).
+- **A validated `scalar_regression_stats` recipe + noisy-recovery test.** The regression macro
+  now ships a worked example (`cfg/example_regression_config.yaml`, mirrored as a fourth skill
+  recipe) that recovers the slope (2.5) and intercept (1.0) of a line observed through `N(0, 1.5)`
+  noise, guarded by `TestScalarRegressionMacroRecoversNoisy` — the "recovers from noise" bar the
+  other macros are held to. The pre-existing macro test was tightened from "2.5 appears somewhere
+  in the state" to asserting the specific slope/intercept/residual-variance slots of the width-9
+  `[n, Sx, Sy, Sxx, Sxy, Syy, alpha, beta, sigma2]` layout, which the skill now documents. No
+  engine change — the closed-form OLS was already batch-validated in `pkg/analysis`; this closes
+  the macro-path and skill-recipe coverage gap.
 
 ### Fixed
 - **The `posterior_estimation` macro can now converge from a prior instead of drifting.**

--- a/cfg/example_regression_config.yaml
+++ b/cfg/example_regression_config.yaml
@@ -1,0 +1,27 @@
+# Ordinary least squares as a macro: recover the slope and intercept of a noisy
+# linear relation. x ramps deterministically; y = 2.5 x + 1 + N(0, 1.5). The
+# closed-form OLS recovers slope ~2.5 and intercept ~1.0 from the noise.
+#
+# Output layout — the one non-obvious thing. With intercept, cumulative mode, the
+# `ols` state is width 9: [n, Sx, Sy, Sxx, Sxy, Syy, alpha, beta, sigma2]. So
+# index 6 is the intercept (alpha), index 7 the slope (beta), index 8 the residual
+# variance (sigma2 ~ 1.5^2). (No intercept drops alpha; `window` mode keeps a
+# rolling buffer ahead of the same tail — see analysis/regression.go for the exact
+# layouts.) There are no convergence levers here: OLS is closed-form, so more
+# `steps` just tightens the estimate against the noise.
+data:
+  steps: 400
+  timestep: 1.0
+  partitions:
+  - {name: x, init_state_values: [0.0], state_history_depth: 1, seed: 0}
+  - {name: y, init_state_values: [0.0], state_history_depth: 1, seed: 71}
+  expressions:
+  - {partition: x, fields: [{name: v}], outputs: ["0.05 * t"]}
+  - {partition: y, fields: [{name: v}], outputs: ["2.5 * (0.05 * t) + 1.0 + shared(normal(0, 1.5))"]}
+macros:
+- type: scalar_regression_stats
+  name: ols
+  y: {partition_name: y}
+  x: {partition_name: x}
+  intercept: true
+  mode: cumulative

--- a/pkg/api/cfg_examples_test.go
+++ b/pkg/api/cfg_examples_test.go
@@ -36,6 +36,7 @@ func TestExampleConfigsRun(t *testing.T) {
 		"cfg/example_posterior_macro_config.yaml",
 		"cfg/example_smc_config.yaml",
 		"cfg/example_evolution_strategy_config.yaml",
+		"cfg/example_regression_config.yaml",
 		"cfg/example_data_source_config.yaml",
 	}
 	for _, path := range examples {

--- a/pkg/api/macros_stats_test.go
+++ b/pkg/api/macros_stats_test.go
@@ -51,16 +51,52 @@ macros:
 		t.Fatal("no ols output")
 	}
 	final := rows[len(rows)-1]
-	// With-intercept cumulative state ends [..., beta, alpha? ]: the slope estimate
-	// is one of the closed-form outputs; assert some element recovers 2.5.
-	foundSlope := false
-	for _, v := range final {
-		if math.Abs(v-2.5) < 1e-6 {
-			foundSlope = true
-		}
+	// With-intercept cumulative layout is width 9:
+	// [n, Sx, Sy, Sxx, Sxy, Syy, alpha, beta, sigma2] — so index 6 is the intercept
+	// (alpha) and index 7 the slope (beta). Assert the SPECIFIC slots recover the
+	// exact relation (not merely that 2.5 appears somewhere in the state), and that
+	// the residual variance is ~0 for a noise-free line.
+	if len(final) != 9 {
+		t.Fatalf("expected width-9 with-intercept state, got %d: %v", len(final), final)
 	}
-	if !foundSlope {
-		t.Errorf("regression did not recover slope 2.5; final state = %v", final)
+	if got := final[7]; math.Abs(got-2.5) > 1e-6 {
+		t.Errorf("slope (beta, index 7) = %v, want 2.5", got)
+	}
+	if got := final[6]; math.Abs(got-1.0) > 1e-6 {
+		t.Errorf("intercept (alpha, index 6) = %v, want 1.0", got)
+	}
+	if got := final[8]; math.Abs(got) > 1e-6 {
+		t.Errorf("residual variance (sigma2, index 8) = %v, want ~0 for a noise-free line", got)
+	}
+}
+
+// TestScalarRegressionMacroRecoversNoisy guards the shipped example end-to-end:
+// the regression macro recovers the slope (2.5) and intercept (1.0) of a linear
+// relation observed through N(0, 1.5) noise, and estimates the residual variance
+// (~1.5^2). This is the "does its job" bar — recovery from noise, not exact
+// algebra on a clean line — matching the convergence tests for the other macros.
+func TestScalarRegressionMacroRecoversNoisy(t *testing.T) {
+	storage, err := runMacros(LoadApiRunConfigFromYaml(
+		"../../cfg/example_regression_config.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows := storage.GetValues("ols")
+	if len(rows) == 0 {
+		t.Fatal("no ols output recorded")
+	}
+	final := rows[len(rows)-1]
+	if len(final) != 9 {
+		t.Fatalf("expected width-9 with-intercept state, got %d: %v", len(final), final)
+	}
+	if got := final[7]; math.Abs(got-2.5) > 0.1 {
+		t.Errorf("slope (beta) = %v, want ~2.5", got)
+	}
+	if got := final[6]; math.Abs(got-1.0) > 0.2 {
+		t.Errorf("intercept (alpha) = %v, want ~1.0", got)
+	}
+	if got := final[8]; math.Abs(got-2.25) > 0.75 {
+		t.Errorf("residual variance (sigma2) = %v, want ~2.25 (1.5^2)", got)
 	}
 }
 

--- a/pkg/api/skill_recipes_test.go
+++ b/pkg/api/skill_recipes_test.go
@@ -18,6 +18,7 @@ func TestSkillRecipesMatchExamples(t *testing.T) {
 		"../../.claude/skills/stochadex-model/recipes/evolution_strategy_optimisation.yaml": "../../cfg/example_evolution_strategy_config.yaml",
 		"../../.claude/skills/stochadex-model/recipes/smc_inference.yaml":                    "../../cfg/example_smc_config.yaml",
 		"../../.claude/skills/stochadex-model/recipes/posterior_estimation.yaml":             "../../cfg/example_posterior_macro_config.yaml",
+		"../../.claude/skills/stochadex-model/recipes/scalar_regression_stats.yaml":          "../../cfg/example_regression_config.yaml",
 	}
 	for recipe, twin := range pairs {
 		t.Run(recipe, func(t *testing.T) {


### PR DESCRIPTION
The follow-up to close the last loose thread: bring `scalar_regression_stats` to the same "does its job" bar as the other macros — recovery from noise, guarded by a test, with a shipped recipe.

## Context
The engine's closed-form OLS was already **batch-validated** in `pkg/analysis/regression_test.go` (cumulative and sliding-window against a hand-written `batchIntercept` oracle). The gaps were at the macro/skill layer:
- The macro-path test only asserted that `2.5` appeared *somewhere* in the state — it never checked *which* slot is the slope, nor the intercept.
- No shipped regression example config, and no skill recipe (the skill listed the macro name only).

## Changes
- **Tightened `TestScalarRegressionMacro`** to assert the specific slots of the width-9 with-intercept layout `[n, Sx, Sy, Sxx, Sxy, Syy, alpha, beta, sigma2]`: slope (index 7) = 2.5, intercept (index 6) = 1.0, residual variance (index 8) ≈ 0 on a clean line.
- **`cfg/example_regression_config.yaml`** — recovers slope 2.5 / intercept 1.0 of a line observed through `N(0, 1.5)` noise. `TestScalarRegressionMacroRecoversNoisy` pins it (recovery from noise, not exact algebra); `TestExampleConfigsRun` runs it.
- **Fourth skill recipe** (`recipes/scalar_regression_stats.yaml`), drift-bound to the cfg twin by `TestSkillRecipesMatchExamples`, plus a "Worked recipes" entry documenting the output layout — the one non-obvious thing about this macro (read the slope *slot*, don't hunt for the number).

No engine change. Full suite green (Postgres integration test excluded — needs a live DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)