### PR TITLE
Realign the docs front page (and pkg/api's doc) with the config-first engine

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,30 +11,27 @@ title: "Home"
 
 It's a simulation engine written in [Go](https://go.dev/) which can be used to sample from, and learn computational models for, a whole 'Pokédex' of possible real-world systems.
 
-For software engineers, the stochadex simulation framework abstracts away many of the common features that sampling algorithms have for performing these computations behind a highly-configurable interface.
+The framework abstracts away the machinery that sampling algorithms have in common behind a single configurable interface; so a whole simulation, and the analysis and inference layered on top of it, **can be stated as pure configuration**.
 
 This simulation engine is designed based on the simulation software fundamentals described in [this collection of blog posts](https://umbralcalc.github.io/posts/simulating_real_world_systems_as_a_programmer_introduction.html).
 
 ## When to use it
 
-The stochadex fits best when you're in [Go](https://go.dev/) and want stochastic simulation and online inference or simulation-based decision-making (like MCTS) together over one composable primitive and a single deployable binary. This is a combination no other Go library offers (to our knowledge).
+The stochadex fits best when you want stochastic simulation, online inference and simulation-based decision-making over one composable primitive and you want a whole run to be a **single config file**.
 
-It's a powerful framework with tons of features, really generalisable abstractions and principled design. However, you should probably reach for something else when:
+The model, its wiring, the run mode, the data in/out and any inference or optimisation on top are **all data**: one YAML file, run by one prebuilt binary, with no Go toolchain anywhere in the loop. Maths outside the built-in catalogue can be written as expressions in the same file, so Go is only for genuinely new primitives.
+
+Other declarative formats are narrower ([SBML](https://sbml.org/), [Modelica](https://modelica.org/)) or are languages with their own compilers ([Stan](https://mc-stan.org/), [GAML](https://gama-platform.org/)). However, you should probably reach for something else when:
 
 - **Large fixed-shape, GPU, or autodiff-heavy Bayesian modelling** → [Stan](https://mc-stan.org/), [PyMC](https://www.pymc.io/), or Julia's [SciML](https://sciml.ai/).
-- **Pure discrete-event simulation** (entities through queues and servers) → [godes](https://github.com/agoussia/godes).
+- **Pure discrete-event simulation** (entities through queues and servers) → [godes](https://github.com/agoussia/godes) or [SimPy](https://gitlab.com/team-simpy/simpy/).
+- **A standards-based interchange format** (systems biology, physical plant) → [SBML](https://sbml.org/) with [COPASI](https://copasi.org/), or [Modelica](https://modelica.org/).
 - **Plain numerics or classical ML in Go** → [gonum](https://github.com/gonum/gonum), which the stochadex is built on.
 - **Training neural networks or deep RL** → train in Python, then import a frozen ONNX/TorchScript model to run inference behind an [`Iteration`](http://stochadex.github.io/pkg/simulator.html#Iteration).
 
 ## Install
 
-There are three ways in, depending on whether you're writing Go, writing YAML, or letting an agent write it for you.
-
-**As a Go library** → build simulations against the `Iteration` interface. Start with the [quickstart](https://stochadex.github.io/pkg/quickstart.html).
-
-```bash
-go get github.com/umbralcalc/stochadex
-```
+Three ways in, depending on whether you're writing YAML, letting an agent write it for you, or writing Go.
 
 **As a CLI** → describe a whole run in one YAML file and execute it with a prebuilt binary. A config that names no Go anywhere runs in-process, so no Go toolchain is needed. See [running with configs](https://stochadex.github.io/pkg/configs.html).
 
@@ -48,6 +45,12 @@ chmod +x stochadex
 ```bash
 claude plugin marketplace add umbralcalc/stochadex
 claude plugin install stochadex@stochadex
+```
+
+**As a Go library** → implement the `Iteration` interface to add a primitive the catalogue doesn't have, or embed the engine in your own service. Start with the [quickstart](https://stochadex.github.io/pkg/quickstart.html).
+
+```bash
+go get github.com/umbralcalc/stochadex
 ```
 
 ## Integrations

--- a/pkg/api/doc.go
+++ b/pkg/api/doc.go
@@ -1,17 +1,86 @@
-// Package api provides configuration management and program generation for stochadex simulations.
-// It handles YAML-based configuration loading, code generation, and execution orchestration
-// for complex simulation setups including embedded runs and templated configurations.
+// Package api is the configuration tier: it turns one YAML document into a running
+// simulation. Everything the engine can do — the forward model, how its partitions are
+// wired, how many seeded members to run, where observations come from, where results go,
+// and the inference, aggregation or optimisation layered on top — is expressible here as
+// data, so a whole run becomes a single artifact that can be versioned, diffed and
+// executed by a prebuilt binary with no Go toolchain present.
 //
-// Key Features:
-//   - YAML configuration loading and validation
-//   - Code generation from string templates
-//   - Embedded simulation run support
-//   - Socket-based communication configuration
-//   - Runtime program execution
+// # Two ways to name a component, and the decision they drive
 //
-// Usage Patterns:
-//   - Load simulation configurations from YAML files
-//   - Generate executable programs from templates
-//   - Run simulations with embedded sub-simulations
-//   - Configure socket-based data exchange
+// Every position in a config that holds a framework component is a union of two spellings:
+//
+//   - a data spec — a mapping selecting a registered name, e.g.
+//     iteration: {type: wiener_process} or timestep_function: {type: constant, stepsize: 1.0},
+//     resolved at load time by this package's registries;
+//   - a Go expression string — e.g. "&continuous.WienerProcessIteration{}", with
+//     extra_packages and extra_vars declaring the imports and variables it needs.
+//
+// The two spellings are what RunWithParsedArgs branches on. ApiRunConfigStrings.IsFullyData
+// reports whether the config — main and every embedded run — names Go anywhere, so a single
+// Go-spelled component opts the whole document in. If it does not, the config is loaded,
+// resolved and run in-process. If it does, program.go hydrates a template into a temporary
+// main program and executes it with "go run" — the path that buys arbitrary Go wiring at the
+// cost of a toolchain. The macros: tier is always in-process, because it uses pkg/analysis,
+// which the generated program does not import.
+//
+// A partition's bespoke maths does not need either spelling: an expressions: entry
+// (ExpressionConfig, inlining general.ExpressionIteration) states the per-step update as
+// expressions, and is data like everything else. The registries are for the framework's own
+// catalogue, not for a model's arithmetic.
+//
+// # The config surface
+//
+//	main:     partitions and the simulation block (output condition and function,
+//	          termination condition, timestep function) — see RunConfig.
+//	embedded: named sub-runs, each a whole RunConfig (EmbeddedRunConfig). A main-run
+//	          partition whose name matches one is replaced by an embedded simulation
+//	          iteration wired to it, which is how a simulation nests inside a partition.
+//	run:      execution mode — batch or ensemble, with seeds and concurrency (RunModeConfig).
+//	data:     a StateTimeStorage, produced either by a sub-simulation or by a pre-recorded
+//	          source (DataSource: csv, json_log, postgres, plus registered ones).
+//	macros:   each entry expands one pkg/analysis constructor into a set of partitions over
+//	          that storage, or runs live with no data: block at all.
+//
+// # Where the registries live
+//
+//	registry.go          data-only iterations — a name maps to a constructed type, params
+//	                     carry the rest.
+//	registry_compose.go  composable iterations, whose interface-typed fields (kernel,
+//	                     likelihood, jump distribution, prior, nested iteration, named
+//	                     function) are themselves specs, resolved recursively. The
+//	                     "expression" builder here makes the whole expressions DSL usable
+//	                     as an inline iteration spec, so maths can appear anywhere an
+//	                     iteration is expected — inside a macro's window, or an embedded run.
+//	macros*.go           the analysis tier: one file per family (aggregation, inference,
+//	                     smc, optimisation, stats, data). Macro inputs are typed spec
+//	                     structs decoded straight from YAML.
+//
+// # Staying honest, and staying lean
+//
+// Two drift tests guard the iteration registry (registry_test.go and
+// registry_coverage_test.go): every registered name must construct the type it claims, and a
+// go/ast scan requires every Iterate-implementing type in the candidate packages to be either
+// registered or listed in excludedIterations with a reason. A newly-added iteration therefore
+// fails CI until it is classified, which is what stops the registry silently lagging the
+// framework.
+//
+// Imports drive go.mod, so components with heavy dependencies are not named here directly.
+// RegisterDataSource (and simulator.RegisterComponent for sinks) lets a package layered above
+// this one contribute a source or output spelling without the engine depending on it; the
+// Arrow, S3 and DuckDB spellings are registered this way by cmd/stochadex-full. An unknown
+// key reports the spellings the running binary actually has.
+//
+// # Pre-flight
+//
+// CheckForDeadlock runs before any batch or ensemble simulation. Within-step wiring
+// (params_from_upstream) that forms a dependency cycle would otherwise surface as an opaque
+// runtime "all goroutines are asleep" with no indication of which partitions are at fault;
+// the check names them and says how to break the cycle. It runs no simulation. See pkg/graph.
+//
+// # Scope
+//
+// Inference as forward simulation — a posterior stepped as a partition — is in scope, which
+// is why posterior_estimation and the other inference macros live here. Inference against
+// real data is the data: resource, which a downstream repo supplies. The decision layer stays
+// in Go on purpose: an agents.Environment is arbitrary game rules, not representable as data.
 package api


### PR DESCRIPTION
Now that the whole engine is drivable from a YAML config, the docs front page was still
selling the old picture: "fits best when you're in Go". That precondition is no longer
true, so this realigns the positioning and brings `pkg/api`'s package doc up to date with
the package it actually describes.

## `docs/README.md` (the front page)

- **"When to use it"** leads with the config-first story: the model, its wiring, the run
  mode, the data in/out and any inference on top are all data — one YAML file, one prebuilt
  binary, no Go toolchain. Go is now framed as the extension tier (new primitives), not the
  entry requirement.
- Dropped the "no other Go library offers this" line, which scoped the claim to Go. The
  differentiator is now stated against the declarative field it actually competes with:
  narrower formats (SBML, Modelica) or languages with their own compilers (Stan, GAML).
- Added a "standards-based interchange format" bullet to the reach-for-something-else list —
  competing on declarative ground makes SBML/COPASI and Modelica real alternatives to name.
- **Install** reordered to CLI → plugin → Go library, matching the new emphasis.

## `pkg/api/doc.go`

The old package comment described YAML loading, templates, code generation and sockets —
none of the registries, `run:`, `data:` or `macros:` tiers. Rewritten as a map of the
package as it now stands:

- the union of two spellings (data spec vs Go expression) and that this is what
  `RunWithParsedArgs` branches on via `IsFullyData` — one Go-spelled component anywhere,
  including inside an embedded run, opts the whole document onto the `go run` path;
- the config surface: `main:` / `embedded:` / `run:` / `data:` / `macros:`;
- where the registries live and what each holds;
- the two drift tests, and why a new `Iterate` type fails CI until it is classified;
- why heavy dependencies are registered from above (`RegisterDataSource`) rather than named
  here — imports drive `go.mod`;
- `CheckForDeadlock` as pre-flight, and the scope boundary (inference-as-forward-simulation
  is in; the `agents.Environment` decision layer stays Go).

Docs-only plus one package comment — no behaviour change. `gofmt`, `go vet` and
`go test ./pkg/api/` all clean; the docs site rebuilds and renders without artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
