### PR TITLE
Close the last non-MCTS config gaps in the iteration registry

### DIFF
--- a/.claude/skills/stochadex-model/SKILL.md
+++ b/.claude/skills/stochadex-model/SKILL.md
@@ -291,13 +291,22 @@ error; it tells you what to fix.
 `compound_poisson_process` (`rates`,`gamma_alphas`,`gamma_betas`; field `jump_dist: {type: gamma_jump}`),
 `drift_jump_diffusion`, `hawkes_process`, `binomial_observation_process`,
 `categorical_state_transition`, `cumulative_time`, `gradient_descent`,
-`ornstein_uhlenbeck_exact_gaussian`.
+`ornstein_uhlenbeck_exact_gaussian`,
+`hawkes_process_intensity` (params: `background_rates`; field `kernel: {...}`; wire the counting
+partition it is excited by with `params_as_partitions: {hawkes_partition_index: [<name>]}`).
 
 **Iterations — utility / composable:** `constant_values`, `copy_values`, `param_values`,
 `cumulative` (field `iteration: {...}`), `discounted_cumulative` (`iteration`),
 `data_generation` (`likelihood: {...}`), `data_comparison` (`likelihood`),
 `values_function_vector_mean` / `values_function_vector_covariance` (`function: <name>`, `kernel: {...}`),
-`values_grouped_aggregation` (`aggregation: <name>`, `kernel`), `values_function`,
+`values_grouped_aggregation` (`aggregation: <name>`, `kernel`),
+`values_function` (either `function: <name>` or `transform: <name>` + `reduce: <name>`),
+`values_changing_events` (fields `event_iteration: {...}` and `iteration_by_event:` — a *list* of
+`{event: <number>, iteration: {...}}` pairs; falls back to `default_values` params, else the
+previous state, when no event matches),
+`values_weighted_resampling` (params: `log_weight_partitions`, `data_values_partitions`,
+optional `log_weight_indices`, `past_discounting_factor` — wire the partition lists by name with
+`params_as_partitions`),
 `posterior_mean` (`transform: mean|variance`), `posterior_covariance`, `posterior_log_normalisation`.
 
 **Kernels:** `exponential` `periodic` `gaussian_state` `t_distribution_state` `binned`
@@ -306,8 +315,11 @@ error; it tells you what to fix.
 `wishart` `beta` `poisson` `gamma` `negative_binomial`.
 **Priors:** `uniform` (`lo`,`hi`) `truncated_normal` (`mu`,`sigma`,`lo`,`hi`) `half_normal` (`sigma`)
 `log_normal` (`mu`,`sigma`).
-**Value functions:** `data_values` `data_values_variance` `other_values` `unit_value`
-`past_discounted_data_values` `past_discounted_other_values`.
+**Value functions** (`function:` on the vector mean/covariance iterations): `data_values`
+`data_values_variance` `other_values` `unit_value` `past_discounted_data_values`
+`past_discounted_other_values`.
+**Whole value functions** (`function:` on `values_function`): `params_event` (reads the `event`
+params) `partition_event` (reads `event_partition_index` / `event_state_value_index`).
 **Aggregations:** `count` `sum` `mean` `max` `min`.
 **Macros:** `vector_mean` `vector_variance` `vector_covariance` `grouped_aggregation`
 `scalar_regression_stats` `likelihood_comparison` `posterior_estimation`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,44 @@ an exact version rather than assume stability across minors.
   resolve to the bundled skill — a broken pointer would otherwise install a plugin that silently
   ships no skill.
 
+### Added
+- **Three more iterations reachable from pure config, leaving MCTS as the only capability that
+  is deliberately Go-only.** Auditing the registry's own exclusion list showed two of its four
+  non-MCTS entries were misclassified rather than genuinely unreachable:
+  `ValuesWeightedResamplingIteration` was excluded as holding a live `rand.Source`, but
+  `Configure` assigns that source from the partition seed, so the zero value was always a
+  complete construction (now `{type: values_weighted_resampling}`); and
+  `HawkesProcessIntensityIteration` was excluded for taking a positional partition index, but
+  `Configure` has always overwritten that argument from the `hawkes_partition_index` param, and
+  `ParamsAsPartitions` is resolved into `Settings` before `Configure` runs — so the wiring is
+  name-based (`{type: hawkes_process_intensity, kernel: {…}}` plus
+  `params_as_partitions: {hawkes_partition_index: [<name>]}`). Only
+  `ValuesChangingEventsIteration` needed new machinery: a reader for its
+  `map[float64]Iteration`, spelled as a **list** of `{event, iteration}` pairs rather than a
+  YAML mapping keyed by number, because yaml.v2 decodes `1` as an `int` and `1.0` as a
+  `float64` — a mapping would silently key the same event two ways — and because mapping keys
+  bypass the strict unknown-field checking every other spec field gets. `values_function` gained
+  a `function:` form naming a whole `ValuesFunctionIteration.Function`, which is what makes the
+  shipped `params_event` / `partition_event` emitters reachable at all. `excludedIterations` is
+  down from six entries to three, and all three survivors (`FromStorageIteration`,
+  `DataComparisonGradientIteration`, `EmbeddedSimulationRunIteration`) are live-object only as
+  *standalone partitions* — the `data:`, `macros:` and `embedded:` tiers already construct them.
+  A new `TestMultiPartitionRegistryBehaviourEquivalence` extends the data-spec-equals-Go
+  invariant to iterations that read *other* partitions' histories, which the existing
+  single-partition runner could not reach, and it fails if the subject's trajectory never varies
+  so the comparison cannot quietly become vacuous.
+
+### Removed
+- **`discrete.NewHawkesProcessIntensityIteration`** — it had no callers anywhere in the repo
+  (its own test built the struct literal), and its `hawkesPartitionIndex` argument was
+  discarded by `Configure` on the next line. `HawkesProcessIntensityIteration.excitingKernel`
+  is now the exported `ExcitingKernel`, matching every other composable iteration in the
+  framework (`.Kernel`, `.JumpDist`, `.Likelihood`, `.Iteration`); construct the struct
+  directly.
+- **`general.ValuesWeightedResamplingIteration.Src`** is now unexported. `Configure`
+  unconditionally overwrote it from the partition seed, so setting it never had an effect;
+  unexporting makes the "no live object here" classification structural rather than incidental.
+
 ## [0.5.3] — 2026-07-20
 
 The agent-facing payoff of the data-drivable-config arc: the `stochadex-model` skill, backed by

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,9 +9,9 @@ title: "Home"
 
 ## So what is the 'stochadex' project?
 
-It's a simulation engine written in [Go](https://go.dev/) which can be used to sample from, and learn computational models for, a whole 'Pokédex' of possible real-world systems.
+It's a simulation engine written in [Go](https://go.dev/) which can be used to sample from, and learn computational models for, a whole 'Pokédex' of possible real-world systems **entirely in YAML**.
 
-The framework abstracts away the machinery that sampling algorithms have in common behind a single configurable interface; so a whole simulation, and the analysis and inference layered on top of it, **can be stated as pure configuration**.
+The framework abstracts away the machinery that sampling algorithms have in common behind a single configurable interface; so a whole simulation, the analysis and inference layered on top of it can be stated as pure configuration.
 
 This simulation engine is designed based on the simulation software fundamentals described in [this collection of blog posts](https://umbralcalc.github.io/posts/simulating_real_world_systems_as_a_programmer_introduction.html).
 

--- a/pkg/api/registry.go
+++ b/pkg/api/registry.go
@@ -47,6 +47,10 @@ var iterationBuilders = map[string]iterationBuilder{
 	"constant_values":                     nullary(func() simulator.Iteration { return &general.ConstantValuesIteration{} }),
 	"copy_values":                         nullary(func() simulator.Iteration { return &general.CopyValuesIteration{} }),
 	"param_values":                        nullary(func() simulator.Iteration { return &general.ParamValuesIteration{} }),
+	// values_weighted_resampling holds a rand.Source, but Configure assigns it from
+	// the partition seed, so the zero value is a complete construction and every
+	// other input (log_weight_partitions, data_values_partitions, …) is params.
+	"values_weighted_resampling": nullary(func() simulator.Iteration { return &general.ValuesWeightedResamplingIteration{} }),
 
 	// pkg/inference
 	"posterior_covariance":        nullary(func() simulator.Iteration { return &inference.PosteriorCovarianceIteration{} }),

--- a/pkg/api/registry_behaviour_test.go
+++ b/pkg/api/registry_behaviour_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"math"
 	"testing"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/umbralcalc/stochadex/pkg/discrete"
 	"github.com/umbralcalc/stochadex/pkg/general"
 	"github.com/umbralcalc/stochadex/pkg/inference"
+	"github.com/umbralcalc/stochadex/pkg/kernels"
 	"github.com/umbralcalc/stochadex/pkg/simulator"
 )
 
@@ -135,6 +137,37 @@ func TestIterationRegistryBehaviourEquivalence(t *testing.T) {
 			init:   []float64{0.0},
 		},
 		{
+			// A nested-iteration *map* keyed by event value, plus a whole named
+			// value function — the two pieces of machinery this iteration needs.
+			// The mapped iteration is seeded, so a registry that built the map but
+			// dropped the Configure propagation would diverge here.
+			name: "values_changing_events switching on a params event",
+			spec: simulator.ComponentSpec{
+				Type: "values_changing_events",
+				Fields: map[string]interface{}{
+					"event_iteration": map[string]interface{}{
+						"type": "values_function", "function": "params_event",
+					},
+					"iteration_by_event": []interface{}{
+						map[string]interface{}{
+							"event":     1.0,
+							"iteration": map[string]interface{}{"type": "wiener_process"},
+						},
+					},
+				},
+			},
+			goIter: &general.ValuesChangingEventsIteration{
+				EventIteration: &general.ValuesFunctionIteration{
+					Function: general.ParamsEventFunction,
+				},
+				IterationByEvent: map[float64]simulator.Iteration{
+					1.0: &continuous.WienerProcessIteration{},
+				},
+			},
+			params: map[string][]float64{"event": {1.0}, "variances": {1.0}},
+			init:   []float64{0.0},
+		},
+		{
 			// A composable one with a nested JumpDistribution.
 			name: "compound_poisson_process with gamma_jump",
 			spec: simulator.ComponentSpec{
@@ -159,6 +192,159 @@ func TestIterationRegistryBehaviourEquivalence(t *testing.T) {
 			fromGo := runOnePartition(tc.goIter, tc.params, tc.init, 42, 30)
 			if len(fromData) != len(fromGo) {
 				t.Fatalf("row counts differ: data %d, go %d", len(fromData), len(fromGo))
+			}
+			for step := range fromGo {
+				for i := range fromGo[step] {
+					if fromData[step][i] != fromGo[step][i] {
+						t.Fatalf("step %d value %d: data-spec %v != go %v (registry mis-wired)",
+							step, i, fromData[step][i], fromGo[step][i])
+					}
+				}
+			}
+		})
+	}
+}
+
+// runPartitions runs a multi-partition simulation and returns the named
+// partition's trajectory. Iterations that read *other* partitions' histories
+// cannot be exercised by runOnePartition, so they get their wiring built here.
+func runPartitions(
+	partitions []*simulator.PartitionConfig,
+	subject string,
+	steps int,
+) [][]float64 {
+	storage := analysis.NewStateTimeStorageFromPartitions(
+		partitions,
+		&simulator.NumberOfStepsTerminationCondition{MaxNumberOfSteps: steps},
+		&simulator.ConstantTimestepFunction{Stepsize: 1.0},
+		0.0,
+	)
+	return storage.GetValues(subject)
+}
+
+// hawkesPartitions wires an intensity iteration to the Hawkes counting process
+// it excites: the counter reads the intensity's output within-step, and the
+// intensity reads the counter's history by name via params_as_partitions —
+// the name-based form of the partition index its Configure resolves.
+func hawkesPartitions(intensity simulator.Iteration) []*simulator.PartitionConfig {
+	return []*simulator.PartitionConfig{
+		{
+			Name:      "intensity",
+			Iteration: intensity,
+			Params: simulator.NewParams(map[string][]float64{
+				"background_rates":                {1.4, 1.2},
+				"exponential_weighting_timescale": {1.1},
+			}),
+			ParamsAsPartitions: map[string][]string{
+				"hawkes_partition_index": {"hawkes"},
+			},
+			InitStateValues:   []float64{0.0, 0.0},
+			StateHistoryDepth: 10,
+			Seed:              253,
+		},
+		{
+			Name:      "hawkes",
+			Iteration: &discrete.HawkesProcessIteration{},
+			Params:    simulator.NewParams(map[string][]float64{}),
+			ParamsFromUpstream: map[string]simulator.NamedUpstreamConfig{
+				"intensity": {Upstream: "intensity"},
+			},
+			InitStateValues:   []float64{0.0, 0.0},
+			StateHistoryDepth: 10,
+			Seed:              1112,
+		},
+	}
+}
+
+// resamplingPartitions wires a resampling iteration to two weight partitions and
+// two data partitions, all named rather than indexed.
+func resamplingPartitions(resampling simulator.Iteration) []*simulator.PartitionConfig {
+	constant := func(name string, init []float64) *simulator.PartitionConfig {
+		return &simulator.PartitionConfig{
+			Name:              name,
+			Iteration:         &general.ConstantValuesIteration{},
+			Params:            simulator.NewParams(map[string][]float64{}),
+			InitStateValues:   init,
+			StateHistoryDepth: 5,
+			Seed:              0,
+		}
+	}
+	return []*simulator.PartitionConfig{
+		constant("weights_a", []float64{-0.5}),
+		constant("weights_b", []float64{-1.5}),
+		constant("data_a", []float64{1.0, 2.0, 3.0}),
+		constant("data_b", []float64{4.0, 5.0, 6.0}),
+		{
+			Name:      "resampled",
+			Iteration: resampling,
+			Params: simulator.NewParams(map[string][]float64{
+				"past_discounting_factor": {0.98},
+			}),
+			ParamsAsPartitions: map[string][]string{
+				"log_weight_partitions":  {"weights_a", "weights_b"},
+				"data_values_partitions": {"data_a", "data_b"},
+			},
+			InitStateValues:   []float64{0.0, 0.0, 0.0},
+			StateHistoryDepth: 2,
+			Seed:              1735,
+		},
+	}
+}
+
+// TestMultiPartitionRegistryBehaviourEquivalence is the same invariant as
+// TestIterationRegistryBehaviourEquivalence for the iterations that read other
+// partitions' state histories, which a single-partition run cannot reach.
+func TestMultiPartitionRegistryBehaviourEquivalence(t *testing.T) {
+	cases := []struct {
+		name    string
+		spec    simulator.ComponentSpec
+		goIter  simulator.Iteration
+		wire    func(simulator.Iteration) []*simulator.PartitionConfig
+		subject string
+	}{
+		{
+			name: "hawkes_process_intensity with an exponential kernel",
+			spec: simulator.ComponentSpec{
+				Type: "hawkes_process_intensity",
+				Fields: map[string]interface{}{
+					"kernel": map[string]interface{}{"type": "exponential"},
+				},
+			},
+			goIter: &discrete.HawkesProcessIntensityIteration{
+				ExcitingKernel: &kernels.ExponentialIntegrationKernel{},
+			},
+			wire:    hawkesPartitions,
+			subject: "intensity",
+		},
+		{
+			name:    "values_weighted_resampling (seeded from the partition seed)",
+			spec:    simulator.ComponentSpec{Type: "values_weighted_resampling"},
+			goIter:  &general.ValuesWeightedResamplingIteration{},
+			wire:    resamplingPartitions,
+			subject: "resampled",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resolved, err := ResolveIteration(tc.spec)
+			if err != nil {
+				t.Fatalf("resolve: %v", err)
+			}
+			fromData := runPartitions(tc.wire(resolved), tc.subject, 30)
+			fromGo := runPartitions(tc.wire(tc.goIter), tc.subject, 30)
+			if len(fromData) != len(fromGo) {
+				t.Fatalf("row counts differ: data %d, go %d", len(fromData), len(fromGo))
+			}
+			// A subject that never moves would make the comparison below vacuous:
+			// two identical constant series agree however badly the registry is wired.
+			distinct := make(map[string]bool)
+			for _, row := range fromGo {
+				distinct[fmt.Sprint(row)] = true
+			}
+			if len(distinct) < 2 {
+				t.Fatalf("subject %q never varies over the run — "+
+					"the equivalence check would be vacuous", tc.subject)
 			}
 			for step := range fromGo {
 				for i := range fromGo[step] {

--- a/pkg/api/registry_compose.go
+++ b/pkg/api/registry_compose.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/umbralcalc/stochadex/pkg/continuous"
+	"github.com/umbralcalc/stochadex/pkg/discrete"
 	"github.com/umbralcalc/stochadex/pkg/general"
 	"github.com/umbralcalc/stochadex/pkg/inference"
 	"github.com/umbralcalc/stochadex/pkg/kernels"
@@ -165,6 +166,45 @@ func (r *specReader) priorList(key string) []inference.Prior {
 	return priors
 }
 
+// iterationByEvent reads a list of {event: <number>, iteration: <spec>} pairs
+// into the map keyed by event value that ValuesChangingEventsIteration switches
+// on. A list rather than a YAML mapping keyed by the event number: yaml.v2
+// decodes `1` as an int and `1.0` as a float64, so a mapping would silently key
+// the same event two ways, and mapping keys bypass the strict unknown-field
+// checking every other spec field gets.
+func (r *specReader) iterationByEvent(key string) map[float64]simulator.Iteration {
+	value, ok := r.value(key, true)
+	if !ok {
+		return nil
+	}
+	raw, ok := value.([]interface{})
+	if !ok {
+		r.fail("field %q must be a list of {event, iteration} pairs, got %T", key, value)
+		return nil
+	}
+	byEvent := make(map[float64]simulator.Iteration, len(raw))
+	for i, element := range raw {
+		fields, err := toFieldMap(element)
+		if err != nil {
+			r.fail("field %q[%d]: %v", key, i, err)
+			return nil
+		}
+		pair := newSpecReader(fmt.Sprintf("%s[%d]", r.what+" "+key, i), fields)
+		event := pair.floatField("event")
+		iteration := pair.iteration("iteration")
+		if err := pair.done(); err != nil {
+			r.fail("%v", err)
+			return nil
+		}
+		if _, duplicate := byEvent[event]; duplicate {
+			r.fail("field %q: duplicate event value %v", key, event)
+			return nil
+		}
+		byEvent[event] = iteration
+	}
+	return byEvent
+}
+
 // namedFunc looks a framework-shipped function value up by name in a typed
 // registry, failing if the name is unknown.
 func namedFunc[T any](r *specReader, key string, registry map[string]T) T {
@@ -198,10 +238,10 @@ func (r *specReader) done() error {
 	return nil
 }
 
-// toComponentSpec coerces a nested YAML value into a ComponentSpec. yaml.v2
+// toFieldMap coerces a nested YAML mapping into string-keyed fields. yaml.v2
 // delivers a nested mapping as map[interface{}]interface{}, so both that and
 // map[string]interface{} are accepted.
-func toComponentSpec(value interface{}) (simulator.ComponentSpec, error) {
+func toFieldMap(value interface{}) (map[string]interface{}, error) {
 	fields := make(map[string]interface{})
 	switch typed := value.(type) {
 	case map[string]interface{}:
@@ -212,13 +252,21 @@ func toComponentSpec(value interface{}) (simulator.ComponentSpec, error) {
 		for k, v := range typed {
 			key, ok := k.(string)
 			if !ok {
-				return simulator.ComponentSpec{}, fmt.Errorf("spec key %v is not a string", k)
+				return nil, fmt.Errorf("spec key %v is not a string", k)
 			}
 			fields[key] = v
 		}
 	default:
-		return simulator.ComponentSpec{}, fmt.Errorf(
-			"expected a {type: ...} mapping, got %T", value)
+		return nil, fmt.Errorf("expected a mapping, got %T", value)
+	}
+	return fields, nil
+}
+
+// toComponentSpec coerces a nested YAML value into a ComponentSpec.
+func toComponentSpec(value interface{}) (simulator.ComponentSpec, error) {
+	fields, err := toFieldMap(value)
+	if err != nil {
+		return simulator.ComponentSpec{}, err
 	}
 	kind, ok := fields["type"].(string)
 	if !ok || kind == "" {
@@ -449,13 +497,39 @@ func registerComposableIterations() {
 		it := &inference.SMCProposalIteration{Priors: r.priorList("priors")}
 		return it, r.done()
 	}
+	// values_function takes either a whole named function ("function") or a
+	// transform + reduce pair composed into one. The composed form covers the
+	// building blocks; the whole-function form reaches the framework's shipped
+	// end-to-end functions, which no transform/reduce pair can express.
 	iterationBuilders["values_function"] = func(f map[string]interface{}) (simulator.Iteration, error) {
 		r := newSpecReader("values_function", f)
+		it := &general.ValuesFunctionIteration{}
+		if _, whole := f["function"]; whole {
+			it.Function = namedFunc(r, "function", valuesFunctions)
+			return it, r.done()
+		}
 		transform := namedFunc(r, "transform", valuesTransforms)
 		reduce := namedFunc(r, "reduce", valuesReduces)
-		it := &general.ValuesFunctionIteration{}
 		if r.err == nil {
 			it.Function = general.NewTransformReduceFunction(transform, reduce)
+		}
+		return it, r.done()
+	}
+	iterationBuilders["values_changing_events"] = func(f map[string]interface{}) (simulator.Iteration, error) {
+		r := newSpecReader("values_changing_events", f)
+		it := &general.ValuesChangingEventsIteration{
+			EventIteration:   r.iteration("event_iteration"),
+			IterationByEvent: r.iterationByEvent("iteration_by_event"),
+		}
+		return it, r.done()
+	}
+	// hawkes_process_intensity reads the partition it is excited by from the
+	// "hawkes_partition_index" param, so the wiring is name-based via
+	// params_as_partitions rather than a positional index baked into the spec.
+	iterationBuilders["hawkes_process_intensity"] = func(f map[string]interface{}) (simulator.Iteration, error) {
+		r := newSpecReader("hawkes_process_intensity", f)
+		it := &discrete.HawkesProcessIntensityIteration{
+			ExcitingKernel: r.kernel("kernel"),
 		}
 		return it, r.done()
 	}
@@ -549,6 +623,22 @@ var valuesTransforms = map[string]valuesTransform{
 
 var valuesReduces = map[string]valuesReduce{
 	"sum": general.SumReduce,
+}
+
+// valuesFunction is the whole Function field type of ValuesFunctionIteration,
+// named directly rather than composed from a transform and a reduce.
+type valuesFunction = func(
+	params *simulator.Params,
+	partitionIndex int,
+	stateHistories []*simulator.StateHistory,
+	timestepsHistory *simulator.CumulativeTimestepsHistory,
+) []float64
+
+// valuesFunctions are the framework's shipped end-to-end value functions. Both
+// emit an event value for values_changing_events to switch on.
+var valuesFunctions = map[string]valuesFunction{
+	"params_event":    general.ParamsEventFunction,
+	"partition_event": general.PartitionEventFunction,
 }
 
 func init() {

--- a/pkg/api/registry_coverage_test.go
+++ b/pkg/api/registry_coverage_test.go
@@ -12,27 +12,26 @@ import (
 // excludedIterations names every Iteration implementation in the candidate
 // packages that is deliberately NOT in the registry (data-only in Phase A,
 // composable in Phase B), each with the reason:
-//   - "composable-deferred": composable in principle, but its constructor takes a
-//     positional partition index that is fragile to express as raw data.
-//   - "live-object": holds a live object, channel, RNG source, or bulk [][]float64
-//     data with no data form at all.
+//   - "live-object": holds a live object bound at runtime by its caller — bulk
+//     [][]float64 data, a batch *StateHistory, or a whole *Settings/*Implementations
+//     pair — with no data form as a standalone partition. All three are still
+//     reachable from config indirectly, constructed by the data:, macros: and
+//     embedded: tiers respectively.
 //
 // Drift test 2 asserts every Iterate-implementing type in the candidate packages
 // is either registered (wantIterationType) or listed here. A NEW iteration then
 // fails CI until it is classified — the guard that stops the registry silently
 // lagging the framework.
+//
+// A field of live-object *type* is not on its own grounds for exclusion: an RNG
+// source that Configure assigns from the partition seed is inert as config, and
+// nested iterations are expressible as recursive specs. Both of those cases were
+// excluded here once and have since been registered.
 var excludedIterations = map[string]string{
-	// composable but deliberately deferred: the constructor takes a positional
-	// partition index, which is fragile to express as raw data — revisit if a
-	// name-resolving form lands.
-	"HawkesProcessIntensityIteration": "composable-deferred: kernel + positional partition index",
-
-	// live-object — no data form
-	"FromStorageIteration":              "live-object: [][]float64 bulk data",
-	"ValuesChangingEventsIteration":     "live-object: map[float64]Iteration + nested Iteration",
-	"ValuesWeightedResamplingIteration": "live-object: rand.Source",
-	"DataComparisonGradientIteration":   "live-object: *StateHistory batch + gradient func",
-	"EmbeddedSimulationRunIteration":    "live-object: *Settings/*Implementations",
+	// live-object — no data form as a standalone partition
+	"FromStorageIteration":            "live-object: [][]float64 bulk data (built by the data: tier)",
+	"DataComparisonGradientIteration": "live-object: *StateHistory batch + gradient func (built by macros:)",
+	"EmbeddedSimulationRunIteration":  "live-object: *Settings/*Implementations (built by the embedded: tier)",
 }
 
 // candidatePackages are the packages whose Iteration implementations are

--- a/pkg/api/registry_test.go
+++ b/pkg/api/registry_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/umbralcalc/stochadex/pkg/general"
 	"github.com/umbralcalc/stochadex/pkg/inference"
 	"github.com/umbralcalc/stochadex/pkg/simulator"
 )
@@ -29,11 +30,13 @@ var wantIterationType = map[string]string{
 	"binomial_observation_process":        "*discrete.BinomialObservationProcessIteration",
 	"categorical_state_transition":        "*discrete.CategoricalStateTransitionIteration",
 	"hawkes_process":                      "*discrete.HawkesProcessIteration",
+	"hawkes_process_intensity":            "*discrete.HawkesProcessIntensityIteration",
 	"values_sorted_collection_mean":       "*general.ValuesSortedCollectionMeanIteration",
 	"values_sorted_collection_covariance": "*general.ValuesSortedCollectionCovarianceIteration",
 	"constant_values":                     "*general.ConstantValuesIteration",
 	"copy_values":                         "*general.CopyValuesIteration",
 	"param_values":                        "*general.ParamValuesIteration",
+	"values_weighted_resampling":          "*general.ValuesWeightedResamplingIteration",
 	"posterior_covariance":                "*inference.PosteriorCovarianceIteration",
 	"posterior_log_normalisation":         "*inference.PosteriorLogNormalisationIteration",
 	"smc_posterior":                       "*inference.SMCPosteriorIteration",
@@ -48,6 +51,7 @@ var wantIterationType = map[string]string{
 	"cumulative":                        "*general.CumulativeIteration",
 	"discounted_cumulative":             "*general.DiscountedCumulativeIteration",
 	"values_function":                   "*general.ValuesFunctionIteration",
+	"values_changing_events":            "*general.ValuesChangingEventsIteration",
 	"values_collection":                 "*general.ValuesCollectionIteration",
 	"values_sorting_collection":         "*general.ValuesSortingCollectionIteration",
 	"data_generation":                   "*inference.DataGenerationIteration",
@@ -69,13 +73,23 @@ var iterationSpecFixtures = map[string]map[string]interface{}{
 	"cumulative":                        {"iteration": map[string]interface{}{"type": "wiener_process"}},
 	"discounted_cumulative":             {"iteration": map[string]interface{}{"type": "wiener_process"}},
 	"values_function":                   {"transform": "params", "reduce": "sum"},
-	"values_collection":                 {"pop_index": "next_non_empty", "push": "param_values"},
-	"values_sorting_collection":         {"push_and_sort": "param_values"},
-	"expression":                        {"fields": []interface{}{map[string]interface{}{"name": "x"}}, "outputs": []interface{}{"x"}},
-	"data_generation":                   {"likelihood": map[string]interface{}{"type": "normal"}},
-	"data_comparison":                   {"likelihood": map[string]interface{}{"type": "normal"}},
-	"posterior_mean":                    {"transform": "mean"},
-	"smc_proposal":                      {"priors": []interface{}{map[string]interface{}{"type": "uniform", "lo": 0.0, "hi": 1.0}}},
+	"hawkes_process_intensity":          {"kernel": map[string]interface{}{"type": "exponential"}},
+	"values_changing_events": {
+		"event_iteration": map[string]interface{}{"type": "values_function", "function": "params_event"},
+		"iteration_by_event": []interface{}{
+			map[string]interface{}{
+				"event":     1.0,
+				"iteration": map[string]interface{}{"type": "constant_values"},
+			},
+		},
+	},
+	"values_collection":         {"pop_index": "next_non_empty", "push": "param_values"},
+	"values_sorting_collection": {"push_and_sort": "param_values"},
+	"expression":                {"fields": []interface{}{map[string]interface{}{"name": "x"}}, "outputs": []interface{}{"x"}},
+	"data_generation":           {"likelihood": map[string]interface{}{"type": "normal"}},
+	"data_comparison":           {"likelihood": map[string]interface{}{"type": "normal"}},
+	"posterior_mean":            {"transform": "mean"},
+	"smc_proposal":              {"priors": []interface{}{map[string]interface{}{"type": "uniform", "lo": 0.0, "hi": 1.0}}},
 }
 
 // TestIterationRegistryConstructs is drift test 1: every registered name builds a
@@ -141,6 +155,74 @@ func TestResolveIterationErrors(t *testing.T) {
 			t.Error("expected an error for an unknown smc_posterior field")
 		}
 	})
+
+	t.Run("values_function takes either a whole function or transform+reduce", func(t *testing.T) {
+		if _, err := ResolveIteration(simulator.ComponentSpec{
+			Type: "values_function", Fields: map[string]interface{}{"function": "params_event"},
+		}); err != nil {
+			t.Errorf("a whole named function should be accepted: %v", err)
+		}
+		if _, err := ResolveIteration(simulator.ComponentSpec{
+			Type: "values_function", Fields: map[string]interface{}{"function": "no_such_function"},
+		}); err == nil {
+			t.Error("expected an error for an unknown function name")
+		}
+		// The whole-function form takes over completely: a stray transform is not
+		// silently ignored alongside it.
+		if _, err := ResolveIteration(simulator.ComponentSpec{
+			Type: "values_function",
+			Fields: map[string]interface{}{
+				"function": "params_event", "transform": "params",
+			},
+		}); err == nil {
+			t.Error("expected an error for transform alongside function")
+		}
+	})
+
+	t.Run("values_changing_events validates its event/iteration pairs", func(t *testing.T) {
+		eventIteration := map[string]interface{}{
+			"type": "values_function", "function": "params_event",
+		}
+		pair := func(event interface{}) map[string]interface{} {
+			return map[string]interface{}{
+				"event":     event,
+				"iteration": map[string]interface{}{"type": "constant_values"},
+			}
+		}
+		resolve := func(byEvent []interface{}) error {
+			_, err := ResolveIteration(simulator.ComponentSpec{
+				Type: "values_changing_events",
+				Fields: map[string]interface{}{
+					"event_iteration": eventIteration, "iteration_by_event": byEvent,
+				},
+			})
+			return err
+		}
+		// An integer event key is accepted: yaml.v2 decodes `1` as an int and `1.0`
+		// as a float64, and both must reach the same map key.
+		if err := resolve([]interface{}{pair(1)}); err != nil {
+			t.Errorf("an integer event value should be accepted: %v", err)
+		}
+		if err := resolve([]interface{}{pair(1.0), pair(1)}); err == nil {
+			t.Error("expected an error for a duplicate event value")
+		}
+		if err := resolve([]interface{}{pair("one")}); err == nil {
+			t.Error("expected an error for a non-numeric event value")
+		}
+		if err := resolve([]interface{}{
+			map[string]interface{}{"event": 1.0, "nope": 2},
+		}); err == nil {
+			t.Error("expected an error for an unknown field in a pair")
+		}
+		if _, err := ResolveIteration(simulator.ComponentSpec{
+			Type: "values_changing_events",
+			Fields: map[string]interface{}{
+				"event_iteration": eventIteration, "iteration_by_event": "not-a-list",
+			},
+		}); err == nil {
+			t.Error("expected an error for a non-list iteration_by_event")
+		}
+	})
 }
 
 // TestDataSpecIterationRunsInProcess is the integration test: a config using a
@@ -177,6 +259,131 @@ func TestDataSpecIterationRunsInProcess(t *testing.T) {
 		t.Errorf("resolved iteration is %s, want a WienerProcessIteration", got)
 	}
 	// Run it: no panic, produces a generator that steps to termination.
+	Run(loaded, &SocketConfig{})
+}
+
+// TestNewlyRegisteredIterationsRunFromYaml is the end-to-end proof for the three
+// iterations that closed the last non-MCTS config gaps: a Hawkes self-exciting
+// intensity (kernel + a partition it reads by name), an event-switched map of
+// nested iterations, and weighted resampling over other partitions' histories.
+// It goes through the YAML loader rather than ComponentSpec literals on purpose:
+// yaml.v2 delivers nested mappings as map[interface{}]interface{}, which the
+// in-Go spec tests never exercise.
+func TestNewlyRegisteredIterationsRunFromYaml(t *testing.T) {
+	const config = `main:
+  partitions:
+  - name: intensity
+    iteration: {type: hawkes_process_intensity, kernel: {type: exponential}}
+    params:
+      background_rates: [1.4, 1.2]
+      exponential_weighting_timescale: [1.1]
+    params_as_partitions: {hawkes_partition_index: [counter]}
+    init_state_values: [0.0, 0.0]
+    state_history_depth: 10
+    seed: 253
+  - name: counter
+    iteration: {type: hawkes_process}
+    params: {}
+    params_from_upstream:
+      intensity: {upstream: intensity}
+    init_state_values: [0.0, 0.0]
+    state_history_depth: 10
+    seed: 1112
+  - name: switcher
+    iteration:
+      type: values_changing_events
+      event_iteration: {type: values_function, function: params_event}
+      iteration_by_event:
+      - event: 1.0
+        iteration: {type: wiener_process}
+      - event: 2.0
+        iteration: {type: constant_values}
+    params: {event: [1.0], variances: [1.0]}
+    init_state_values: [0.0]
+    state_history_depth: 1
+    seed: 99
+  - name: weights_a
+    iteration: {type: constant_values}
+    params: {}
+    init_state_values: [-0.5]
+    state_history_depth: 5
+    seed: 0
+  - name: weights_b
+    iteration: {type: constant_values}
+    params: {}
+    init_state_values: [-1.5]
+    state_history_depth: 5
+    seed: 0
+  - name: data_a
+    iteration: {type: constant_values}
+    params: {}
+    init_state_values: [1.0, 2.0, 3.0]
+    state_history_depth: 5
+    seed: 0
+  - name: data_b
+    iteration: {type: constant_values}
+    params: {}
+    init_state_values: [4.0, 5.0, 6.0]
+    state_history_depth: 5
+    seed: 0
+  - name: resampled
+    iteration: {type: values_weighted_resampling}
+    params: {past_discounting_factor: [0.98]}
+    params_as_partitions:
+      log_weight_partitions: [weights_a, weights_b]
+      data_values_partitions: [data_a, data_b]
+    init_state_values: [0.0, 0.0, 0.0]
+    state_history_depth: 2
+    seed: 1735
+  simulation:
+    output_condition: {type: every_step}
+    output_function: {type: nil}
+    termination_condition: {type: number_of_steps, max_steps: 20}
+    timestep_function: {type: constant, stepsize: 1.0}
+    init_time_value: 0.0
+`
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(config), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !LoadApiRunConfigStringsFromYaml(path).IsFullyData() {
+		t.Fatal("this config names no Go anywhere — it should be fully data")
+	}
+	loaded := LoadApiRunConfigFromYaml(path)
+	want := map[string]string{
+		"intensity": "*discrete.HawkesProcessIntensityIteration",
+		"switcher":  "*general.ValuesChangingEventsIteration",
+		"resampled": "*general.ValuesWeightedResamplingIteration",
+	}
+	for _, partition := range loaded.Main.Partitions {
+		expected, checked := want[partition.Name]
+		if !checked {
+			continue
+		}
+		if partition.Iteration == nil {
+			t.Fatalf("%s: iteration not resolved at load", partition.Name)
+		}
+		if got := reflect.TypeOf(partition.Iteration).String(); got != expected {
+			t.Errorf("%s resolved to %s, want %s", partition.Name, got, expected)
+		}
+		// The event keys must survive YAML decoding as the exact float values the
+		// iteration switches on. A key that arrived mis-typed would simply never
+		// match, and the partition would silently fall through to its previous
+		// state — a failure the type check above cannot see.
+		if switcher, ok := partition.Iteration.(*general.ValuesChangingEventsIteration); ok {
+			for _, event := range []float64{1.0, 2.0} {
+				if _, found := switcher.IterationByEvent[event]; !found {
+					t.Errorf("switcher has no iteration keyed by event %v: got keys %v",
+						event, switcher.IterationByEvent)
+				}
+			}
+		}
+		delete(want, partition.Name)
+	}
+	if len(want) > 0 {
+		t.Fatalf("partitions missing from the loaded config: %v", want)
+	}
+	// No Go toolchain involved: this steps to termination in-process.
 	Run(loaded, &SocketConfig{})
 }
 

--- a/pkg/discrete/hawkes_process.go
+++ b/pkg/discrete/hawkes_process.go
@@ -9,8 +9,13 @@ import (
 
 // HawkesProcessIntensityIteration an iteration for a Hawkes process
 // self-exciting intensity function.
+//
+// Usage hints:
+//   - Provide: "background_rates" and "hawkes_partition_index" (the partition
+//     running the HawkesProcessIteration whose history excites this intensity).
+//   - Set ExcitingKernel to the kernel weighting past events by their age.
 type HawkesProcessIntensityIteration struct {
-	excitingKernel       kernels.IntegrationKernel
+	ExcitingKernel       kernels.IntegrationKernel
 	hawkesPartitionIndex int
 }
 
@@ -18,7 +23,7 @@ func (h *HawkesProcessIntensityIteration) Configure(
 	partitionIndex int,
 	settings *simulator.Settings,
 ) {
-	h.excitingKernel.Configure(partitionIndex, settings)
+	h.ExcitingKernel.Configure(partitionIndex, settings)
 	h.hawkesPartitionIndex = int(
 		settings.Iterations[partitionIndex].Params.GetIndex(
 			"hawkes_partition_index", 0),
@@ -31,7 +36,7 @@ func (h *HawkesProcessIntensityIteration) Iterate(
 	stateHistories []*simulator.StateHistory,
 	timestepsHistory *simulator.CumulativeTimestepsHistory,
 ) []float64 {
-	h.excitingKernel.SetParams(params)
+	h.ExcitingKernel.SetParams(params)
 	hawkesHistory := stateHistories[h.hawkesPartitionIndex]
 	values := params.GetCopy("background_rates")
 	for i := 1; i < hawkesHistory.StateHistoryDepth; i++ {
@@ -42,7 +47,7 @@ func (h *HawkesProcessIntensityIteration) Iterate(
 			hawkesHistory.Values.RawRowView(i),
 		)
 		floats.Scale(
-			h.excitingKernel.Evaluate(
+			h.ExcitingKernel.Evaluate(
 				hawkesHistory.Values.RawRowView(0),
 				hawkesHistory.Values.RawRowView(i),
 				timestepsHistory.Values.AtVec(0),
@@ -53,19 +58,6 @@ func (h *HawkesProcessIntensityIteration) Iterate(
 		floats.Add(values, sumValues)
 	}
 	return values
-}
-
-// NewHawkesProcessIntensityIteration creates a new
-// HawkesProcessIntensityIteration given a partition index
-// for the Hawkes process itself.
-func NewHawkesProcessIntensityIteration(
-	excitingKernel kernels.IntegrationKernel,
-	hawkesPartitionIndex int,
-) *HawkesProcessIntensityIteration {
-	return &HawkesProcessIntensityIteration{
-		excitingKernel:       excitingKernel,
-		hawkesPartitionIndex: hawkesPartitionIndex,
-	}
 }
 
 // HawkesProcessIteration defines an iteration for a Hawkes process.

--- a/pkg/discrete/hawkes_process_test.go
+++ b/pkg/discrete/hawkes_process_test.go
@@ -15,7 +15,7 @@ func TestHawkesProcess(t *testing.T) {
 				"hawkes_process_settings.yaml",
 			)
 			intensityIteration := &HawkesProcessIntensityIteration{
-				excitingKernel: &kernels.ExponentialIntegrationKernel{},
+				ExcitingKernel: &kernels.ExponentialIntegrationKernel{},
 			}
 			intensityIteration.Configure(0, settings)
 			hawkesIteration := &HawkesProcessIteration{}
@@ -47,7 +47,7 @@ func TestHawkesProcess(t *testing.T) {
 				"hawkes_process_settings.yaml",
 			)
 			intensityIteration := &HawkesProcessIntensityIteration{
-				excitingKernel: &kernels.ExponentialIntegrationKernel{},
+				ExcitingKernel: &kernels.ExponentialIntegrationKernel{},
 			}
 			hawkesIteration := &HawkesProcessIteration{}
 			store := simulator.NewStateTimeStorage()

--- a/pkg/general/values_weighted_resampling.go
+++ b/pkg/general/values_weighted_resampling.go
@@ -18,7 +18,7 @@ import (
 //   - Provide: "data_values_partitions" to choose which values to resample.
 //   - Use "past_discounting_factor" to downweight older history (exponential).
 type ValuesWeightedResamplingIteration struct {
-	Src     rand.Source
+	src     rand.Source
 	catDist distuv.Categorical
 }
 
@@ -34,11 +34,11 @@ func (v *ValuesWeightedResamplingIteration) Configure(
 			settings.Iterations[int(logWeightPartitions[0])].StateHistoryDepth,
 	)
 	nilWeights[0] = 1.0
-	v.Src = rand.NewPCG(
+	v.src = rand.NewPCG(
 		settings.Iterations[partitionIndex].Seed,
 		settings.Iterations[partitionIndex].Seed,
 	)
-	v.catDist = distuv.NewCategorical(nilWeights, v.Src)
+	v.catDist = distuv.NewCategorical(nilWeights, v.src)
 }
 
 func (v *ValuesWeightedResamplingIteration) Iterate(


### PR DESCRIPTION
Leaves MCTS as the only capability that cannot be written in pure config.

## What was actually wrong

Auditing `excludedIterations` showed that **two of its four non-MCTS entries were misclassified, not genuinely unreachable**:

- **`ValuesWeightedResamplingIteration`** was excluded as holding a live `rand.Source` — but `Configure` assigns that source from the partition seed, so the zero value was always a complete construction. Now `{type: values_weighted_resampling}`, a one-line registry entry. `Src` is unexported, since setting it never had an effect.
- **`HawkesProcessIntensityIteration`** was excluded for taking a positional partition index — but `Configure` has always overwritten that argument from the `hawkes_partition_index` param, and `ParamsAsPartitions` is resolved into `Settings` *before* `Configure` runs. So the wiring is name-based:
  ```yaml
  iteration: {type: hawkes_process_intensity, kernel: {type: exponential}}
  params_as_partitions: {hawkes_partition_index: [counter]}
  ```

Only **`ValuesChangingEventsIteration`** needed new machinery: a reader for its `map[float64]Iteration`, spelled as a **list** of `{event, iteration}` pairs rather than a YAML mapping keyed by number. yaml.v2 decodes `1` as an `int` and `1.0` as a `float64`, so a mapping would silently key the same event two ways — and mapping keys bypass the strict unknown-field checking every other spec field gets.

`values_function` also gained a `function:` form naming a whole `ValuesFunctionIteration.Function`, which is what makes the shipped `params_event` / `partition_event` emitters reachable at all — without it `values_changing_events` would have had no natural event source.

`excludedIterations` drops from six entries to three. Its doc comment now records the lesson: a live-object *type* is not on its own grounds for exclusion. All three survivors (`FromStorageIteration`, `DataComparisonGradientIteration`, `EmbeddedSimulationRunIteration`) are live-object only as *standalone partitions* — the `data:`, `macros:` and `embedded:` tiers already construct them.

## Breaking changes

Both are removals of things that did nothing:

- **`discrete.NewHawkesProcessIntensityIteration` deleted.** No callers anywhere in the repo (its own test built the struct literal), and its `hawkesPartitionIndex` argument was discarded by `Configure` on the next line. `excitingKernel` is now the exported `ExcitingKernel`, matching every other composable iteration (`.Kernel`, `.JumpDist`, `.Likelihood`, `.Iteration`).
- **`general.ValuesWeightedResamplingIteration.Src` unexported.** `Configure` unconditionally overwrote it; unexporting makes the "no live object here" classification structural rather than incidental.

## Tests

- **`TestMultiPartitionRegistryBehaviourEquivalence`** — extends the data-spec-equals-Go invariant to iterations that read *other* partitions' histories, which the existing single-partition runner cannot reach. It fails if the subject's trajectory never varies, so the comparison cannot quietly become vacuous. Checked empirically first: the resampler genuinely switches between data partitions (19/10 draws over 30 steps), so the RNG path is real rather than a constant series trivially matching itself.
- **`TestNewlyRegisteredIterationsRunFromYaml`** — an 8-partition config exercising all three, loaded and run in-process. Deliberately routed through the YAML loader: yaml.v2 delivers nested mappings as `map[interface{}]interface{}`, which the in-Go spec tests never touch. It asserts the event keys land as the exact floats the iteration switches on — a mis-typed key would make the partition silently fall through to its previous state, which a type check alone cannot see.
- Error paths for both new spec shapes, including that `1` and `1.0` reach the same map key.

Full suite passes. `TestPostgresWritingAndQuerying` fails locally without a DB on :5432 — pre-existing and unrelated.

## Also included

Docs site rebuilt (drops the removed constructor from the generated pages), skill catalogue updated, CHANGELOG entries under Added and Removed, plus in-flight frontpage wording on `docs/README.md`.

> Note: `docs/_pkg/` still names the deleted constructor. That directory is an orphan — last touched Oct 2025, nothing in the repo regenerates it, and it already predates `RegisterDataSource` and `ExecutionStrategy`. The live pipeline writes `docs/pkg/*.html` and is correct. Worth deleting or wiring into `build.sh` separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)