### PR TITLE
Release v0.6.0: stamp changelog

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The stochadex simulation engine, packaged as an installable Claude Code plugin.",
-    "version": "0.5.3"
+    "version": "0.6.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stochadex",
   "description": "Author, run, and analyse a stochastic simulation as a single YAML config for the stochadex engine — no Go, no compilation, no toolchain. Bundles the stochadex-model skill with four validated, converging worked recipes.",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "author": {
     "name": "umbralcalc",
     "email": "umbralcalc@gmail.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ an exact version rather than assume stability across minors.
 
 ## [Unreleased]
 
+## [0.6.0] — 2026-07-23
+
+The release that makes the engine reachable from outside itself. Egress stops being a Go-only
+concern — Arrow, DuckDB and S3 are carried by the released binaries and reachable from config —
+and the CLI plus the `stochadex-model` skill install without a Go toolchain. On the config side,
+the iteration registry closes the last gaps that were not MCTS, so **the decision layer is now
+the only capability that is deliberately Go-only**.
+
+A minor bump rather than a patch because it is breaking twice over: gonum v0.17 is now required,
+and two exported symbols that did nothing were removed.
+
 ### Added
 - **The released binary now carries the integrations: Arrow output everywhere, plus an
   accelerated build with an optimised system BLAS and DuckDB output.** Imports drive
@@ -64,12 +75,6 @@ an exact version rather than assume stability across minors.
   (still two methods) and every existing sink is unaffected; this is what lets a columnar sink
   — which only becomes a readable batch after the last row — work at all.
 
-### Changed
-- **The engine now requires gonum v0.17** (was v0.16), matching the version the Arrow/DuckDB
-  modules already resolved to, so the shipped binary runs the same version the engine's tests
-  cover. The full suite, including every convergence test, passes unchanged.
-
-### Added
 - **Installable as a Claude Code plugin + prebuilt CLI binaries — the distribution layer that makes
   "install a skill next to your agent" real.** The repo is now a plugin marketplace
   (`.claude-plugin/marketplace.json` + `plugin.json`, with the plugin's `skills` pointing at the
@@ -90,7 +95,6 @@ an exact version rather than assume stability across minors.
   resolve to the bundled skill — a broken pointer would otherwise install a plugin that silently
   ships no skill.
 
-### Added
 - **Three more iterations reachable from pure config, leaving MCTS as the only capability that
   is deliberately Go-only.** Auditing the registry's own exclusion list showed two of its four
   non-MCTS entries were misclassified rather than genuinely unreachable:
@@ -116,6 +120,11 @@ an exact version rather than assume stability across minors.
   invariant to iterations that read *other* partitions' histories, which the existing
   single-partition runner could not reach, and it fails if the subject's trajectory never varies
   so the comparison cannot quietly become vacuous.
+
+### Changed
+- **The engine now requires gonum v0.17** (was v0.16), matching the version the Arrow/DuckDB
+  modules already resolved to, so the shipped binary runs the same version the engine's tests
+  cover. The full suite, including every convergence test, passes unchanged.
 
 ### Removed
 - **`discrete.NewHawkesProcessIntensityIteration`** — it had no callers anywhere in the repo
@@ -684,7 +693,8 @@ treat the intermediates as internal, never shipped API.
   stochastic-process formalism (diffusions, Poisson noise, windowed history for noise
   dependencies) before any Go engine existed. The pivot to Go begins Feb 2023.
 
-[Unreleased]: https://github.com/umbralcalc/stochadex/compare/v0.5.3...HEAD
+[Unreleased]: https://github.com/umbralcalc/stochadex/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/umbralcalc/stochadex/compare/v0.5.3...v0.6.0
 [0.5.3]: https://github.com/umbralcalc/stochadex/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/umbralcalc/stochadex/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/umbralcalc/stochadex/compare/v0.5.0...v0.5.1


### PR DESCRIPTION
Rebased onto `main` after #49 merged. Replaces #50, which GitHub pinned to a commit the rebase made unreachable and then refused to reopen.

Merging this is the release decision — tag `v0.6.0` afterwards.

## Why 0.6.0 and not 0.5.4

The versioning policy at the top of the CHANGELOG takes breaking changes in a **minor** bump while pre-1.0. `[Unreleased]` carried two:

- **gonum v0.16 → v0.17** is now a hard requirement
- **two exported symbols removed** in #49 — `discrete.NewHawkesProcessIntensityIteration` and `general.ValuesWeightedResamplingIteration.Src`, both of which did nothing (the constructor discarded its index argument on the next line; the field was overwritten by `Configure`)

A patch bump would misrepresent both.

## Changes

| File | Change |
|---|---|
| `CHANGELOG.md` | `## [Unreleased]` → `## [0.6.0] — 2026-07-23` + release summary; a new empty `[Unreleased]` is retained |
| `CHANGELOG.md` | link refs: `[Unreleased]` → `v0.6.0...HEAD`, new `[0.6.0]: …v0.5.3...v0.6.0` |
| `.claude-plugin/plugin.json` | `0.5.3` → `0.6.0` |
| `.claude-plugin/marketplace.json` | `0.5.3` → `0.6.0` |

The manifest bumps are not optional: `TestPluginManifestsMatchRelease` reads the newest *released* CHANGELOG heading and requires both manifests to match, so stamping the heading alone fails CI. Verified passing locally.

## Cleanup folded in

`[Unreleased]` had accumulated **three separate `### Added` sections** from successive PRs each appending their own, which would have rendered the release notes as three disjoint lists. Consolidated into one `### Added` / `### Changed` / `### Removed`. No bullet text was altered — only the headers they sit under.

## After merge

Tag `v0.6.0` to trigger `.github/workflows/release.yml`, which cross-compiles the CLI for six platforms and attaches binaries to a public GitHub Release. I have deliberately not tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)