### PR TITLE
Replace the retired macos-13 runner label with macos-15-intel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,13 @@ jobs:
           - runner: macos-14      # Apple silicon
             goos: darwin
             goarch: arm64
-          - runner: macos-13      # Intel
+          # macos-15-intel, not macos-13: the macOS 13 image was deprecated in
+          # September 2025 and fully retired that December. A retired label does not
+          # fail the job — nothing ever claims it, so it sits queued until the 24h
+          # limit cancels it, which is how v0.6.0 shipped without this asset.
+          # x86_64 macOS goes away entirely when the macos-15 image retires in
+          # autumn 2027; drop this leg then rather than hunting for another label.
+          - runner: macos-15-intel # Intel
             goos: darwin
             goarch: amd64
           - runner: ubuntu-latest


### PR DESCRIPTION
`v0.6.0`'s release run left one job queued for ~13 hours. It wasn't capacity — `macos-13` is a **retired label**, so no runner can ever claim it.

## What happened

The macOS 13 image was [deprecated 22 Sep 2025 and fully retired by 4–8 Dec 2025](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/). A retired label doesn't fail fast — nothing picks the job up, and it sits queued until the 24h limit cancels it.

`v0.6.0`'s run was this workflow's **first ever execution** (v0.5.3's binaries were attached retroactively), so the label had never actually been exercised. It was stale from the day it was written.

Evidence it's the label rather than luck: every other leg of the same matrix — `macos-14`, `ubuntu-latest`, `ubuntu-24.04-arm` — succeeded within minutes of the same trigger.

## Blast radius

Small, because the workflow was built defensively. `fail-fast: false` plus the create-or-upload publish step meant the other three legs published normally, so **v0.6.0 shipped with 8 of 9 assets**. The only casualty is `stochadex-accel-darwin-amd64`.

Intel Mac users still get the portable `stochadex-darwin-amd64`; what's missing for that platform is the BLAS/DuckDB acceleration tier.

## The fix

`macos-13` → `macos-15-intel`, the free-tier Intel replacement. (`macos-14-large` / `macos-15-large` also work but are billable larger runners.)

The comment also records that [x86_64 macOS disappears entirely when the macos-15 image retires in autumn 2027](https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/) — at that point the leg should be dropped rather than re-pointed at yet another label.

Swept the other workflows while here: every remaining label (`ubuntu-latest`, `macos-14`, `ubuntu-24.04-arm`) is current.

## Deliberately not re-tagging v0.6.0

A tag-triggered run reads the workflow from the tag ref, so `v0.6.0` would still request `macos-13` on a re-run. Getting that asset onto this release would need the tag deleted and re-pushed. Fixing forward instead — this takes effect on the next version tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)