### PR TITLE
Release v0.6.1: stamp changelog

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The stochadex simulation engine, packaged as an installable Claude Code plugin.",
-    "version": "0.6.0"
+    "version": "0.6.1"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stochadex",
   "description": "Author, run, and analyse a stochastic simulation as a single YAML config for the stochadex engine — no Go, no compilation, no toolchain. Bundles the stochadex-model skill with four validated, converging worked recipes.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": {
     "name": "umbralcalc",
     "email": "umbralcalc@gmail.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,25 @@ an exact version rather than assume stability across minors.
 
 ## [Unreleased]
 
+## [0.6.1] — 2026-07-23
+
+### Fixed
+- **The accelerated `darwin/amd64` release asset builds again.** `v0.6.0`'s release run asked
+  for the `macos-13` runner label, which GitHub deprecated in September 2025 and retired that
+  December. A retired label does not fail the job: nothing ever claims it, so it sits queued
+  until the 24-hour limit cancels it — which is why one leg of that run was still pending
+  ~13 hours after the tag. It was the release workflow's *first* execution (`v0.5.3`'s binaries
+  were attached retroactively), so the label had never actually been exercised; it was stale
+  from the day it was written. `fail-fast: false` and the create-or-upload publish step
+  contained the damage: the other three legs published normally, so `v0.6.0` shipped 8 of its
+  9 assets, missing only `stochadex-accel-darwin-amd64`. Intel macOS users still had the
+  portable `stochadex-darwin-amd64` — what was absent for that platform was the BLAS/DuckDB
+  acceleration tier. The label is now `macos-15-intel`, the free-tier Intel replacement, and
+  this release is also the proof that it resolves: a tag-triggered run reads the workflow from
+  the tag ref, so the fix could not be validated by the pull request that made it. x86_64 macOS
+  disappears entirely when the macos-15 image retires in autumn 2027, at which point the leg
+  should be dropped rather than re-pointed at another label.
+
 ## [0.6.0] — 2026-07-23
 
 The release that makes the engine reachable from outside itself. Egress stops being a Go-only
@@ -693,7 +712,8 @@ treat the intermediates as internal, never shipped API.
   stochastic-process formalism (diffusions, Poisson noise, windowed history for noise
   dependencies) before any Go engine existed. The pivot to Go begins Feb 2023.
 
-[Unreleased]: https://github.com/umbralcalc/stochadex/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/umbralcalc/stochadex/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/umbralcalc/stochadex/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/umbralcalc/stochadex/compare/v0.5.3...v0.6.0
 [0.5.3]: https://github.com/umbralcalc/stochadex/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/umbralcalc/stochadex/compare/v0.5.1...v0.5.2


### PR DESCRIPTION
Cuts the runner-label fix (#52) as `v0.6.1`. Merging this is the release decision — tag `v0.6.1` afterwards.

## Why a patch, not a minor

`[Unreleased]` held nothing but #52, which is neither a feature nor a breaking change — the pre-1.0 policy at the top of the CHANGELOG reserves minor bumps for the latter. What this restores is a release asset that should have shipped with `v0.6.0`, which is textbook patch territory. A `0.7.0` release page would have read as one infrastructure line with no features behind it.

## Changes

| File | Change |
|---|---|
| `CHANGELOG.md` | new `## [0.6.1] — 2026-07-23` with a `### Fixed` entry; empty `[Unreleased]` retained |
| `CHANGELOG.md` | link refs: `[Unreleased]` → `v0.6.1...HEAD`, new `[0.6.1]: …v0.6.0...v0.6.1` |
| `.claude-plugin/plugin.json` | `0.6.0` → `0.6.1` |
| `.claude-plugin/marketplace.json` | `0.6.0` → `0.6.1` |

Manifest bumps are mandatory — `TestPluginManifestsMatchRelease` pins both to the newest released CHANGELOG heading. Verified passing locally.

## This release is also the test

`v0.6.0` requested the retired `macos-13` label; a retired label doesn't fail, it queues until the 24h limit cancels it, so that release published 8 of 9 assets. #52 repointed it at `macos-15-intel`.

**#52's own CI could not validate that**, because a tag-triggered run reads the workflow from the tag ref. `v0.6.1` is the first execution of the corrected matrix.

So when the tag goes up, the thing to watch is the `accelerated (macos-15-intel, darwin, amd64)` job specifically. If that label were also wrong, the symptom is a job that *hangs* rather than fails — indistinguishable from "still building" until the 24-hour cancel. A green run here means the complete 9-asset matrix, including the `stochadex-accel-darwin-amd64` that `v0.6.0` never got.

🤖 Generated with [Claude Code](https://claude.com/claude-code)