### PR TITLE
Release v0.7.0: stamp changelog

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The stochadex simulation engine, packaged as an installable Claude Code plugin.",
-    "version": "0.6.1"
+    "version": "0.7.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stochadex",
   "description": "Author, run, and analyse a stochastic simulation as a single YAML config for the stochadex engine — no Go, no compilation, no toolchain. Bundles the stochadex-model skill with four validated, converging worked recipes.",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "author": {
     "name": "umbralcalc",
     "email": "umbralcalc@gmail.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ an exact version rather than assume stability across minors.
 
 ## [Unreleased]
 
+## [0.7.0] — 2026-07-24
+
+Stochadex ships as a container. A published multi-arch OCI image on GHCR carries the fully
+accelerated CLI, which is the unit cloud-native pipelines actually compose: a Kubernetes Job,
+an Argo step or a Cloud Run Job takes an image, not a binary. The two ad-hoc Dockerfiles are
+gone, replaced by one multi-stage `Dockerfile` and a `compose.yaml`, and the running-with-configs
+guide is folded into the quickstart so the Go and YAML routes read as one document.
+
+A minor bump rather than a patch because it is breaking: the public `Dockerfile.stochadex` and
+`Dockerfile.postgres` are removed, and `https://stochadex.github.io/pkg/configs.html` no longer
+resolves.
+
 ### Added
 - **A published OCI image (`ghcr.io/umbralcalc/stochadex`), multi-arch for `linux/amd64`
   and `linux/arm64`.** A binary is not the unit cloud-native pipelines compose — a
@@ -761,7 +773,8 @@ treat the intermediates as internal, never shipped API.
   stochastic-process formalism (diffusions, Poisson noise, windowed history for noise
   dependencies) before any Go engine existed. The pivot to Go begins Feb 2023.
 
-[Unreleased]: https://github.com/umbralcalc/stochadex/compare/v0.6.1...HEAD
+[Unreleased]: https://github.com/umbralcalc/stochadex/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/umbralcalc/stochadex/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/umbralcalc/stochadex/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/umbralcalc/stochadex/compare/v0.5.3...v0.6.0
 [0.5.3]: https://github.com/umbralcalc/stochadex/compare/v0.5.2...v0.5.3


### PR DESCRIPTION
Stamps `[Unreleased]` (the container work from #54) as `v0.7.0`. Merging this is the release decision; tag `v0.7.0` afterwards to trigger the build.

## Why 0.7.0, not 0.6.2

The pre-1.0 policy takes breaking changes in a minor bump. `[Unreleased]` carried two:

- `Dockerfile.stochadex` and `Dockerfile.postgres` removed (the quickstart used to tell people to `docker build -f Dockerfile.stochadex`)
- `https://stochadex.github.io/pkg/configs.html` no longer resolves

Plus a whole new distribution channel (the GHCR image), which is minor-worthy on its own.

## Changes

| File | Change |
|---|---|
| `CHANGELOG.md` | `## [Unreleased]` → `## [0.7.0] — 2026-07-24` + summary; empty `[Unreleased]` retained |
| `CHANGELOG.md` | link refs: `[Unreleased]` → `v0.7.0...HEAD`, new `[0.7.0]: …v0.6.1...v0.7.0` |
| `.claude-plugin/plugin.json` | `0.6.1` → `0.7.0` |
| `.claude-plugin/marketplace.json` | `0.6.1` → `0.7.0` |

`TestPluginManifestsMatchRelease` pins both manifests to the newest released CHANGELOG heading, so stamping the heading without bumping them fails CI. Verified passing locally.

## After merge

Tag `v0.7.0`. This is the **first** run of the new `image` / `image-manifest` jobs in `release.yml`, which push to GHCR — until then `ghcr.io/umbralcalc/stochadex:latest` (already advertised on the front page) 404s. The publish path is a tag-only code path, so like the macos-13 case it cannot be exercised by this PR's CI; watch those two jobs specifically. The `linux/amd64` leg and the manifest merge are untested — I could only verify arm64 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)