### PR TITLE
Run/image provenance + bind-mount UID contract

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,7 +220,9 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
-          build-args: VERSION=${{ env.VERSION }}
+          build-args: |
+            VERSION=${{ env.VERSION }}
+            REVISION=${{ github.sha }}
           outputs: type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true,push=true
           provenance: true
           sbom: true
@@ -306,3 +308,29 @@ jobs:
           # And it must actually step a config, not merely start.
           docker run --rm --platform linux/amd64 -v "$PWD:/work" "${IMAGE}:${VERSION}" \
             --config cfg/example_data_only_config.yaml | tail -5
+
+          # Provenance binding: a run must stamp which build produced it, and echo the
+          # image digest a deployer injects. Resolve this manifest's digest and prove
+          # the run reports it — this is the containerised claim-to-test binding, so a
+          # silent regression in it must fail the release, not surface later as an
+          # unreproducible result.
+          digest=$(docker buildx imagetools inspect "${IMAGE}:${VERSION}" \
+            --format '{{.Manifest.Digest}}')
+          echo "manifest digest: ${digest}"
+          prov=$(docker run --rm --platform linux/amd64 \
+            -e STOCHADEX_IMAGE_DIGEST="${digest}" -v "$PWD:/work" "${IMAGE}:${VERSION}" \
+            --config cfg/example_data_only_config.yaml 2>&1 >/dev/null \
+            | grep '^stochadex-run ')
+          echo "provenance line: ${prov}"
+          case "${prov}" in
+            *"version=${VERSION}"*) ;;
+            *) echo "provenance line missing the expected version"; exit 1 ;;
+          esac
+          case "${prov}" in
+            *"image=${digest}"*) ;;
+            *) echo "provenance line did not echo the injected image digest"; exit 1 ;;
+          esac
+          case "${prov}" in
+            *"revision=${{ github.sha }}"*) ;;
+            *) echo "provenance line missing the build revision"; exit 1 ;;
+          esac

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,27 @@ an exact version rather than assume stability across minors.
 
 ## [Unreleased]
 
+### Added
+- **Per-run provenance line.** Every CLI run now stamps a single machine-parseable
+  `stochadex-run version=… os=… arch=… revision=… features=… image=…` line to **stderr**
+  before it starts, so a job log ties whatever the run produces to the exact build that
+  produced it — the containerised counterpart of the claim-to-test binding. It reports the
+  build version, git revision (embedded VCS info for the binaries; stamped in for the image,
+  whose context excludes `.git`) and compiled-in features, and echoes an image digest a
+  deployer injects via `STOCHADEX_IMAGE_DIGEST` (a binary cannot know the digest of the image
+  that wraps it). Sent to stderr so it never corrupts a `stdout` data output.
+- **OCI provenance labels on the published image** (`org.opencontainers.image.source`,
+  `.revision`, `.version`, `.title`, `.description`, `.licenses`), fed from `VERSION`/`REVISION`
+  build-args. `source` is what makes GHCR link the package back to this repository; `revision`
+  pins the exact commit. The release workflow now passes the commit SHA and its manifest
+  smoke-test asserts the run echoes the resolved image digest.
+
+### Documented
+- **Bind-mount write-permission contract.** The image runs as non-root uid `65532`, so a
+  host output directory mounted at `/work` must be writable by that uid or egress fails with
+  "permission denied" on native Linux (invisible on Docker Desktop). The `Dockerfile` and
+  `compose.yaml` now spell out the `--user "$(id -u):$(id -g)"` / pre-chown escape hatches.
+
 ## [0.7.0] — 2026-07-24
 
 Stochadex ships as a container. A published multi-arch OCI image on GHCR carries the fully

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,12 @@
 ARG GO_VERSION=1.25
 ARG DEBIAN_RELEASE=bookworm
 
+# VERSION is the human tag (e.g. 0.7.0); REVISION is the git commit it was built from.
+# Both are passed by the release workflow and become OCI labels + a compiled-in
+# version stamp, so a pulled image can be traced back to an exact source commit.
+ARG VERSION=dev
+ARG REVISION=unknown
+
 # ---- build -------------------------------------------------------------------
 FROM golang:${GO_VERSION}-${DEBIAN_RELEASE} AS build
 
@@ -42,10 +48,14 @@ WORKDIR /src
 # go.mod-only cache layer.
 COPY . .
 
+# .git is excluded from the build context (see .dockerignore), so the toolchain
+# cannot embed the revision itself — it is stamped in explicitly from the REVISION
+# build-arg instead, and the run provenance line reports it (api.BuildRevision).
 ARG VERSION=dev
+ARG REVISION=unknown
 RUN cd cmd/stochadex-full \
  && CGO_ENABLED=1 CGO_LDFLAGS="-lopenblas" go build -trimpath \
-      -ldflags "-s -w -X main.version=${VERSION}" \
+      -ldflags "-s -w -X main.version=${VERSION} -X main.revision=${REVISION}" \
       -tags "cblas duckdb_arrow" \
       -o /out/stochadex .
 
@@ -79,6 +89,28 @@ RUN apt-get update \
 
 COPY --from=build /out/stochadex /usr/local/bin/stochadex
 
+# OCI provenance labels, fed from the build-args. org.opencontainers.image.source is
+# the load-bearing one: it is what makes GHCR link this package back to the repository
+# and what a registry UI reads to show where an image came from. revision + version
+# pin the exact source a pulled image was built from — the provenance the release
+# workflow's SBOM/attestation complement rather than replace.
+ARG VERSION=dev
+ARG REVISION=unknown
+LABEL org.opencontainers.image.title="stochadex" \
+      org.opencontainers.image.description="Accelerated stochadex CLI — data-path simulation engine for cloud-native pipelines" \
+      org.opencontainers.image.source="https://github.com/umbralcalc/stochadex" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${REVISION}"
+
+# The same version/revision as env vars, so a running container can report its own
+# provenance without shelling out to inspect labels. STOCHADEX_IMAGE_DIGEST is left
+# UNSET on purpose: the digest is a hash of this image and so cannot be known while
+# building it. A deployer that resolved an image@sha256:… reference passes that digest
+# in via this variable, and the run provenance line (api.LogRunProvenance) echoes it.
+ENV STOCHADEX_VERSION="${VERSION}" \
+    STOCHADEX_REVISION="${REVISION}"
+
 # The websocket port used by cfg/socket.yaml when --socket is passed.
 EXPOSE 2112
 
@@ -86,7 +118,17 @@ EXPOSE 2112
 # to mount one directory.
 WORKDIR /work
 
-# Non-root by default; a simulation never needs privilege.
+# Non-root by default; a simulation never needs privilege. UID 65532 is the
+# conventional "nonroot" id (matches distroless), so it is predictable for wrappers
+# that pre-create or chown a mount.
+#
+# BIND-MOUNT CONTRACT: because the process runs as 65532, a host directory mounted at
+# /work for output must be writable by that uid, or CSV/JSON egress fails with
+# "permission denied". On Docker Desktop (macOS/Windows) the file-sharing layer maps
+# ownership and this is invisible; on native Linux it is not. Two escape hatches:
+#   - run as the host user:   docker run --user "$(id -u):$(id -g)" -v "$PWD:/work" …
+#   - or pre-chown the mount:  chown 65532:65532 <output-dir>
+# Read-only inputs never hit this — only directories the run writes into.
 RUN useradd --uid 65532 --user-group --home-dir /work --no-create-home stochadex \
  && chown stochadex:stochadex /work
 USER stochadex

--- a/cmd/stochadex-full/main.go
+++ b/cmd/stochadex-full/main.go
@@ -35,6 +35,12 @@ import (
 // variable, not a placeholder: without one the -X flag silently does nothing.
 var version = "dev"
 
+// revision is the git commit, stamped with -ldflags "-X main.revision=<sha>" only by
+// builds that cannot embed VCS info themselves — the OCI image, whose context excludes
+// .git. It stays empty for the binary releases, which the toolchain stamps
+// automatically from the repository (see api.BuildRevision).
+var revision = ""
+
 func main() {
 	// Handled before ArgParse so it needs no config and cannot be refused by argument
 	// validation — `--version` must answer even on a machine with nothing set up.
@@ -44,6 +50,12 @@ func main() {
 			return
 		}
 	}
+	// Hand this build's version stamp and compiled-in feature list to the engine so
+	// the per-run provenance line (api.LogRunProvenance) reports the accelerated CLI
+	// as what actually ran, not the base engine's "dev"/no-features default.
+	api.BuildVersion = version
+	api.BuildFeatures = features
+	api.BuildRevision = revision
 	api.RunWithParsedArgs(api.ArgParse())
 }
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -34,6 +34,10 @@ services:
   # One-shot runs: `docker compose run --rm stochadex --config <path>`.
   # The repo is mounted at /work (the image's WORKDIR) so configs and any CSV or
   # JSON egress land back on the host.
+  # On native Linux the container's non-root uid (65532) may not be able to write
+  # into a host-owned mount — see the BIND-MOUNT CONTRACT note in the Dockerfile. Add
+  # `user: "${UID}:${GID}"` here (with UID/GID exported) if a config writes output and
+  # you hit "permission denied".
   # Deliberately no depends_on: most runs write nowhere near Postgres, and making
   # every config run boot a database first is friction for the common case. Bring
   # the DB up explicitly when a config or test actually needs it.

--- a/pkg/api/run.go
+++ b/pkg/api/run.go
@@ -282,6 +282,14 @@ func checkGoToolchain(lookPath func(string) (string, error)) error {
 // toolchain; any config that names Go is run by generating a temporary main program
 // and executing it via go run, which is what enables dynamic iteration wiring.
 func RunWithParsedArgs(args ParsedArgs) {
+	// Stamp the run's provenance to stderr before anything else, so the very first
+	// line of a job log ties whatever this run produces to the exact build (and,
+	// when the orchestrator supplies it, the exact image) that produced it. It is
+	// emitted once per invocation here — the codegen path below execs a freshly
+	// compiled program that drives the engine directly, not through this function,
+	// so there is no double stamp.
+	LogRunProvenance(os.Stderr)
+
 	// A fully-data config, or any macros: config (analysis runs are always
 	// in-process and use pkg/analysis, which the generated program does not import),
 	// runs directly.

--- a/pkg/api/run_provenance.go
+++ b/pkg/api/run_provenance.go
@@ -1,0 +1,107 @@
+package api
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"runtime/debug"
+	"sort"
+	"strings"
+)
+
+// BuildVersion and BuildFeatures describe the executable orchestrating a run. They
+// default to the base engine's view — "dev", no optional features — and are
+// overwritten by a CLI's main package before RunWithParsedArgs is called.
+// cmd/stochadex-full sets them from its own -ldflags version stamp and its
+// compiled-in feature list, so a provenance line reports exactly the binary that ran
+// rather than a generic default.
+var (
+	BuildVersion  = "dev"
+	BuildFeatures []string
+)
+
+// BuildRevision is the git commit a build was stamped with via -ldflags, for builds
+// that cannot read it from the embedded Go build info. The OCI image is exactly this
+// case: its build context excludes .git (see .dockerignore), so the toolchain has no
+// VCS to read and the release workflow passes the commit in explicitly instead. When
+// set it wins over the embedded build info; when empty the build info is used, which
+// is how the binary releases (built with .git present) report their revision.
+var BuildRevision = ""
+
+// imageDigestEnv names the environment variable an orchestrator injects with the
+// digest of the OCI image a run is executing from. A binary cannot know the digest
+// of the image that wraps it — the digest is a hash of the image, so nothing
+// knowable at build time can be baked in as the answer. The image instead carries
+// its git revision (via the Go build info below) and its human tag (STOCHADEX_VERSION
+// / the OCI version label), and a deployer that resolved an image@sha256:… reference
+// can close the loop by passing that digest through this variable. When it is set,
+// the run echoes it back; when it is not, the version and revision still pin the
+// source that produced a result.
+const imageDigestEnv = "STOCHADEX_IMAGE_DIGEST"
+
+// LogRunProvenance writes a single machine-parseable provenance line to w at the
+// start of a run. It is deliberately sent to stderr, never stdout, so it never
+// corrupts a data output (StdoutOutputFunction writes result rows to stdout); in a
+// containerised run — the image's whole reason for being — the job log that captures
+// stderr is the durable record a result is reproduced against. The line is
+// space-separated key=value pairs so it survives log aggregation and greps cleanly:
+//
+//	stochadex-run version=v0.7.0 os=linux arch=arm64 revision=d44bcd8… features=arrow,cblas,duckdb,postgres,s3 image=sha256:abc…
+//
+// revision and dirty come from the Go build info the toolchain embeds automatically
+// (buildvcs, on by default); image= is present only when STOCHADEX_IMAGE_DIGEST is
+// set. A result is only reproducible if you know which build produced it, and this
+// line is that binding for the CLI/image surface.
+func LogRunProvenance(w io.Writer) {
+	fields := []string{
+		"stochadex-run",
+		"version=" + BuildVersion,
+		"os=" + runtime.GOOS,
+		"arch=" + runtime.GOARCH,
+	}
+	if BuildRevision != "" {
+		// Explicitly stamped (the image path): trust it as-is. The build info is
+		// unavailable here, so there is no dirty flag to report.
+		fields = append(fields, "revision="+BuildRevision)
+	} else if revision, dirty, ok := vcsRevision(); ok {
+		fields = append(fields, "revision="+revision)
+		if dirty {
+			// A working tree with uncommitted changes cannot be pinned to a commit,
+			// so say so rather than let the revision imply a clean build.
+			fields = append(fields, "dirty=true")
+		}
+	}
+	if len(BuildFeatures) > 0 {
+		feats := append([]string(nil), BuildFeatures...)
+		sort.Strings(feats)
+		fields = append(fields, "features="+strings.Join(feats, ","))
+	}
+	if digest := os.Getenv(imageDigestEnv); digest != "" {
+		fields = append(fields, "image="+digest)
+	}
+	fmt.Fprintln(w, strings.Join(fields, " "))
+}
+
+// vcsRevision reads the git revision and dirty flag the Go toolchain embeds in the
+// binary at build time. ok is false when the build carried no VCS info (e.g. built
+// with -buildvcs=false, or from outside a repository), in which case the caller
+// simply omits the field.
+func vcsRevision() (revision string, dirty bool, ok bool) {
+	info, available := debug.ReadBuildInfo()
+	if !available {
+		return "", false, false
+	}
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			revision = setting.Value
+		case "vcs.modified":
+			dirty = setting.Value == "true"
+		}
+	}
+	if revision == "" {
+		return "", false, false
+	}
+	return revision, dirty, true
+}

--- a/pkg/api/run_provenance_test.go
+++ b/pkg/api/run_provenance_test.go
@@ -1,0 +1,82 @@
+package api
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// withBuildInfo swaps the package build-info globals for the duration of a test and
+// restores them, so cases cannot leak state into one another (or into other tests
+// that read LogRunProvenance's output).
+func withBuildInfo(t *testing.T, version, revision string, features []string) {
+	t.Helper()
+	origV, origR, origF := BuildVersion, BuildRevision, BuildFeatures
+	t.Cleanup(func() {
+		BuildVersion, BuildRevision, BuildFeatures = origV, origR, origF
+	})
+	BuildVersion, BuildRevision, BuildFeatures = version, revision, features
+}
+
+func TestLogRunProvenance(t *testing.T) {
+	t.Run("reports version, os and arch on a single line", func(t *testing.T) {
+		withBuildInfo(t, "v1.2.3", "", nil)
+		var buf bytes.Buffer
+		LogRunProvenance(&buf)
+		line := buf.String()
+		if strings.Count(line, "\n") != 1 {
+			t.Fatalf("expected exactly one line, got %q", line)
+		}
+		for _, want := range []string{"stochadex-run", "version=v1.2.3", "os=", "arch="} {
+			if !strings.Contains(line, want) {
+				t.Errorf("provenance line %q missing %q", line, want)
+			}
+		}
+	})
+
+	t.Run("omits image and features when unset", func(t *testing.T) {
+		withBuildInfo(t, "dev", "", nil)
+		var buf bytes.Buffer
+		LogRunProvenance(&buf)
+		line := buf.String()
+		if strings.Contains(line, "image=") {
+			t.Errorf("expected no image= without %s, got %q", imageDigestEnv, line)
+		}
+		if strings.Contains(line, "features=") {
+			t.Errorf("expected no features= with none compiled in, got %q", line)
+		}
+	})
+
+	t.Run("echoes an injected image digest", func(t *testing.T) {
+		withBuildInfo(t, "v1.2.3", "", nil)
+		t.Setenv(imageDigestEnv, "sha256:deadbeef")
+		var buf bytes.Buffer
+		LogRunProvenance(&buf)
+		if !strings.Contains(buf.String(), "image=sha256:deadbeef") {
+			t.Errorf("provenance line %q did not echo injected digest", buf.String())
+		}
+	})
+
+	t.Run("reports a stamped revision verbatim", func(t *testing.T) {
+		withBuildInfo(t, "v1.2.3", "abc123", nil)
+		var buf bytes.Buffer
+		LogRunProvenance(&buf)
+		line := buf.String()
+		if !strings.Contains(line, "revision=abc123") {
+			t.Errorf("provenance line %q missing stamped revision", line)
+		}
+		// A stamped revision comes with no build info, so nothing can claim dirty.
+		if strings.Contains(line, "dirty=") {
+			t.Errorf("stamped revision must not carry a dirty flag, got %q", line)
+		}
+	})
+
+	t.Run("lists compiled-in features sorted", func(t *testing.T) {
+		withBuildInfo(t, "v1.2.3", "", []string{"s3", "arrow", "postgres"})
+		var buf bytes.Buffer
+		LogRunProvenance(&buf)
+		if !strings.Contains(buf.String(), "features=arrow,postgres,s3") {
+			t.Errorf("expected sorted features, got %q", buf.String())
+		}
+	})
+}


### PR DESCRIPTION
Follow-up to the OCI image work (#54), acting on three provenance/filesystem-contract suggestions. Most of the original suggestions were already shipped in #54; this PR closes the genuine gaps that were left.

## What was already done (no change needed)
- **Filesystem contract** — `/work` WORKDIR, single mount, non-root uid `65532`. Fixed.
- **Tags** — SemVer `:${VERSION}` + `:latest` (prerelease excluded), multi-arch amd64+arm64 native, plus `provenance: true` + `sbom: true` SLSA attestations.

## What this PR adds

### 1. Per-run provenance line (the real gap)
Outputs carried no provenance stamp — a result file couldn't tell you which build produced it. `RunWithParsedArgs` now emits one machine-parseable line to **stderr** at run start:

```
stochadex-run version=v0.7.0 os=linux arch=arm64 revision=d44bcd8… features=arrow,cblas,duckdb,postgres,s3 image=sha256:abc…
```

- **stderr, never stdout** — so it never corrupts a `stdout` data output.
- **revision** — embedded VCS info for the binary releases; stamped via `-ldflags` for the image, whose build context excludes `.git` (`.dockerignore`).
- **image digest** — a binary can't know the digest of the image wrapping it (the digest is a hash of the image), so it's echoed from `STOCHADEX_IMAGE_DIGEST`, which a deployer/orchestrator injects.
- Emitted once per invocation (the codegen path execs a fresh program that drives the engine directly, not through this function).

### 2. OCI provenance labels
The Dockerfile set zero labels, so GHCR couldn't auto-link the package to the repo. Added `org.opencontainers.image.source/revision/version/title/description/licenses` fed from `VERSION`/`REVISION` build-args. The release workflow now passes `github.sha`, and the manifest smoke-test asserts the run echoes the resolved manifest digest + version + revision — a regression in the binding fails the release.

### 3. Documented the bind-mount UID contract
Running as uid `65532` means a host output mount must be writable by that uid or egress fails with "permission denied" on native Linux (invisible on Docker Desktop). Dockerfile + compose.yaml now spell out the `--user "$(id -u):$(id -g)"` / pre-chown escape hatches.

## Testing
- New `pkg/api/run_provenance_test.go` (version/os/arch line, feature sorting, digest echo, stamped-revision-has-no-dirty, omissions when unset).
- `go test ./pkg/...` green; both CLIs verified end-to-end (base reports `version=dev` + buildvcs revision + `dirty=true`; full CLI reports stamped version/revision/features + echoed digest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)