### PR TITLE
Release v0.8.0: stamp changelog

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The stochadex simulation engine, packaged as an installable Claude Code plugin.",
-    "version": "0.7.0"
+    "version": "0.8.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stochadex",
   "description": "Author, run, and analyse a stochastic simulation as a single YAML config for the stochadex engine — no Go, no compilation, no toolchain. Bundles the stochadex-model skill with four validated, converging worked recipes.",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "author": {
     "name": "umbralcalc",
     "email": "umbralcalc@gmail.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ an exact version rather than assume stability across minors.
 
 ## [Unreleased]
 
+## [0.8.0] — 2026-07-24
+
+Provenance for the container surface. Every CLI run now stamps a one-line, machine-parseable
+record of the build that produced it to stderr, and the published image carries OCI labels and a
+git revision so a pulled image traces back to an exact commit — the containerised counterpart of
+the engine's claim-to-test binding. A binary cannot know the digest of the image that wraps it, so
+the run echoes one a deployer injects via `STOCHADEX_IMAGE_DIGEST`, and the release's manifest
+smoke-test asserts that echo end-to-end.
+
+A minor rather than a patch: the per-run provenance line and the image labels are new
+backward-compatible behaviour, which SemVer classes as a minor bump.
+
 ### Added
 - **Per-run provenance line.** Every CLI run now stamps a single machine-parseable
   `stochadex-run version=… os=… arch=… revision=… features=… image=…` line to **stderr**


### PR DESCRIPTION
Stamps the `[Unreleased]` provenance work (#56) into `[0.8.0] — 2026-07-24` and bumps both plugin manifests (`plugin.json`, `marketplace.json`) to match, which `TestPluginManifestsMatchRelease` pins to the newest released CHANGELOG heading.

**Contents of v0.8.0** (all from #56):
- Per-run provenance line to stderr (`stochadex-run version=… revision=… features=… image=…`).
- OCI provenance labels on the published image + a stamped git revision.
- Documented bind-mount UID write-permission contract.

**Minor, not patch:** the provenance line and image labels are new backward-compatible behaviour → SemVer minor.

Merge this, then push the `v0.8.0` tag to trigger `release.yml` (binaries + the labeled multi-arch GHCR image, whose manifest smoke-test verifies the digest-echo end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)