### PR TITLE
Release v0.9.0: stamp changelog

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The stochadex simulation engine, packaged as an installable Claude Code plugin.",
-    "version": "0.8.0"
+    "version": "0.9.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stochadex",
   "description": "Author, run, and analyse a stochastic simulation as a single YAML config for the stochadex engine — no Go, no compilation, no toolchain. Bundles the stochadex-model skill with four validated, converging worked recipes.",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "author": {
     "name": "umbralcalc",
     "email": "umbralcalc@gmail.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ an exact version rather than assume stability across minors.
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-07-24
+
 Removes the Go-expression config path entirely: the YAML API is now a single data
 surface. A component is named by `{type: ...}` from the framework registry, a partition's
 bespoke maths is written as `expressions:`, and everything resolves and runs in-process with


### PR DESCRIPTION
Stamps the `[Unreleased]` section as **[0.9.0] — 2026-07-24** (the Go-expression config path removal, #58) and bumps the `.claude-plugin` manifests to 0.9.0. Tag `v0.9.0` follows on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)