### PR TITLE
Release v0.10.0: stamp changelog

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The stochadex simulation engine, packaged as an installable Claude Code plugin.",
-    "version": "0.9.0"
+    "version": "0.10.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stochadex",
   "description": "Author, run, and analyse a stochastic simulation as a single YAML config for the stochadex engine — no Go, no compilation, no toolchain. Bundles the stochadex-model skill with four validated, converging worked recipes.",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "author": {
     "name": "umbralcalc",
     "email": "umbralcalc@gmail.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ an exact version rather than assume stability across minors.
 
 ## [Unreleased]
 
+## [0.10.0] — 2026-07-24
+
 ### Added
 
 - **ONNX inference partition** (`pkg/onnx`, opt-in module). Run a frozen ONNX model —


### PR DESCRIPTION
Stamps the `[Unreleased]` section as **`[0.10.0]` — 2026-07-24** and bumps the plugin manifests (`plugin.json`, `marketplace.json`) `0.9.0` → `0.10.0`. Follows the same minimal convention as the v0.9.0 release (#59): changelog header insert + manifest bumps only.

## What's in v0.10.0

- **ONNX inference partition** (`pkg/onnx`, opt-in module) — run a frozen ONNX model behind an `Iteration`; new `api.RegisterIteration` downstream hook. (#60)
- **Single CLI** — `cmd/stochadex-full` renamed to `cmd/stochadex`; the engine module is now library-only. **Breaking**: the `…/cmd/stochadex-full` module path is gone, and `go install …/cmd/stochadex@latest` no longer resolves (the CLI is a nested module). (#61)

The breaking change is why this is a **minor** bump under the repo's `v0.x` policy.

## After merge

Tag `v0.10.0` on the merge commit to trigger the release workflow (binary + image build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)