### PR TITLE
CI: cache image builds with mode=min, not mode=max

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,17 @@ jobs:
           load: true
           tags: stochadex:ci
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # mode=min, NOT mode=max. mode=max caches every intermediate stage of the
+          # multi-stage build; on a job that runs on every PR push and every merge,
+          # that accumulated 3.9 GB of buildkit blobs across 71 cache entries and —
+          # together with the release workflow's share — pushed the repo past the
+          # 10 GB per-repo cache cap. Over the cap GitHub evicts least-recently-used
+          # entries, which is how a ~600 MB setup-go cache that actually pays for
+          # itself gets thrown away to make room for intermediate layers of an image
+          # built with push: false and immediately discarded. mode=min caches the
+          # final layers only — enough to warm-start this build, small enough to
+          # coexist with the caches that matter.
+          cache-to: type=gha,mode=min
       # The image is the accelerated CLI, so assert the integrations are actually in
       # it. --version self-reports the feature set, which makes this a cheap and
       # exact check: a dropped build tag or an unlinked library would otherwise only

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,7 +227,16 @@ jobs:
           provenance: true
           sbom: true
           cache-from: type=gha,scope=${{ matrix.slug }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.slug }}
+          # mode=min for the same reason as ci.yml, but the arithmetic here is worse.
+          # A cache written from refs/tags/vX can only be restored by that same tag or
+          # by the default branch — sibling tags cannot read each other. So every
+          # release wrote ~1.1 GB that no *later* release can ever restore: v0.8.0,
+          # v0.9.0 and v0.10.0 were each sitting on their own copy, 3.07 GB of the
+          # repo's 10 GB cap, none of it reachable by the next release. The only real
+          # beneficiary is a re-run of the tag that wrote it — worth keeping (a failed
+          # manifest step on an expensive multi-arch QEMU build is exactly the case),
+          # but worth keeping cheaply. mode=min preserves the retry warm-start.
+          cache-to: type=gha,mode=min,scope=${{ matrix.slug }}
       - name: Export the digest
         env:
           DIGEST: ${{ steps.build.outputs.digest }}


### PR DESCRIPTION
## The problem

`umbralcalc/stochadex` was sitting at **10.54 GB of active Actions cache across 149 entries** — past the **10 GB per-repo cap**. Over the cap GitHub evicts least-recently-used entries, so the cache stops being a cache: the 596 MB `setup-go-Linux` and 389 MB `setup-go-macOS` entries — the two that pay for themselves on *every* run — get evicted to make room for intermediate layers of images that were already discarded.

## The cause

`mode=max` stores every intermediate stage of the multi-stage build, not just the final layers. **Both** image jobs used it. Split by producing workflow:

| Source | Entries | Size |
|---|---:|---:|
| `release.yml` (tag refs) | 67 | 3.07 GB |
| `ci.yml` (pull + main) | 71 | 3.94 GB |
| `setup-go` / `binfmt` | 11 | 3.53 GB ← the ones worth keeping |

**`ci.yml`** is the obvious one: it runs on every PR push and every merge, with `push: false`, so the image is discarded immediately.

**`release.yml` is the worse one, and it isn't obvious.** GitHub scopes cache *reads* to the current ref plus the default branch, so a cache written from `refs/tags/vX` can never be restored by a sibling tag. Each release was holding its own copy that no later release could ever read:

```
refs/heads/refs/tags/v0.8.0    13 entries   0.85 GB
refs/heads/refs/tags/v0.9.0    27 entries   1.11 GB
refs/heads/refs/tags/v0.10.0   27 entries   1.11 GB
```

That's 3.07 GB of the cap, **growing by ~1.1 GB per release**, with the only real beneficiary being a re-run of the tag that wrote it.

## The change

`mode=max` → `mode=min` in both jobs. `mode=min` keeps the final layers, which is all `ci.yml` needs to warm-start and all `release.yml` needs to make a retry cheap — a failed manifest step on an expensive multi-arch QEMU build is exactly that case, and it's preserved.

## Scope

- **No billing impact.** The repo is public; Actions cache is free and doesn't appear on the bill. This is purely about keeping the cache useful and CI fast.
- The existing 138 blob/index entries are being pruned separately via the caches API for immediate relief; this PR is what stops it recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)