### PR TITLE
Release v0.11.0: stamp changelog

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The stochadex simulation engine, packaged as an installable Claude Code plugin.",
-    "version": "0.10.0"
+    "version": "0.11.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stochadex",
   "description": "Author, run, and analyse a stochastic simulation as a single YAML config for the stochadex engine — no Go, no compilation, no toolchain. Bundles the stochadex-model skill with four validated, converging worked recipes.",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "author": {
     "name": "umbralcalc",
     "email": "umbralcalc@gmail.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ an exact version rather than assume stability across minors.
 
 ## [Unreleased]
 
+## [0.11.0] — 2026-07-25
+
 ### Changed
 
 - **BREAKING: `pkg/analysis` split into `pkg/analysis` + `pkg/macros`.** The package was


### PR DESCRIPTION
Stamps `[Unreleased]` as **`[0.11.0]` — 2026-07-25** and bumps the two plugin manifests. Same three-file shape as [the v0.10.0 release](https://github.com/umbralcalc/stochadex/commit/fc762d1).

## Why 0.11.0 and not 0.10.1

The `pkg/analysis` split is a **breaking change for Go callers**. Under the project's stated versioning policy — a `v0.x` project makes breaking changes in a *minor* bump — this is a minor.

## What's in the release

**`pkg/analysis` → `pkg/analysis` + `pkg/macros`** (#64). The package was doing two unrelated jobs behind one import; now `pkg/analysis` is the data layer and `pkg/macros` is the `Applied*` spec → partitions tier. Dependency runs strictly one way: `pkg/api → pkg/macros → pkg/analysis → pkg/simulator`.

Migration is an import addition plus `analysis.X` → `macros.X` for the moved names — full inventory in the changelog entry. **No signatures changed, and YAML configs are entirely unaffected**: no config key, macro name or spec field moved.

**ONNX multi-input binding and thread-pool control** (#63). `onnx_inference` binds several model inputs via an `inputs:` map, plus `intra_op_threads` / `inter_op_threads`. Backward-compatible.

## Not in the changelog, deliberately

Two things landed since v0.10.0 that aren't user-facing, and there's no precedent for CI or test entries anywhere in the changelog's 460+ lines:

- **CI cache hygiene** (#65) — `mode=max` → `mode=min` on both image jobs. The repo had hit the 10 GB per-repo Actions cache cap (10.54 GB / 149 entries), so GitHub was evicting the `setup-go` caches that actually earn their space. Combined with a one-off prune of 138 buildkit entries: now 17 entries / 3.6 GB. Also fixed unbounded ~1.1 GB-per-release growth from tag-scoped caches that no later release could ever restore.
- **Tests for the new cross-package seam** (in #64) — `pkg/analysis` 63.0% → 70.9%, `pkg/macros` 85.1% → 86.4%, targeting the calls the split turned into a package boundary (the grouping accessors, `DataRef.GetTimeIndexFromStorage`, and the previously untested `inference_validate.go`). Mutation-checked, not just coverage-checked. Plus pre-existing `gofmt` drift in three files.

## Verification

- `go build`, `go vet`, `gofmt` clean.
- `TestPluginManifestsMatchRelease` passes — it's the guard that both manifests track the newest released CHANGELOG heading, so it would have caught a missed bump.
- `main` is green on the merged split (`test`, `image`, `site` all pass).

## After merge

Tag `v0.11.0` on the merge commit, which fires `release.yml` (portable + accel binaries, multi-arch GHCR images). Then the 12 downstream repos get swept from their local path `replace` onto the real version — they're already migrated and verified green, just pinned at `v0.9.0` and waiting on this tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)