### PR TITLE
Reach mcts_self_play from config via an environment registry

### DIFF
--- a/.claude/skills/stochadex-model/SKILL.md
+++ b/.claude/skills/stochadex-model/SKILL.md
@@ -229,6 +229,15 @@ Notable macros (all take a `data:` block): `vector_mean` / `vector_variance` / `
 `comparison:` with a windowed embedded model). `evolution_strategy_optimisation` and `smc_inference`
 run live (no `data:` needed; give them `steps:`).
 
+`mcts_self_play` also runs live, but is the one macro you cannot write from config alone: its
+`env:` names an `agents.Environment` — decision rules like a game's legal moves and win
+condition — which only Go can supply. A downstream module registers one with
+`api.RegisterEnvironment` and the binary must link that module. The engine ships a single
+`tictactoe` fixture, so `{type: mcts_self_play, name: ttt, steps: 10, sims_per_ply: 120, env:
+{type: tictactoe}}` runs out of the box and nothing else will unless you built the binary. If the
+user wants tree search over a *simulation* rather than over game rules, that is not this macro —
+reach for `evolution_strategy_optimisation` over a policy parameterisation instead.
+
 ## Worked recipes (start here for the inference/optimisation macros)
 
 The three learning macros have levers that decide whether they *converge* or merely *run* — so
@@ -323,7 +332,10 @@ params) `partition_event` (reads `event_partition_index` / `event_state_value_in
 **Aggregations:** `count` `sum` `mean` `max` `min`.
 **Macros:** `vector_mean` `vector_variance` `vector_covariance` `grouped_aggregation`
 `scalar_regression_stats` `likelihood_comparison` `posterior_estimation`
-`likelihood_mean_function_fit` `evolution_strategy_optimisation` `smc_inference`.
+`likelihood_mean_function_fit` `evolution_strategy_optimisation` `smc_inference`
+`mcts_self_play` (needs a registered `env:`).
+**Environments** (`mcts_self_play`'s `env:`): `tictactoe` only, unless the binary links a module
+that called `api.RegisterEnvironment`.
 **Simulation components:** output_condition `nil|every_step|every_n_steps|only_given_partitions`;
 output_function `nil|stdout|json_log`; termination `number_of_steps|time_elapsed`;
 timestep `constant|exponential_distribution|from_history`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,47 @@ an exact version rather than assume stability across minors.
 
 ## [Unreleased]
 
+### Added
+
+- **`mcts_self_play` is reachable from config, via a downstream environment registry.**
+  MCTS was the last macro with no YAML spelling, because an `agents.Environment` is
+  arbitrary decision rules rather than part of the framework catalogue. It is now split
+  rather than excluded: the search settings are data (`macros: - type: mcts_self_play`,
+  with `name`, `steps`, `sims_per_ply` and the UCT knobs), while the environment is named
+  from a new registry that downstream modules fill with `api.RegisterEnvironment`.
+
+  The registered builder receives the `env:` spec verbatim and returns finished partitions,
+  so the engine never parses a downstream's rules format and never has to erase the
+  `Environment[S, A]` type parameters. `macros.MCTSSearchSettings` plus
+  `macros.ApplyMCTSSearchSettings` carry the config-stated half across that boundary, with
+  override-if-set semantics so an environment can ship per-ruleset defaults that a config
+  selectively overrides. The engine registers exactly one environment — the `tictactoe`
+  fixture — which keeps the whole path covered end-to-end in CI and gives
+  `cfg/example_mcts_config.yaml` something to run.
+
+  Note that a registration hook only fires if the binary links the registering module, so a
+  downstream ships its own CLI (as `cmd/stochadex` already does for the ONNX partition).
+
+### Fixed
+
+- **MCTS: terminal selections are backed up instead of dropped.** In the decomposed
+  partition pipeline, `MCTSTreeIteration` discarded any selection that walked into an
+  already-terminal node — `SelectLeaf` returns `ok=false` there, and the path was thrown
+  away with no visit and no score. `MCTSTree.RunOne` has always backed the terminal scores
+  up instead, so the one-shot `RunMCTSSearch` and the partitioned self-play stack disagreed.
+
+  The effect was severe wherever a tree saturates: from a five-empty-cell tic-tac-toe
+  position, 200 simulations per ply produced **9** root visits, and raising the simulation
+  count bought nothing, so self-play returned near-arbitrary moves. It now accumulates the
+  full 200 and finds the win. This was not caught earlier because the existing assertions
+  used a position whose winning move happened to be first in legal order, which a
+  non-searching stack picks anyway.
+
+  One divergence from `RunOne` remains and is documented in the code: a depth-capped node
+  is rolled out and backed up by `RunOne`, but the pipeline cannot do that inline because
+  the rollout is a separate partition, so deep searches that hit `MaxTreeDepth` still drop
+  those iterations.
+
 ## [0.11.0] — 2026-07-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,23 +45,27 @@ an exact version rather than assume stability across minors.
 
 ### Fixed
 
-- **MCTS: terminal selections are backed up instead of dropped.** In the decomposed
-  partition pipeline, `MCTSTreeIteration` discarded any selection that walked into an
-  already-terminal node — `SelectLeaf` returns `ok=false` there, and the path was thrown
-  away with no visit and no score. `MCTSTree.RunOne` has always backed the terminal scores
-  up instead, so the one-shot `RunMCTSSearch` and the partitioned self-play stack disagreed.
+- **MCTS: the decomposed pipeline no longer drops non-expansion selections.**
+  `MCTSTreeIteration` treated every `ok=false` from `SelectLeaf` as "nothing happened" and
+  threw the path away with no visit and no score. `MCTSTree.RunOne` has always backed
+  something up in three of those four cases, so the one-shot `RunMCTSSearch` and the
+  partitioned self-play stack disagreed about the same position.
 
-  The effect was severe wherever a tree saturates: from a five-empty-cell tic-tac-toe
-  position, 200 simulations per ply produced **9** root visits, and raising the simulation
-  count bought nothing, so self-play returned near-arbitrary moves. It now accumulates the
-  full 200 and finds the win. This was not caught earlier because the existing assertions
-  used a position whose winning move happened to be first in legal order, which a
-  non-searching stack picks anyway.
+  The effect was severe wherever a tree saturates. From a five-empty-cell tic-tac-toe
+  position, 200 simulations per ply produced **9** root visits; with `MaxTreeDepth` reached,
+  visits plateaued at the number of root children. Raising the simulation count bought
+  nothing in either case, so self-play returned near-arbitrary moves. Both now accumulate
+  the full count and find the win. This escaped the existing tests because their assertions
+  used a position whose winning move was first in legal order — which a stack that is not
+  searching at all picks anyway.
 
-  One divergence from `RunOne` remains and is documented in the code: a depth-capped node
-  is rolled out and backed up by `RunOne`, but the pipeline cannot do that inline because
-  the rollout is a separate partition, so deep searches that hit `MaxTreeDepth` still drop
-  those iterations.
+  `SelectLeaf`'s four stop reasons are now explicit rather than collapsed into a bool, via
+  the new `MCTSLeafOutcome` and `MCTSTree.SelectLeafWithOutcome`. `SelectLeaf` keeps its
+  signature and is unchanged for callers that only care whether the tree grew. Each outcome
+  gets the backup `RunOne` gives it: terminal nodes are scored exactly by the environment
+  and backed up directly; depth-capped and stalled (no-legal-action) nodes are published as
+  leaves so the rollout partition scores them; and an `env.Apply` failure backs up nothing,
+  since a broken transition is an environment fault rather than evidence about the action.
 
 ## [0.11.0] — 2026-07-25
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,15 +118,29 @@ Simulations are usually assembled with a `simulator.ConfigGenerator` (`SetPartit
      `StateTimeStorage` via `pkg/analysis`; each macro expands one
      of the `pkg/macros` constructors against it (`posterior_estimation`, `likelihood_comparison`,
      the aggregations, `scalar_regression_stats`) or runs live (`evolution_strategy_optimisation`,
-     `smc_inference`). Macro inputs are typed spec structs decoded straight from YAML.
+     `smc_inference`, `mcts_self_play`). Macro inputs are typed spec structs decoded straight
+     from YAML.
+   - **Environments** — `pkg/api/registry_environment.go`, the one registry the engine leaves
+     empty for downstreams to fill (`RegisterEnvironment`), backing the `mcts_self_play`
+     macro's `env:`. See the Invariant A note below for why this one is a hook, not a spec.
 
 **Invariant A restated for this surface (repo boundary).** Inference-*as-forward-simulation* — a
 posterior being stepped as a partition — is in scope here; `posterior_estimation` and the other
 inference macros belong in this engine. Inference *against real data* is the `data:` resource
 (the observed dataset), which a downstream repo supplies. The engine owns the forward and
 inferential model; it does not own the dataset, the calibration loop, or the decision layer.
-`mcts_self_play` stays Go on purpose — its `agents.Environment` is arbitrary game rules (the
-decision layer), not representable as data.
+`mcts_self_play` is the boundary case, and it is split rather than excluded. Its search
+settings are data (a `macros:` entry like any other), but its `agents.Environment` is
+arbitrary decision rules — the decision layer — and stays Go. A config therefore *names* an
+environment that a downstream module contributed via `api.RegisterEnvironment`, and the
+engine passes the `env:` spec to that builder without interpreting it (see
+`pkg/api/registry_environment.go`). The engine ships exactly one environment, the
+`tictactoe` fixture, to keep the path covered end-to-end in CI.
+
+The line this holds: naming a downstream component is data; **spelling decision rules as
+data is not**, and would mean growing a rules language inside the config. If a config ever
+needs to state `Legal`/`Apply`/`Terminal` themselves, that is a separate design question —
+not an extension of this hook.
 
 ## Testing conventions
 

--- a/cfg/example_mcts_config.yaml
+++ b/cfg/example_mcts_config.yaml
@@ -1,0 +1,25 @@
+# MCTS self-play run entirely as config.
+#
+# The `env:` spec names an environment from the environment registry, not from
+# the data-spec registries the rest of the config uses. Decision rules (Legal /
+# Apply / Terminal) are arbitrary Go, owned by whichever project owns the
+# decision layer, so they have no data spelling: a downstream module registers
+# one with api.RegisterEnvironment and its fields are parsed by that module, not
+# by the engine. `tictactoe` is the reference fixture the engine itself ships.
+#
+# Output is the "<name>_apply" partition: the encoded game state after each ply.
+macros:
+- type: mcts_self_play
+  name: ttt
+  # Plies to play out.
+  steps: 10
+  # MCTS iterations run between each ply. The remaining UCT knobs
+  # (simulations, exploration, max_tree_depth, rollout_max_steps) are optional
+  # and fall back to the environment's own defaults when unset.
+  sims_per_ply: 120
+  seed: 2024
+  env:
+    type: tictactoe
+    # Optional starting position: 0 empty, 1 X, 2 O. Defaults to an empty board.
+    init_grid: [0, 0, 0, 0, 0, 0, 0, 0, 0]
+    current_player: 0

--- a/pkg/agents/doc.go
+++ b/pkg/agents/doc.go
@@ -27,7 +27,10 @@
 //     (macros.NewMCTSSelfPlayPartitions wires this up)
 //   - Per-simulation telemetry: run MCTSTreeIteration + MCTSRolloutIteration
 //     directly without the apply layer, then read the tree's row
-//   - YAML / pkg/api use: ship non-generic façade types per environment family
-//     that bake in the type parameters, since generic types in YAML iteration
-//     strings are awkward
+//   - YAML / pkg/api use: register an environment with api.RegisterEnvironment
+//     and name it from the mcts_self_play macro's env: spec. The registered
+//     builder keeps the type parameters on the Go side — it fills the typed half
+//     of a macros.MCTSSelfPlaySpec and applies the config-stated half
+//     (macros.MCTSSearchSettings) over the top — so no generic type ever has to
+//     be spelled in YAML.
 package agents

--- a/pkg/agents/doc.go
+++ b/pkg/agents/doc.go
@@ -11,7 +11,11 @@
 // Key Features:
 //   - Generic Environment[S, A] interface (Legal/Apply/Terminal/Actor/Players)
 //   - MCTS decomposed as three partitions: tree (selection + backup),
-//     rollout (one playout per step), and apply (state advancer)
+//     rollout (one playout per step), and apply (state advancer). The
+//     decomposition must reproduce MCTSTree.RunOne's backup for every way
+//     selection can stop, which is what MCTSLeafOutcome makes explicit —
+//     dropping a stop reason silently starves the tree of statistics rather
+//     than failing, so raising the simulation count buys nothing.
 //   - Pluggable rollout functions (UniformRandomRollout, FromProgress,
 //     WinnerToTerminal)
 //   - MAST as an optional rollout strategy: a learning rollout policy backed

--- a/pkg/agents/mcts_tree.go
+++ b/pkg/agents/mcts_tree.go
@@ -704,10 +704,27 @@ func (m *MCTSTreeIteration[S, A]) Iterate(
 	if ok {
 		m.pendingPath = path
 		hasLeaf = true
+	} else if scores, done := m.Env.Terminal(leafState); done {
+		// Selection reached an already-terminal node. The environment gives
+		// exact scores here, so back them up now rather than routing through
+		// the rollout partition — this is the decomposed equivalent of the
+		// terminal branch in MCTSTree.RunOne, and SelectLeaf returns the path
+		// for exactly this purpose.
+		//
+		// Load-bearing: without this, every selection that lands on a terminal
+		// node is a silently dropped iteration — no visit, no score. Trees
+		// that saturate (endgames, shallow games) then stop accumulating
+		// statistics entirely, so raising SimsPerPly buys nothing and the
+		// search returns near-arbitrary moves.
+		m.tree.backupScores(path, scores)
+		leafState = m.root
 	} else {
-		// MCTSTree is exhausted (terminal at root, or Apply error during
-		// expansion). Leave pendingPath nil; the rollout partition will
-		// see has_leaf=0 and skip.
+		// Depth-capped, no legal moves, or an Apply error during expansion.
+		// Leave pendingPath nil; the rollout partition sees has_leaf=0 and
+		// skips. NOTE: RunOne rolls out from a depth-capped node and backs up
+		// the result, which this pipeline cannot do inline — the rollout is a
+		// separate partition. Deep searches that hit MaxTreeDepth therefore
+		// still drop those iterations here.
 		leafState = m.root
 	}
 

--- a/pkg/agents/mcts_tree.go
+++ b/pkg/agents/mcts_tree.go
@@ -64,14 +64,44 @@ func (t *MCTSTree[S, A]) NodeCount() int {
 	return len(t.nodes)
 }
 
+// MCTSLeafOutcome says why selection stopped where it did. The distinction is
+// load-bearing for callers driving the decomposed pipeline: the four non-expansion
+// outcomes each need a different backup, and MCTSTree.RunOne applies exactly one
+// of those per iteration. Collapsing them into a single "not ok" and dropping the
+// iteration silently starves the tree of statistics — see MCTSTreeIteration.Iterate.
+type MCTSLeafOutcome int
+
+const (
+	// MCTSLeafExpanded: a new child node was created. Roll out from it and back
+	// the resulting scores up along the returned path.
+	MCTSLeafExpanded MCTSLeafOutcome = iota
+	// MCTSLeafTerminal: selection reached a finished position. The environment
+	// scores it exactly, so back those scores up directly — no rollout needed.
+	MCTSLeafTerminal
+	// MCTSLeafDepthCapped: MaxTreeDepth was reached. RunOne rolls out from the
+	// capped node (a Progress proxy is the usual way to score the truncation)
+	// and backs the result up; a decomposed caller should do the same.
+	MCTSLeafDepthCapped
+	// MCTSLeafNoLegalActions: a non-terminal node offering no legal actions —
+	// a stalled position. Handled exactly like a depth cap.
+	MCTSLeafNoLegalActions
+	// MCTSLeafApplyFailed: env.Apply errored during expansion, so no node was
+	// created. Nothing is backed up: this is an environment fault, not a search
+	// result, and crediting a visit for it would bias selection away from an
+	// action whose only sin is a broken transition.
+	MCTSLeafApplyFailed
+)
+
 // SelectLeaf walks the tree from the root using UCB1 (with first-visit
 // preference for unvisited children) until it reaches an unexpanded edge,
 // then expands it by creating a new child node. Returns the path of node
 // indices from the root's child down to the new leaf, the leaf's state,
 // the leaf's node index, and ok=true. Returns ok=false if the root is
 // terminal, has no legal moves, MaxTreeDepth is reached, or env.Apply
-// fails during expansion (the caller should treat this as "no leaf
-// selected this step").
+// fails during expansion.
+//
+// ok=false collapses four outcomes that want different backups, so prefer
+// SelectLeafWithOutcome unless you genuinely only care whether the tree grew.
 //
 // SelectLeaf does NOT roll out and does NOT back up — it is the
 // (selection + expansion) half of one MCTS iteration. Pair it with
@@ -81,6 +111,14 @@ func (t *MCTSTree[S, A]) NodeCount() int {
 // Calls cfg.applyDefaults() so a fresh MCTSConfig works out of the box. The
 // mutation is idempotent (only zero values are filled).
 func (t *MCTSTree[S, A]) SelectLeaf(env Environment[S, A], cfg *MCTSConfig[S, A], rng *rand.Rand) (path []int, leafState S, leafIdx int, ok bool) {
+	path, leafState, leafIdx, outcome := t.SelectLeafWithOutcome(env, cfg, rng)
+	return path, leafState, leafIdx, outcome == MCTSLeafExpanded
+}
+
+// SelectLeafWithOutcome is SelectLeaf with the stop reason reported explicitly,
+// so a caller splitting selection / rollout / backup across partitions can apply
+// the same backup RunOne would for each case.
+func (t *MCTSTree[S, A]) SelectLeafWithOutcome(env Environment[S, A], cfg *MCTSConfig[S, A], rng *rand.Rand) (path []int, leafState S, leafIdx int, outcome MCTSLeafOutcome) {
 	cfg.applyDefaults()
 	_ = rng // not currently consumed (selection is deterministic given UCB ties); kept for future tie-break randomisation
 	path = make([]int, 0, 32)
@@ -89,14 +127,10 @@ func (t *MCTSTree[S, A]) SelectLeaf(env Environment[S, A], cfg *MCTSConfig[S, A]
 	for {
 		nd := &t.nodes[cur]
 		if _, done := env.Terminal(nd.state); done {
-			// Already-terminal node: caller can backupScores via this path.
-			return path, nd.state, cur, false
+			return path, nd.state, cur, MCTSLeafTerminal
 		}
 		if depth >= cfg.MaxTreeDepth {
-			// Depth-capped: caller may want to score via progress proxy
-			// downstream; we surface this leaf's state but signal not-ok
-			// so the caller knows there's no real expansion.
-			return path, nd.state, cur, false
+			return path, nd.state, cur, MCTSLeafDepthCapped
 		}
 		if !nd.expanded {
 			leg := env.Legal(nd.state)
@@ -108,7 +142,7 @@ func (t *MCTSTree[S, A]) SelectLeaf(env Environment[S, A], cfg *MCTSConfig[S, A]
 		}
 		leg := env.Legal(nd.state)
 		if len(leg) == 0 {
-			return path, nd.state, cur, false
+			return path, nd.state, cur, MCTSLeafNoLegalActions
 		}
 		unvisited := -1
 		for i, ci := range nd.children {
@@ -131,7 +165,7 @@ func (t *MCTSTree[S, A]) SelectLeaf(env Environment[S, A], cfg *MCTSConfig[S, A]
 		if ci < 0 {
 			ns, err := env.Apply(nd.state, leg[pickIdx])
 			if err != nil {
-				return path, nd.state, cur, false
+				return path, nd.state, cur, MCTSLeafApplyFailed
 			}
 			child := len(t.nodes)
 			t.nodes = append(t.nodes, node[S]{
@@ -142,7 +176,7 @@ func (t *MCTSTree[S, A]) SelectLeaf(env Environment[S, A], cfg *MCTSConfig[S, A]
 			})
 			t.nodes[cur].children[pickIdx] = child
 			path = append(path, child)
-			return path, ns, child, true
+			return path, ns, child, MCTSLeafExpanded
 		}
 		path = append(path, ci)
 		cur = ci
@@ -699,32 +733,33 @@ func (m *MCTSTreeIteration[S, A]) Iterate(
 	// arrive at this partition next step (via state-history reading).
 	step := uint64(timestepsHistory.CurrentStepNumber)
 	rng := rand.New(rand.NewPCG(m.seed^step, uint64(partitionIndex+911)))
-	path, leafState, _, ok := m.tree.SelectLeaf(m.Env, &cfg, rng)
+	path, leafState, _, outcome := m.tree.SelectLeafWithOutcome(m.Env, &cfg, rng)
 	hasLeaf := false
-	if ok {
+	switch outcome {
+	case MCTSLeafExpanded, MCTSLeafDepthCapped, MCTSLeafNoLegalActions:
+		// All three want the same thing: a rollout from leafState, scored and
+		// backed up along path — which is exactly what MCTSTree.RunOne does for
+		// each of them. Here the rollout is a separate partition, so publish
+		// the leaf (has_leaf=1) and hold the path until its scores arrive next
+		// step, in phase A.
+		//
+		// Load-bearing: dropping the two non-expansion cases instead makes
+		// every depth-capped or stalled selection a silent no-op — no visit, no
+		// score — so a tree that saturates stops accumulating statistics and
+		// raising SimsPerPly buys nothing.
 		m.pendingPath = path
 		hasLeaf = true
-	} else if scores, done := m.Env.Terminal(leafState); done {
-		// Selection reached an already-terminal node. The environment gives
-		// exact scores here, so back them up now rather than routing through
-		// the rollout partition — this is the decomposed equivalent of the
-		// terminal branch in MCTSTree.RunOne, and SelectLeaf returns the path
-		// for exactly this purpose.
-		//
-		// Load-bearing: without this, every selection that lands on a terminal
-		// node is a silently dropped iteration — no visit, no score. Trees
-		// that saturate (endgames, shallow games) then stop accumulating
-		// statistics entirely, so raising SimsPerPly buys nothing and the
-		// search returns near-arbitrary moves.
-		m.tree.backupScores(path, scores)
+	case MCTSLeafTerminal:
+		// The environment scores a finished position exactly, so back it up now
+		// rather than paying a rollout round-trip for an already-known result.
+		if scores, done := m.Env.Terminal(leafState); done {
+			m.tree.backupScores(path, scores)
+		}
 		leafState = m.root
-	} else {
-		// Depth-capped, no legal moves, or an Apply error during expansion.
-		// Leave pendingPath nil; the rollout partition sees has_leaf=0 and
-		// skips. NOTE: RunOne rolls out from a depth-capped node and backs up
-		// the result, which this pipeline cannot do inline — the rollout is a
-		// separate partition. Deep searches that hit MaxTreeDepth therefore
-		// still drop those iterations here.
+	case MCTSLeafApplyFailed:
+		// An environment fault, not a search result. RunOne backs up nothing
+		// here and neither do we: crediting a visit would bias selection away
+		// from an action whose only problem is a broken transition.
 		leafState = m.root
 	}
 

--- a/pkg/agents/mcts_tree_test.go
+++ b/pkg/agents/mcts_tree_test.go
@@ -7,6 +7,7 @@ package agents_test
 // tictactoe.go as a deterministic, easy-to-reason-about driver.
 
 import (
+	"errors"
 	"math/rand/v2"
 	"testing"
 
@@ -554,4 +555,128 @@ func TestMCTSTreeIterationBacksUpTerminalSelections(t *testing.T) {
 			total, steps, steps-1,
 		)
 	}
+}
+
+// TestMCTSTreeIterationBacksUpDepthCappedSelections is the depth-cap counterpart
+// to the terminal test above: MCTSTree.RunOne rolls out from a depth-capped node
+// and backs the result up, so the decomposed pipeline must publish that node as a
+// leaf rather than drop the iteration.
+//
+// MaxTreeDepth is 1, so once every root child has been expanded, every further
+// selection descends one level and stops at the cap. Root visits must keep
+// tracking the step count; before the fix they plateaued at roughly the number of
+// root children, which is why raising SimsPerPly bought nothing on deep searches.
+func TestMCTSTreeIterationBacksUpDepthCappedSelections(t *testing.T) {
+	const steps = 60
+	tree := &agents.MCTSTreeIteration[agents.TTTState, agents.TTTAction]{
+		Env:             &agents.TTTGame{},
+		Cfg:             agents.MCTSConfig[agents.TTTState, agents.TTTAction]{MaxTreeDepth: 1},
+		Decoder:         agents.TTTDecode,
+		Encoder:         agents.TTTEncode,
+		MaxLegalActions: 9,
+		StateWidth:      agents.TTTWidth,
+		Players:         2,
+	}
+	gen := simulator.NewConfigGenerator()
+	store := simulator.NewStateTimeStorage()
+
+	rowInit := make([]float64, agents.MCTSTreeRowWidth(agents.TTTWidth, 9))
+	copy(rowInit[agents.MCTSTreeRowLeafStateOffset:], agents.TTTEncode(agents.TTTState{}))
+
+	gen.SetSimulation(&simulator.SimulationConfig{
+		OutputCondition:      &simulator.EveryStepOutputCondition{},
+		OutputFunction:       &simulator.StateTimeStorageOutputFunction{Store: store},
+		TerminationCondition: &simulator.NumberOfStepsTerminationCondition{MaxNumberOfSteps: steps},
+		TimestepFunction:     &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+		InitTimeValue:        0,
+	})
+	gen.SetPartition(&simulator.PartitionConfig{
+		Name:              "tree",
+		Iteration:         tree,
+		InitStateValues:   rowInit,
+		StateHistoryDepth: 1,
+		Seed:              0,
+	})
+	settings, impl := gen.GenerateConfigs()
+	simulator.NewPartitionCoordinator(settings, impl).Run()
+
+	rows := store.GetValues("tree")
+	final := rows[len(rows)-1]
+	visitsOffset := agents.MCTSTreeRowVisitsOffset(agents.TTTWidth)
+	total := 0.0
+	for _, visits := range final[visitsOffset : visitsOffset+9] {
+		total += visits
+	}
+	if total < steps-5 {
+		t.Fatalf(
+			"root visits stopped accumulating past the depth cap: got %v after %d "+
+				"steps, want ~%d (capped selections are being dropped instead of "+
+				"published as leaves)",
+			total, steps, steps-1,
+		)
+	}
+}
+
+// TestMCTSTreeIterationDropsApplyFailures pins the one outcome that must NOT be
+// backed up. A broken transition is an environment fault, not evidence about the
+// action, so crediting a visit would bias selection away from it — and RunOne
+// backs up nothing in this case either.
+func TestMCTSTreeIterationDropsApplyFailures(t *testing.T) {
+	tree := &agents.MCTSTreeIteration[agents.TTTState, agents.TTTAction]{
+		Env:             brokenApplyEnv{&agents.TTTGame{}},
+		Cfg:             agents.MCTSConfig[agents.TTTState, agents.TTTAction]{},
+		Decoder:         agents.TTTDecode,
+		Encoder:         agents.TTTEncode,
+		MaxLegalActions: 9,
+		StateWidth:      agents.TTTWidth,
+		Players:         2,
+	}
+	gen := simulator.NewConfigGenerator()
+	store := simulator.NewStateTimeStorage()
+
+	rowInit := make([]float64, agents.MCTSTreeRowWidth(agents.TTTWidth, 9))
+	copy(rowInit[agents.MCTSTreeRowLeafStateOffset:], agents.TTTEncode(agents.TTTState{}))
+
+	gen.SetSimulation(&simulator.SimulationConfig{
+		OutputCondition:      &simulator.EveryStepOutputCondition{},
+		OutputFunction:       &simulator.StateTimeStorageOutputFunction{Store: store},
+		TerminationCondition: &simulator.NumberOfStepsTerminationCondition{MaxNumberOfSteps: 20},
+		TimestepFunction:     &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+		InitTimeValue:        0,
+	})
+	gen.SetPartition(&simulator.PartitionConfig{
+		Name:              "tree",
+		Iteration:         tree,
+		InitStateValues:   rowInit,
+		StateHistoryDepth: 1,
+		Seed:              0,
+	})
+	settings, impl := gen.GenerateConfigs()
+	simulator.NewPartitionCoordinator(settings, impl).Run()
+
+	rows := store.GetValues("tree")
+	final := rows[len(rows)-1]
+	visitsOffset := agents.MCTSTreeRowVisitsOffset(agents.TTTWidth)
+	for i, visits := range final[visitsOffset : visitsOffset+9] {
+		if visits != 0 {
+			t.Fatalf("a failing Apply must not be credited a visit; slot %d has %v", i, visits)
+		}
+	}
+	hasLeafSlot := agents.MCTSTreeRowHasLeafOffset(agents.TTTWidth)
+	for i, row := range rows {
+		if i == 0 {
+			continue // initial row, before any Iterate
+		}
+		if row[hasLeafSlot] != 0 {
+			t.Fatalf("step %d: a failing Apply produced no leaf, want has_leaf=0", i)
+		}
+	}
+}
+
+// brokenApplyEnv is tic-tac-toe with a transition that always errors, so every
+// expansion attempt fails.
+type brokenApplyEnv struct{ *agents.TTTGame }
+
+func (brokenApplyEnv) Apply(agents.TTTState, agents.TTTAction) (agents.TTTState, error) {
+	return agents.TTTState{}, errors.New("broken transition")
 }

--- a/pkg/agents/mcts_tree_test.go
+++ b/pkg/agents/mcts_tree_test.go
@@ -496,3 +496,62 @@ func TestMCTSTreeIterationTerminalRootEmitsHasLeafFalse(t *testing.T) {
 		}
 	}
 }
+
+// TestMCTSTreeIterationBacksUpTerminalSelections pins the decomposed pipeline's
+// terminal handling against MCTSTree.RunOne's.
+//
+// When SelectLeaf walks into an already-terminal node it returns ok=false. The
+// partition used to discard that path entirely — no visit, no score — so once a
+// tree saturated (endgames, shallow games) it stopped accumulating statistics
+// and raising the simulation count bought nothing. RunOne has always backed the
+// terminal scores up instead, which is why the one-shot RunMCTSSearch found
+// wins the partitioned self-play stack missed.
+//
+// The position has three empty cells, so the tree saturates within a handful of
+// steps and almost every later selection lands on a terminal node. Root visits
+// must therefore keep tracking the step count.
+func TestMCTSTreeIterationBacksUpTerminalSelections(t *testing.T) {
+	const steps = 60
+	tree := newMCTSTreeIteration()
+	gen := simulator.NewConfigGenerator()
+	store := simulator.NewStateTimeStorage()
+
+	// X at 0, 2, 4; O at 1, 3, 5; cells 6, 7, 8 empty and X to move.
+	nearEnd := agents.TTTFromGrid([9]int8{1, 2, 1, 2, 1, 2, 0, 0, 0}, 0)
+	rowInit := make([]float64, agents.MCTSTreeRowWidth(agents.TTTWidth, 9))
+	copy(rowInit[agents.MCTSTreeRowLeafStateOffset:], agents.TTTEncode(nearEnd))
+
+	gen.SetSimulation(&simulator.SimulationConfig{
+		OutputCondition:      &simulator.EveryStepOutputCondition{},
+		OutputFunction:       &simulator.StateTimeStorageOutputFunction{Store: store},
+		TerminationCondition: &simulator.NumberOfStepsTerminationCondition{MaxNumberOfSteps: steps},
+		TimestepFunction:     &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+		InitTimeValue:        0,
+	})
+	gen.SetPartition(&simulator.PartitionConfig{
+		Name:              "tree",
+		Iteration:         tree,
+		InitStateValues:   rowInit,
+		StateHistoryDepth: 1,
+		Seed:              0,
+	})
+	settings, impl := gen.GenerateConfigs()
+	simulator.NewPartitionCoordinator(settings, impl).Run()
+
+	rows := store.GetValues("tree")
+	final := rows[len(rows)-1]
+	visitsOffset := agents.MCTSTreeRowVisitsOffset(agents.TTTWidth)
+	total := 0.0
+	for _, visits := range final[visitsOffset : visitsOffset+9] {
+		total += visits
+	}
+	// One backup per step, minus the first step's selection which is still
+	// pending when the run ends. Before the fix this plateaued in single digits.
+	if total < steps-5 {
+		t.Fatalf(
+			"root visits stopped accumulating: got %v after %d steps, want ~%d "+
+				"(terminal selections are being dropped instead of backed up)",
+			total, steps, steps-1,
+		)
+	}
+}

--- a/pkg/api/cfg_examples_test.go
+++ b/pkg/api/cfg_examples_test.go
@@ -36,6 +36,7 @@ func TestExampleConfigsRun(t *testing.T) {
 		"cfg/example_posterior_macro_config.yaml",
 		"cfg/example_smc_config.yaml",
 		"cfg/example_evolution_strategy_config.yaml",
+		"cfg/example_mcts_config.yaml",
 		"cfg/example_regression_config.yaml",
 		"cfg/example_data_source_config.yaml",
 	}

--- a/pkg/api/doc.go
+++ b/pkg/api/doc.go
@@ -46,7 +46,15 @@
 //	                     iteration is expected — inside a macro's window, or an embedded run.
 //	macros*.go           the macro tier: decodes typed spec structs straight from YAML and
 //	                     calls the matching pkg/macros constructor. One file per family
-//	                     (aggregation, inference, smc, optimisation, stats, data).
+//	                     (aggregation, inference, smc, optimisation, stats, data, mcts).
+//	registry_environment.go
+//	                     agents.Environment implementations for the mcts_self_play macro.
+//	                     Unlike the registries above this one is empty by default and filled
+//	                     by downstream modules calling RegisterEnvironment: decision rules
+//	                     are not part of the framework catalogue and have no data spelling,
+//	                     so the engine passes an env: spec through to its registered builder
+//	                     without interpreting it. The tictactoe fixture is the exception the
+//	                     engine ships, so the path stays covered end-to-end in CI.
 //
 // # Staying honest, and staying lean
 //

--- a/pkg/api/macros.go
+++ b/pkg/api/macros.go
@@ -36,9 +36,12 @@ type macroSpec interface {
 }
 
 // macroSpecFactories maps a macro type to a factory for its empty typed spec.
-// Aggregation and inference/stats macros are here; MCTS and SMC stay in Go (their
-// models are user closures), and evolution-strategy optimisation is a live run,
-// not an against-storage analysis.
+// Aggregation and inference/stats macros are against-storage analyses;
+// evolution-strategy optimisation, SMC inference and MCTS self-play are live
+// runs (see liveMacroSpec). mcts_self_play is the odd one out in how its central
+// component resolves: its environment is arbitrary decision rules with no data
+// spelling, so it comes from the environment registry rather than a data
+// registry — see registry_environment.go.
 var macroSpecFactories = map[string]func() macroSpec{
 	"vector_mean":                     func() macroSpec { return &vectorMeanSpec{} },
 	"vector_variance":                 func() macroSpec { return &vectorVarianceSpec{} },
@@ -50,6 +53,7 @@ var macroSpecFactories = map[string]func() macroSpec{
 	"likelihood_mean_function_fit":    func() macroSpec { return &likelihoodMeanFunctionFitSpec{} },
 	"evolution_strategy_optimisation": func() macroSpec { return &evolutionStrategySpec{} },
 	"smc_inference":                   func() macroSpec { return &smcInferenceSpec{} },
+	"mcts_self_play":                  func() macroSpec { return &mctsSelfPlaySpec{} },
 }
 
 // DataConfig is the data: tier: it produces the StateTimeStorage that macros

--- a/pkg/api/macros_mcts.go
+++ b/pkg/api/macros_mcts.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"fmt"
+
+	"github.com/umbralcalc/stochadex/pkg/macros"
+	"github.com/umbralcalc/stochadex/pkg/simulator"
+)
+
+// mcts_self_play is a LIVE macro, like evolution_strategy_optimisation: its
+// partitions form a self-contained self-play loop run as a fresh simulation
+// rather than an analysis against pre-recorded storage.
+//
+// It is also the one macro whose central component is not resolved from the
+// data registries. Its `env:` spec goes to the environment registry instead
+// (registry_environment.go), which explains why the engine can run this macro
+// over rules it has never heard of.
+type mctsSelfPlaySpec struct {
+	macroTypeField `yaml:",inline"`
+	// Env names a registered environment and carries that environment's own
+	// fields, which this package passes through without interpreting.
+	Env simulator.ComponentSpec `yaml:"env"`
+	// Name prefixes the generated partitions: "<name>_apply" holds the encoded
+	// state after each ply and is normally what you read output from;
+	// "<name>_search" holds the embedded search.
+	Name string `yaml:"name"`
+	// Steps is the number of outer plies to run.
+	Steps int `yaml:"steps"`
+	// SimsPerPly and the UCT knobs below are all optional: an unset value keeps
+	// whatever default the registered environment chose.
+	SimsPerPly      int     `yaml:"sims_per_ply,omitempty"`
+	Simulations     int     `yaml:"simulations,omitempty"`
+	Exploration     float64 `yaml:"exploration,omitempty"`
+	MaxTreeDepth    int     `yaml:"max_tree_depth,omitempty"`
+	RolloutMaxSteps int     `yaml:"rollout_max_steps,omitempty"`
+	Seed            uint64  `yaml:"seed,omitempty"`
+	Timestep        float64 `yaml:"timestep,omitempty"`
+}
+
+// resolve reports that this is a live macro (it does not run against storage).
+func (s *mctsSelfPlaySpec) resolve(
+	*simulator.StateTimeStorage,
+) ([]*simulator.PartitionConfig, map[string]int, error) {
+	return nil, nil, fmt.Errorf(
+		"mcts_self_play is a live macro; it runs its own simulation and must " +
+			"not be combined with against-storage macros")
+}
+
+func (s *mctsSelfPlaySpec) resolveLive(
+	*simulator.StateTimeStorage,
+) ([]*simulator.PartitionConfig, int, float64, error) {
+	if s.Name == "" {
+		return nil, 0, 0, fmt.Errorf("mcts_self_play needs a name: (it prefixes the partition names)")
+	}
+	if s.Steps <= 0 {
+		return nil, 0, 0, fmt.Errorf("mcts_self_play needs steps: > 0 (the number of plies to play)")
+	}
+	if s.Env.IsZero() {
+		return nil, 0, 0, fmt.Errorf(
+			"mcts_self_play needs an env: {type: ...} naming a registered environment")
+	}
+	partitions, err := ResolveEnvironment(s.Env, macros.MCTSSearchSettings{
+		Name:            s.Name,
+		SimsPerPly:      s.SimsPerPly,
+		Simulations:     s.Simulations,
+		Exploration:     s.Exploration,
+		MaxTreeDepth:    s.MaxTreeDepth,
+		RolloutMaxSteps: s.RolloutMaxSteps,
+		Seed:            s.Seed,
+	})
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	timestep := s.Timestep
+	if timestep == 0 {
+		timestep = 1.0
+	}
+	return partitions, s.Steps, timestep, nil
+}

--- a/pkg/api/macros_mcts_test.go
+++ b/pkg/api/macros_mcts_test.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/umbralcalc/stochadex/pkg/agents"
+)
+
+// macroConfigError is runMacroConfig's counterpart for the configs that must
+// fail: it returns the expansion error instead of failing the test on it.
+func macroConfigError(t *testing.T, yamlText string) error {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(yamlText), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := runMacros(LoadApiRunConfigFromYaml(path))
+	return err
+}
+
+// TestMCTSSelfPlayMacro drives the whole hook end-to-end through YAML: the macro
+// tier resolves an environment from the registry, builds the self-play stack,
+// and runs it — no Go toolchain, no main.partitions. The assertion is the sharp
+// one: seeded one move from a win, the search has to find it. A macro that wired
+// up but searched nothing would still produce rows, so "it ran" is not the test.
+//
+// The position matters. X's win is at cell 8, which is LAST in legal order
+// (empty cells are 1, 2, 4, 5, 8), so a stack that returns a near-arbitrary
+// index cannot stumble onto it — an earlier draft of this test used a position
+// whose winning cell happened to come first in legal order and passed at one
+// simulation per ply, i.e. it asserted nothing about the search.
+func TestMCTSSelfPlayMacro(t *testing.T) {
+	// X at cells 6 and 7; playing cell 8 completes the bottom row. X to move.
+	const cfg = `macros:
+- type: mcts_self_play
+  name: ttt
+  steps: 3
+  sims_per_ply: 200
+  seed: 99
+  env:
+    type: tictactoe
+    init_grid: [2, 0, 0, 2, 0, 0, 1, 1, 0]
+    current_player: 0
+`
+	out := runMacroConfig(t, cfg)
+	rows := out["ttt_apply"]
+	if len(rows) < 3 {
+		t.Fatalf("expected at least 3 recorded plies, got %d", len(rows))
+	}
+	// Row 0 is the seeded position; row 1 is the step where search has not yet
+	// produced a real best index (the -1 sentinel), so apply holds. Row 2 is the
+	// first ply the search actually chose.
+	played, err := agents.TTTDecode(rows[2])
+	if err != nil {
+		t.Fatalf("decode ply 2: %v", err)
+	}
+	if !played.Done || played.Winner != 0 {
+		t.Fatalf("expected the search to play the winning move; got %+v", played)
+	}
+}
+
+// TestMCTSSelfPlayMacroValidation checks the macro fails loudly and specifically
+// on the mistakes a config author actually makes, rather than deadlocking or
+// producing an empty run.
+func TestMCTSSelfPlayMacroValidation(t *testing.T) {
+	for _, testCase := range []struct {
+		name       string
+		cfg        string
+		wantErrHas string
+	}{
+		{
+			name:       "missing name",
+			cfg:        "macros:\n- type: mcts_self_play\n  steps: 2\n  env: {type: tictactoe}\n",
+			wantErrHas: "needs a name",
+		},
+		{
+			name:       "missing steps",
+			cfg:        "macros:\n- type: mcts_self_play\n  name: ttt\n  env: {type: tictactoe}\n",
+			wantErrHas: "steps",
+		},
+		{
+			name:       "unregistered environment",
+			cfg:        "macros:\n- type: mcts_self_play\n  name: ttt\n  steps: 2\n  env: {type: chess}\n",
+			wantErrHas: "unknown type \"chess\"",
+		},
+		{
+			name: "unknown environment field",
+			cfg: "macros:\n- type: mcts_self_play\n  name: ttt\n  steps: 2\n" +
+				"  env: {type: tictactoe, board: [1, 2]}\n",
+			wantErrHas: "unknown field \"board\"",
+		},
+		{
+			name: "out-of-range cell value",
+			cfg: "macros:\n- type: mcts_self_play\n  name: ttt\n  steps: 2\n" +
+				"  env: {type: tictactoe, init_grid: [9, 0, 0, 0, 0, 0, 0, 0, 0]}\n",
+			wantErrHas: "init_grid[0]",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := macroConfigError(t, testCase.cfg)
+			if err == nil {
+				t.Fatalf("expected an error mentioning %q", testCase.wantErrHas)
+			}
+			if !strings.Contains(err.Error(), testCase.wantErrHas) {
+				t.Errorf("error should mention %q, got: %v", testCase.wantErrHas, err)
+			}
+		})
+	}
+}
+
+// TestMCTSSelfPlayMacroRejectsStorageCombination pins the live/against-storage
+// split: mcts_self_play produces its own run, so pairing it with a data: block
+// and an analysis macro is a config error rather than a silent misread.
+func TestMCTSSelfPlayMacroRejectsStorageCombination(t *testing.T) {
+	spec := &mctsSelfPlaySpec{}
+	if _, _, err := spec.resolve(nil); err == nil {
+		t.Fatal("expected the against-storage path to be rejected")
+	}
+}

--- a/pkg/api/registry_environment.go
+++ b/pkg/api/registry_environment.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/umbralcalc/stochadex/pkg/macros"
+	"github.com/umbralcalc/stochadex/pkg/simulator"
+)
+
+// The environment registry: the downstream extension point that lets the
+// mcts_self_play macro name an agents.Environment from config.
+//
+// # Why this is a hook and not a data spelling
+//
+// Every other component family in this engine resolves from a {type: ...} data
+// spec because the thing being named is part of the framework's own catalogue —
+// a Wiener process, an exponential kernel, a normal likelihood. An
+// agents.Environment is not: it is arbitrary decision-process rules (Legal /
+// Apply / Terminal), which the repo boundary places downstream, in the project
+// that owns the decision layer. Spelling those rules as data would mean growing
+// a rules language inside the config, which is a different (and much larger)
+// project than this registry — and one that would only serve games.
+//
+// So the engine ships no environments beyond the tic-tac-toe fixture below, and
+// instead lets a downstream module contribute one. The registered builder is
+// handed the environment's whole ComponentSpec verbatim and returns finished
+// partitions: the fields under `env:` are parsed by the *downstream*, never by
+// this package. A card-game project's `{type: cardgame_rules, rules: uno.yaml}`
+// is opaque here — the engine passes it through and never learns what a zone or
+// a phase is.
+//
+// # Why the builder returns partitions rather than an environment
+//
+// macros.NewMCTSSelfPlayPartitions is generic in the environment's state and
+// action types, so this package cannot call it: a registry map has to hold a
+// concrete type, and erasing S and A to fit one would force an encode/decode
+// round-trip through every Apply in the search hot loop. Having the builder
+// call the generic constructor itself keeps the typed Environment[S, A] intact
+// for its Go callers and keeps this side free of type parameters entirely.
+// macros.MCTSSearchSettings carries the config-stated half across that boundary.
+
+// EnvironmentBuilder constructs the partitions of an MCTS self-play stack from
+// a downstream environment's data spec plus the search settings the config
+// stated. Implementations fill the typed half of a macros.MCTSSelfPlaySpec,
+// call macros.ApplyMCTSSearchSettings with the settings, and return
+// macros.NewMCTSSelfPlayPartitions of the result.
+type EnvironmentBuilder func(
+	spec simulator.ComponentSpec,
+	settings macros.MCTSSearchSettings,
+) ([]*simulator.PartitionConfig, error)
+
+// environmentBuilders holds every registered environment spelling. Unlike the
+// iteration registry there is no separate core map to shadow: the engine claims
+// only the "tictactoe" fixture name, registered through this same entry point.
+var environmentBuilders = map[string]EnvironmentBuilder{}
+
+// RegisterEnvironment adds an environment spelling usable as the mcts_self_play
+// macro's `env:` type. Call it from an init function in the module that owns
+// the environment; the engine only sees it if the binary links that module, so
+// a downstream ships its own CLI (as cmd/stochadex does for the ONNX partition).
+//
+// Panics on a duplicate name, so two modules cannot silently claim one spelling.
+func RegisterEnvironment(typeName string, build EnvironmentBuilder) {
+	if _, exists := environmentBuilders[typeName]; exists {
+		panic("api: duplicate environment registration " + typeName)
+	}
+	environmentBuilders[typeName] = build
+}
+
+// RegisteredEnvironments returns the registered spellings in sorted order, for
+// error messages and for a downstream to check what its binary has linked.
+func RegisteredEnvironments() []string {
+	names := make([]string, 0, len(environmentBuilders))
+	for name := range environmentBuilders {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// ResolveEnvironment dispatches an `env:` spec to its registered builder.
+func ResolveEnvironment(
+	spec simulator.ComponentSpec,
+	settings macros.MCTSSearchSettings,
+) ([]*simulator.PartitionConfig, error) {
+	build, ok := environmentBuilders[spec.Type]
+	if !ok {
+		return nil, fmt.Errorf(
+			"environment: unknown type %q (registered: %s). An environment is "+
+				"supplied by the downstream module that owns the decision rules and "+
+				"registered with api.RegisterEnvironment — the engine ships only the "+
+				"tictactoe fixture. If you registered one, check the binary links "+
+				"that module",
+			spec.Type,
+			strings.Join(RegisteredEnvironments(), ", "),
+		)
+	}
+	partitions, err := build(spec, settings)
+	if err != nil {
+		return nil, fmt.Errorf("environment %q: %w", spec.Type, err)
+	}
+	if len(partitions) == 0 {
+		return nil, fmt.Errorf(
+			"environment %q: builder returned no partitions", spec.Type)
+	}
+	return partitions, nil
+}

--- a/pkg/api/registry_environment_test.go
+++ b/pkg/api/registry_environment_test.go
@@ -1,0 +1,183 @@
+package api
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/umbralcalc/stochadex/pkg/agents"
+	"github.com/umbralcalc/stochadex/pkg/macros"
+	"github.com/umbralcalc/stochadex/pkg/simulator"
+)
+
+// TestRegisterEnvironment covers the downstream-environment hook: a module
+// layered above pkg/api contributes an agents.Environment spelling without the
+// engine importing it, or knowing anything about the rules it encodes.
+func TestRegisterEnvironment(t *testing.T) {
+	var gotSpec simulator.ComponentSpec
+	var gotSettings macros.MCTSSearchSettings
+	RegisterEnvironment("test_environment", func(
+		spec simulator.ComponentSpec,
+		settings macros.MCTSSearchSettings,
+	) ([]*simulator.PartitionConfig, error) {
+		gotSpec = spec
+		gotSettings = settings
+		selfPlay := macros.MCTSSelfPlaySpec[agents.TTTState, agents.TTTAction]{
+			Env: &agents.TTTGame{},
+			Cfg: agents.MCTSConfig[agents.TTTState, agents.TTTAction]{
+				Rollout: agents.UniformRandomRollout[agents.TTTState, agents.TTTAction](),
+			},
+			Decoder:         agents.TTTDecode,
+			Encoder:         agents.TTTEncode,
+			MaxLegalActions: 9,
+			StateWidth:      agents.TTTWidth,
+			Players:         2,
+			SimsPerPly:      11,
+		}
+		macros.ApplyMCTSSearchSettings(&selfPlay, settings)
+		return macros.NewMCTSSelfPlayPartitions(selfPlay), nil
+	})
+
+	t.Run("a registered environment is dispatched, with its whole spec", func(t *testing.T) {
+		partitions, err := ResolveEnvironment(
+			simulator.ComponentSpec{
+				Type:   "test_environment",
+				Fields: map[string]interface{}{"rules": "uno.yaml", "players": 3},
+			},
+			macros.MCTSSearchSettings{Name: "game", Simulations: 25},
+		)
+		if err != nil {
+			t.Fatalf("ResolveEnvironment: %v", err)
+		}
+		if len(partitions) != 2 {
+			t.Fatalf("expected the apply + search partitions, got %d", len(partitions))
+		}
+		// The engine must hand the environment's own fields through untouched —
+		// that is the whole point: it never parses a downstream's rules format.
+		if gotSpec.Type != "test_environment" ||
+			gotSpec.Fields["rules"] != "uno.yaml" || gotSpec.Fields["players"] != 3 {
+			t.Errorf("spec not passed through verbatim: %+v", gotSpec)
+		}
+		if gotSettings.Name != "game" || gotSettings.Simulations != 25 {
+			t.Errorf("search settings not passed through: %+v", gotSettings)
+		}
+		if partitions[0].Name != "game_apply" {
+			t.Errorf("config's name: should drive partition naming, got %q", partitions[0].Name)
+		}
+	})
+
+	t.Run("an unknown environment names the registered ones", func(t *testing.T) {
+		_, err := ResolveEnvironment(
+			simulator.ComponentSpec{Type: "no_such_environment"},
+			macros.MCTSSearchSettings{Name: "x"},
+		)
+		if err == nil {
+			t.Fatal("expected an error for an unknown environment")
+		}
+		// The likely cause of this error is a binary that did not link the
+		// registering module, so the message has to show what it *did* link.
+		if !strings.Contains(err.Error(), "no_such_environment") ||
+			!strings.Contains(err.Error(), "tictactoe") {
+			t.Errorf("error should name the unknown type and the registered ones, got: %v", err)
+		}
+	})
+
+	t.Run("a builder error is wrapped with the environment name", func(t *testing.T) {
+		RegisterEnvironment("failing_environment", func(
+			simulator.ComponentSpec, macros.MCTSSearchSettings,
+		) ([]*simulator.PartitionConfig, error) {
+			return nil, fmt.Errorf("bad ruleset")
+		})
+		_, err := ResolveEnvironment(
+			simulator.ComponentSpec{Type: "failing_environment"},
+			macros.MCTSSearchSettings{Name: "x"},
+		)
+		if err == nil || !strings.Contains(err.Error(), "failing_environment") ||
+			!strings.Contains(err.Error(), "bad ruleset") {
+			t.Errorf("expected the builder error wrapped with its name, got: %v", err)
+		}
+	})
+
+	t.Run("a builder returning no partitions is an error, not a silent no-op", func(t *testing.T) {
+		RegisterEnvironment("empty_environment", func(
+			simulator.ComponentSpec, macros.MCTSSearchSettings,
+		) ([]*simulator.PartitionConfig, error) {
+			return nil, nil
+		})
+		_, err := ResolveEnvironment(
+			simulator.ComponentSpec{Type: "empty_environment"},
+			macros.MCTSSearchSettings{Name: "x"},
+		)
+		if err == nil || !strings.Contains(err.Error(), "no partitions") {
+			t.Errorf("expected an empty-partitions error, got: %v", err)
+		}
+	})
+
+	t.Run("registering the same name twice panics", func(t *testing.T) {
+		defer func() {
+			if recover() == nil {
+				t.Error("expected a panic on duplicate registration")
+			}
+		}()
+		RegisterEnvironment("test_environment", func(
+			simulator.ComponentSpec, macros.MCTSSearchSettings,
+		) ([]*simulator.PartitionConfig, error) {
+			return nil, nil
+		})
+	})
+}
+
+// TestApplyMCTSSearchSettingsOverrideSemantics pins the override-if-set rule the
+// registry depends on: a registered environment carries per-ruleset defaults, and
+// a config overrides only the knobs it actually states. Getting this backwards
+// would silently reset every unstated knob to zero.
+func TestApplyMCTSSearchSettingsOverrideSemantics(t *testing.T) {
+	base := func() macros.MCTSSelfPlaySpec[agents.TTTState, agents.TTTAction] {
+		spec := macros.MCTSSelfPlaySpec[agents.TTTState, agents.TTTAction]{
+			Name:       "builder_default",
+			SimsPerPly: 11,
+			Seed:       3,
+		}
+		spec.Cfg.Simulations = 7
+		spec.Cfg.Exploration = 0.5
+		return spec
+	}
+
+	t.Run("unset settings leave the builder's defaults alone", func(t *testing.T) {
+		spec := base()
+		macros.ApplyMCTSSearchSettings(&spec, macros.MCTSSearchSettings{Name: "from_config"})
+		if spec.SimsPerPly != 11 || spec.Seed != 3 ||
+			spec.Cfg.Simulations != 7 || spec.Cfg.Exploration != 0.5 {
+			t.Errorf("builder defaults were clobbered: %+v cfg=%+v", spec, spec.Cfg)
+		}
+		if spec.Name != "from_config" {
+			t.Errorf("name should always come from config, got %q", spec.Name)
+		}
+	})
+
+	t.Run("stated settings win", func(t *testing.T) {
+		spec := base()
+		macros.ApplyMCTSSearchSettings(&spec, macros.MCTSSearchSettings{
+			Name:            "from_config",
+			SimsPerPly:      99,
+			Seed:            42,
+			Simulations:     100,
+			Exploration:     1.4,
+			MaxTreeDepth:    5,
+			RolloutMaxSteps: 30,
+		})
+		if spec.SimsPerPly != 99 || spec.Seed != 42 || spec.Cfg.Simulations != 100 ||
+			spec.Cfg.Exploration != 1.4 || spec.Cfg.MaxTreeDepth != 5 ||
+			spec.Cfg.RolloutMaxSteps != 30 {
+			t.Errorf("config settings did not take effect: %+v cfg=%+v", spec, spec.Cfg)
+		}
+	})
+
+	t.Run("an empty name leaves the builder's name", func(t *testing.T) {
+		spec := base()
+		macros.ApplyMCTSSearchSettings(&spec, macros.MCTSSearchSettings{SimsPerPly: 2})
+		if spec.Name != "builder_default" {
+			t.Errorf("empty name should not blank the builder's, got %q", spec.Name)
+		}
+	})
+}

--- a/pkg/api/registry_environment_tictactoe.go
+++ b/pkg/api/registry_environment_tictactoe.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"fmt"
+
+	"github.com/umbralcalc/stochadex/pkg/agents"
+	"github.com/umbralcalc/stochadex/pkg/macros"
+	"github.com/umbralcalc/stochadex/pkg/simulator"
+)
+
+// The one environment the engine registers itself. Tic-tac-toe is already this
+// repo's canonical Environment fixture (see agents.TTTGame): small enough to be
+// obvious, sharp enough that a broken search fails a "win in one" assertion.
+// Registering it here is what makes the mcts_self_play macro runnable from the
+// stock CLI with no downstream module — which is what keeps the whole hook
+// covered by an end-to-end config in engine CI, and gives cfg/ a worked example.
+//
+// It is a fixture, not a domain model: it is deliberately the only environment
+// the engine ships, and real decision rules belong downstream (see the registry
+// note in registry_environment.go).
+func init() {
+	RegisterEnvironment("tictactoe", buildTicTacToeEnvironment)
+}
+
+// buildTicTacToeEnvironment is the reference EnvironmentBuilder. It shows the
+// intended shape for a downstream one: parse your own fields out of the spec,
+// fill the typed half of the self-play spec, apply the config-stated search
+// settings over the top, and hand back the partitions.
+//
+// Fields (all optional):
+//
+//	init_grid:      9 cell values, 0 empty / 1 X / 2 O (default: empty board)
+//	current_player: 0 for X to move, 1 for O (default: 0)
+func buildTicTacToeEnvironment(
+	spec simulator.ComponentSpec,
+	settings macros.MCTSSearchSettings,
+) ([]*simulator.PartitionConfig, error) {
+	initState := agents.TTTState{}
+	var grid [9]int8
+	currentPlayer := 0
+	haveGrid := false
+
+	for key, value := range spec.Fields {
+		switch key {
+		case "init_grid":
+			raw, ok := value.([]interface{})
+			if !ok || len(raw) != 9 {
+				return nil, fmt.Errorf("init_grid must be a list of 9 cell values, got %v", value)
+			}
+			for i, element := range raw {
+				cell, ok := element.(int)
+				if !ok || cell < 0 || cell > 2 {
+					return nil, fmt.Errorf(
+						"init_grid[%d] must be 0 (empty), 1 (X) or 2 (O), got %v", i, element)
+				}
+				grid[i] = int8(cell)
+			}
+			haveGrid = true
+		case "current_player":
+			player, ok := value.(int)
+			if !ok || (player != 0 && player != 1) {
+				return nil, fmt.Errorf("current_player must be 0 or 1, got %v", value)
+			}
+			currentPlayer = player
+		default:
+			return nil, fmt.Errorf("unknown field %q", key)
+		}
+	}
+	if haveGrid || currentPlayer != 0 {
+		initState = agents.TTTFromGrid(grid, currentPlayer)
+	}
+
+	selfPlay := macros.MCTSSelfPlaySpec[agents.TTTState, agents.TTTAction]{
+		Env: &agents.TTTGame{},
+		Cfg: agents.MCTSConfig[agents.TTTState, agents.TTTAction]{
+			Rollout: agents.UniformRandomRollout[agents.TTTState, agents.TTTAction](),
+		},
+		InitState: initState,
+		Decoder:   agents.TTTDecode,
+		Encoder:   agents.TTTEncode,
+		// The environment's own shape — never config's to state, because a
+		// mismatch here is a silently misshapen row rather than a loud error.
+		MaxLegalActions: 9,
+		StateWidth:      agents.TTTWidth,
+		Players:         2,
+		// A per-environment default the config may override.
+		SimsPerPly: 50,
+	}
+	macros.ApplyMCTSSearchSettings(&selfPlay, settings)
+
+	return macros.NewMCTSSelfPlayPartitions(selfPlay), nil
+}

--- a/pkg/macros/doc.go
+++ b/pkg/macros/doc.go
@@ -6,10 +6,13 @@
 //
 // This is the tier the YAML `macros:` key expands into. Every constructor here
 // is reachable from a config through pkg/api, which decodes the spec structs
-// from YAML and calls into this package; the one exception is
-// NewMCTSSelfPlayPartitions, whose agents.Environment is arbitrary Go game
-// rules and so has no data spelling. The package is named for the shape of
-// what it produces — spec in, partitions out — not for the YAML key alone.
+// from YAML and calls into this package. NewMCTSSelfPlayPartitions is reachable
+// too, but by a different route: its agents.Environment is arbitrary Go
+// decision rules with no data spelling, so a config names an environment that a
+// downstream module registered with api.RegisterEnvironment, and only the
+// env-independent half of the spec (MCTSSearchSettings) comes from the config.
+// The package is named for the shape of what it produces — spec in, partitions
+// out — not for the YAML key alone.
 //
 // # Layering
 //

--- a/pkg/macros/mcts.go
+++ b/pkg/macros/mcts.go
@@ -76,6 +76,69 @@ type MCTSSelfPlaySpec[S any, A any] struct {
 	Seed uint64
 }
 
+// MCTSSearchSettings is the env-independent half of MCTSSelfPlaySpec: the
+// partition naming, seed, and UCT hyperparameters, all of which are plain
+// scalars a config can state as data. The other half of the spec — the typed
+// Environment, the codecs, the initial state, and the row-shape constants
+// derived from them — has no data spelling and can only come from Go.
+//
+// That split is what the pkg/api environment registry is built on. A config
+// states the search settings; a downstream-registered builder supplies the
+// environment half and calls ApplyMCTSSearchSettings to combine the two. The
+// engine therefore never has to know what the environment *is*.
+type MCTSSearchSettings struct {
+	// Name prefix for the generated partitions (see MCTSSelfPlaySpec.Name).
+	Name string
+	// SimsPerPly is the inner-sim step count between outer plies.
+	SimsPerPly int
+	// Simulations, Exploration, MaxTreeDepth and RolloutMaxSteps are the UCT
+	// hyperparameters. Zero means "leave whatever the builder set", which in
+	// turn leaves the agents package defaults when the builder set nothing.
+	Simulations     int
+	Exploration     float64
+	MaxTreeDepth    int
+	RolloutMaxSteps int
+	// Seed is the base RNG seed for the inner partitions.
+	Seed uint64
+}
+
+// ApplyMCTSSearchSettings copies the config-stated settings onto spec, leaving
+// the typed environment fields (Env, Cfg.Rollout, Cfg.Progress, InitState,
+// Decoder, Encoder, MaxLegalActions, StateWidth, Players) untouched.
+//
+// Every numeric field is override-if-set: a zero in the settings leaves the
+// builder's own value in place. This makes a registered environment free to
+// carry sensible per-ruleset defaults that a config may selectively override,
+// rather than having every config restate every knob. Name is the exception —
+// it always wins when non-empty, because it determines the partition names the
+// surrounding config reads output from.
+func ApplyMCTSSearchSettings[S any, A any](
+	spec *MCTSSelfPlaySpec[S, A],
+	settings MCTSSearchSettings,
+) {
+	if settings.Name != "" {
+		spec.Name = settings.Name
+	}
+	if settings.SimsPerPly > 0 {
+		spec.SimsPerPly = settings.SimsPerPly
+	}
+	if settings.Seed != 0 {
+		spec.Seed = settings.Seed
+	}
+	if settings.Simulations > 0 {
+		spec.Cfg.Simulations = settings.Simulations
+	}
+	if settings.Exploration > 0 {
+		spec.Cfg.Exploration = settings.Exploration
+	}
+	if settings.MaxTreeDepth > 0 {
+		spec.Cfg.MaxTreeDepth = settings.MaxTreeDepth
+	}
+	if settings.RolloutMaxSteps > 0 {
+		spec.Cfg.RolloutMaxSteps = settings.RolloutMaxSteps
+	}
+}
+
 // NewMCTSSelfPlayPartitions returns the outer partitions for an MCTS
 // self-play simulation built around the spec. The returned slice contains
 // two entries: the apply partition (outer state, one ply per outer step)


### PR DESCRIPTION
MCTS was the last macro with no YAML spelling, because an `agents.Environment` is arbitrary decision rules rather than part of the framework catalogue. This splits it rather than excluding it: the **search settings become data**, while the **environment stays Go** and is named from a registry that downstream modules fill.

## The hook

`pkg/api/registry_environment.go` adds `RegisterEnvironment` / `ResolveEnvironment`, mirroring the existing `RegisterIteration` ONNX hook.

No downstream code moves upstream. The registered builder receives the `env:` `ComponentSpec` **verbatim** and returns finished partitions, so the engine never parses a downstream's rules format — a card-game project's `{type: cardgame_rules, rules: uno.yaml}` is opaque here.

Returning *partitions* rather than an environment is what avoids the generics problem: a registry map needs a concrete type, and erasing `S`/`A` to fit one would force an encode/decode round-trip through every `Apply` in the search hot loop. The downstream calls the generic constructor itself, so `Environment[S, A]` stays intact and this side is free of type parameters entirely.

`macros.MCTSSearchSettings` + `ApplyMCTSSearchSettings` carry the config-stated half across the boundary, with override-if-set semantics so an environment ships per-ruleset defaults a config selectively overrides.

The engine registers exactly one environment — the `tictactoe` fixture — which keeps the path covered end-to-end in CI and gives `cfg/example_mcts_config.yaml` something to run.

**Caveat worth stating:** a registration hook only fires if the binary links the registering module, so a downstream ships its own CLI (as `cmd/stochadex` already does for the ONNX partition).

## Two MCTS bugs fixed along the way

Found while falsifying the new tests; both pre-existing and independent of the registry work.

`SelectLeaf` collapsed **four** stop reasons into one `ok=false`, and `MCTSTreeIteration` treated all four as "nothing happened". `MCTSTree.RunOne` backs something up in three of them, so the one-shot `RunMCTSSearch` and the partitioned self-play stack disagreed about the same position.

The effect was severe wherever a tree saturates:

- from a five-empty-cell tic-tac-toe position, **200 sims/ply produced 9 root visits**
- with `MaxTreeDepth` reached, visits plateaued at the number of root children

Raising the simulation count bought nothing in either case, so self-play returned near-arbitrary moves.

This escaped the existing tests because their assertions used a position whose winning move was **first in legal order** — which a stack that is not searching at all picks anyway. My own first draft had the same flaw and passed at 1 sim/ply, which is how it surfaced.

New `MCTSLeafOutcome` / `SelectLeafWithOutcome` make the reason explicit; `SelectLeaf` keeps its signature as a wrapper (it has no callers outside this repo). Each outcome gets the backup `RunOne` gives it:

| Outcome | Backup |
|---|---|
| `Expanded` | roll out → back up (unchanged) |
| `Terminal` | env scores it exactly → back up directly |
| `DepthCapped` | published as a leaf → rollout partition scores it |
| `NoLegalActions` | same as depth-capped |
| `ApplyFailed` | nothing — a broken transition is an environment fault, not evidence about the action |

## Verification

- Both regression tests fail without their fix (3 visits/60 steps terminal; 9 visits/60 steps depth-cap) — checked by stashing.
- The `ApplyFailed` test passes before and after; it guards against future regression rather than demonstrating a bug.
- End-to-end YAML test asserts the search finds a win placed **last** in legal order.
- CLI runs the example config and plays an optimal draw, visits landing at exactly `sims_per_ply`.
- Full suite green (bar the Postgres integration test, which needs a live DB).

## Not in scope

The environment-as-embedded-simulation path — where `S` is a sub-simulation's state rows and `Apply` steps it — plus the chance-node / per-step-reward / discounting changes that real-world planning would need. Those are a separate design question; this PR only covers naming a Go-supplied environment from config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)