### PR TITLE
Planning over simulations: re-entrant runs, chance nodes, and the mcts_planning macro

### DIFF
--- a/.claude/skills/stochadex-model/SKILL.md
+++ b/.claude/skills/stochadex-model/SKILL.md
@@ -241,9 +241,11 @@ Two decision-making macros also run live, and the distinction between them matte
   rather than letting returns clamp). Every model partition must have `state_history_depth: 1`,
   and the model must be Markov in its own rows: the planner restarts it each transition, so
   nothing may rely on the step counter — carry a phase/counter in the state instead.
-  **Caveat to pass on:** the search plans against a pinned noise realisation, so with a stochastic
-  model its predicted return is optimistic. Vary `scenario_seed` and aggregate rather than quoting
-  one run's return as a forecast.
+  On stochastic models it uses **chance nodes** by default, averaging each action's value over
+  sampled successors. `pinned_noise: true` opts out (faster, and free when the model is
+  deterministic) — but only do that knowingly: a pinned search exploits the noise draw it is
+  going to receive, and its over-promise *grows* with `sims_per_decision`. Either way, quote a
+  planned return as one scenario's outcome, not a forecast; vary `scenario_seed` and aggregate.
 - **`mcts_self_play`** — search over *decision rules written in Go*, and the one macro you cannot
   write from config alone: its `env:` names an `agents.Environment` (a game's legal moves and win
   condition), registered by a downstream module via `api.RegisterEnvironment`, and the binary must

--- a/.claude/skills/stochadex-model/SKILL.md
+++ b/.claude/skills/stochadex-model/SKILL.md
@@ -261,8 +261,9 @@ macro *names* only, so change the numbers and the objective/model, but keep the 
   now panics if you forget, naming the fix.) **Levers:** proposal covariance wide enough to explore
   prior→truth (diag ≈9); `past_discount` near 1 (0.999) so evidence accumulates instead of being
   forgotten; enough `steps` to concentrate.
-- **`recipes/smc_inference.yaml`** — particle-filter inference; the inner per-particle model is a
-  template (`{particle}` is instantiated per particle) and it recovers the observed stream's mean.
+- **`recipes/smc_inference.yaml`** — particle-filter inference; write the model once under
+  `model.partitions` and it is run once per particle (each with its own random streams), routing
+  each particle's parameters in via `param_forwarding`. Recovers the observed stream's mean.
   **Levers:** `num_particles` (more = tighter posterior), `num_rounds`, and the `priors` ranges.
 - **`recipes/scalar_regression_stats.yaml`** — closed-form OLS of scalar `y` on scalar `x`;
   recovers slope 2.5 and intercept 1.0 of a noisy line. No convergence levers (it's closed-form —

--- a/.claude/skills/stochadex-model/SKILL.md
+++ b/.claude/skills/stochadex-model/SKILL.md
@@ -229,14 +229,30 @@ Notable macros (all take a `data:` block): `vector_mean` / `vector_variance` / `
 `comparison:` with a windowed embedded model). `evolution_strategy_optimisation` and `smc_inference`
 run live (no `data:` needed; give them `steps:`).
 
-`mcts_self_play` also runs live, but is the one macro you cannot write from config alone: its
-`env:` names an `agents.Environment` — decision rules like a game's legal moves and win
-condition — which only Go can supply. A downstream module registers one with
-`api.RegisterEnvironment` and the binary must link that module. The engine ships a single
-`tictactoe` fixture, so `{type: mcts_self_play, name: ttt, steps: 10, sims_per_ply: 120, env:
-{type: tictactoe}}` runs out of the box and nothing else will unless you built the binary. If the
-user wants tree search over a *simulation* rather than over game rules, that is not this macro —
-reach for `evolution_strategy_optimisation` over a policy parameterisation instead.
+Two decision-making macros also run live, and the distinction between them matters:
+
+- **`mcts_planning`** — tree search over *your model*. The dynamics are already partitions, so an
+  action is a params injection (`actions:` + `action_partition` + `action_param`), a transition is
+  one step of the model, and the reward is just another partition named by `reward_partition`
+  (write it as an `{type: expression}` partition). Nothing has to come from Go. Use this whenever
+  the user wants "what should I do, given this simulation" — dispatch, dosing, intervention
+  timing. See `cfg/example_planning_config.yaml`. It needs `horizon:` (lookahead), `steps:`
+  (decisions to take) and `return_range: [min, max]` (UCB1 needs a bounded value scale — widen it
+  rather than letting returns clamp). Every model partition must have `state_history_depth: 1`,
+  and the model must be Markov in its own rows: the planner restarts it each transition, so
+  nothing may rely on the step counter — carry a phase/counter in the state instead.
+  **Caveat to pass on:** the search plans against a pinned noise realisation, so with a stochastic
+  model its predicted return is optimistic. Vary `scenario_seed` and aggregate rather than quoting
+  one run's return as a forecast.
+- **`mcts_self_play`** — search over *decision rules written in Go*, and the one macro you cannot
+  write from config alone: its `env:` names an `agents.Environment` (a game's legal moves and win
+  condition), registered by a downstream module via `api.RegisterEnvironment`, and the binary must
+  link that module. The engine ships a single `tictactoe` fixture, so `{type: mcts_self_play,
+  name: ttt, steps: 10, sims_per_ply: 120, env: {type: tictactoe}}` runs out of the box and
+  nothing else will unless you built the binary.
+
+For optimising a *policy parameterisation* globally rather than an action sequence from the
+current state, `evolution_strategy_optimisation` is the right tool instead of either.
 
 ## Worked recipes (start here for the inference/optimisation macros)
 
@@ -334,7 +350,7 @@ params) `partition_event` (reads `event_partition_index` / `event_state_value_in
 **Macros:** `vector_mean` `vector_variance` `vector_covariance` `grouped_aggregation`
 `scalar_regression_stats` `likelihood_comparison` `posterior_estimation`
 `likelihood_mean_function_fit` `evolution_strategy_optimisation` `smc_inference`
-`mcts_self_play` (needs a registered `env:`).
+`mcts_self_play` (needs a registered `env:`) `mcts_planning` (tree search over your own model).
 **Environments** (`mcts_self_play`'s `env:`): `tictactoe` only, unless the binary links a module
 that called `api.RegisterEnvironment`.
 **Simulation components:** output_condition `nil|every_step|every_n_steps|only_given_partitions`;

--- a/.claude/skills/stochadex-model/recipes/smc_inference.yaml
+++ b/.claude/skills/stochadex-model/recipes/smc_inference.yaml
@@ -1,6 +1,7 @@
-# Sequential Monte Carlo (particle filter) inference as config. The inner
-# per-particle model is a template: {particle} in partition names and upstream
-# refs is instantiated once per particle. Recovers the observed stream's mean.
+# Sequential Monte Carlo (particle filter) inference as config. The model under
+# `model.partitions` is written once and run once per particle, with each
+# particle's parameters routed in by `param_forwarding` and its random streams
+# seeded independently. Recovers the observed stream's mean.
 data:
   steps: 60
   timestep: 1.0
@@ -23,20 +24,20 @@ macros:
   param_names: [mean]
   model:
     observed_data: {name: observed_data, ref: {partition_name: obs}}
-    per_particle_partitions:
-    - name: "pred_{particle}"
+    partitions:
+    - name: "pred"
       iteration: {type: param_values}
       params: {param_values: [0.0]}
       init_state_values: [0.0]
       state_history_depth: 2
-    - name: "loglike_{particle}"
+    - name: "loglike"
       iteration: {type: data_comparison, likelihood: {type: normal}}
       params: {mean: [0.0], variance: [0.5], latest_data_values: [2.0], cumulative: [1], burn_in_steps: [0]}
       params_from_upstream:
-        mean: {upstream: "pred_{particle}"}
+        mean: {upstream: "pred"}
         latest_data_values: {upstream: observed_data}
       init_state_values: [0.0]
       state_history_depth: 2
-    loglike_partition: "loglike_{particle}"
+    loglike_partition: "loglike"
     param_forwarding:
-      "pred_{particle}/param_values": [0]
+      "pred/param_values": [0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,38 @@ an exact version rather than assume stability across minors.
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING: SMC states its model once instead of replicating it per particle.** The particle
+  structure used to be a *template* — a partition set written with a `{particle}` placeholder,
+  expanded into N copies inside a single simulation. That made the particle count a property of
+  the configuration, and left per-particle random seeding to whoever wrote the template.
+
+  Evaluating one model many times is what `simulator.ReentrantSimulation` is for, so the model
+  is now written once and run once per particle by
+  `macros.SMCParticleEvaluationIteration`. Particles are evaluated concurrently and synchronise
+  once per round rather than at every inner step; the shipped convergence test runs ~30% faster.
+
+  Migration — Go: `SMCParticleModel.Build` takes `(nParams int)` rather than `(N, nParams int)`
+  and returns one particle's model; `SMCInnerSimConfig.LoglikePartitions []string` becomes
+  `LoglikePartition string`; `ParamForwarding` indices are into the particle's own d-length
+  vector rather than the flat N*d one. YAML: `model.per_particle_partitions` and
+  `model.shared_partitions` become a single `model.partitions`, and `{particle}` placeholders
+  are dropped from partition names, upstream references and `loglike_partition`. The
+  `<sim_name>` partition's row is now one log-likelihood per particle rather than the
+  concatenated inner state.
+
+### Fixed
+
+- **SMC gave every particle the same noise realisation.** Per-particle partitions inherited
+  their template's seed verbatim, so with a stochastic model all N particles produced identical
+  trajectories and identical log-likelihoods. Invisible with a deterministic model — which is
+  why the existing tests missed it — and damaging for simulation-based inference, where the
+  particle cloud is meant to carry the model's Monte Carlo variation: posterior spread was
+  understated because only the proposed parameters varied. Seeds are now derived per particle,
+  and under the redesign above they are derived by the evaluation iteration rather than by the
+  configuration, so a config cannot get this wrong.
+
 ### Added
 
 - **`simulator.ReentrantSimulation`: running a simulation as a pure function of its inputs.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,25 @@ an exact version rather than assume stability across minors.
   rather than continued. The macros (windowed likelihood, evolution strategy, SMC) are
   untouched and keep streaming.
 
+- **`mcts_planning`: planning over your own model, entirely as config.** The macro surface over
+  `agents.SimulationEnvironment`. The dynamics are already partitions, so an action is a params
+  injection (`actions:`, `action_partition`, `action_param`), a transition is one step of the
+  model, and the reward is another partition named by `reward_partition` — normally an
+  `{type: expression}` one, which keeps rewards in the expressions DSL rather than introducing a
+  second language. Nothing is named from outside, so the whole decision problem is data.
+
+  This is the counterpart to `mcts_self_play`, and the two sit on opposite sides of the repo
+  boundary deliberately: `mcts_self_play` searches decision *rules* (arbitrary Go, named through
+  the environment registry), while `mcts_planning` searches a *model* — search-as-forward-
+  simulation, in scope by the same argument that puts `posterior_estimation` in scope. It is also
+  a sibling of `evolution_strategy_optimisation` rather than a replacement: the evolution strategy
+  optimises a policy *parameterisation* globally, this optimises an action *sequence* from the
+  current state and replans each step.
+
+  `cfg/example_planning_config.yaml` is battery arbitrage over a cyclic price, where buying looks
+  like a pure loss at the moment it has to happen: the search recovers the hand-computable optimum
+  of 160 against 0 for doing nothing.
+
 - **`agents.SimulationEnvironment`: MCTS planning over a sub-simulation.** Where the
   `pkg/api` environment registry lets a config *name* decision rules written in Go, this
   needs no rules at all — the dynamics are already stated as partitions, so an action is a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,35 @@ an exact version rather than assume stability across minors.
   rather than continued. The macros (windowed likelihood, evolution strategy, SMC) are
   untouched and keep streaming.
 
+- **`agents.MCTSChanceTree`: chance nodes, so a stochastic plan's value is an average.**
+  `MCTSTree` materialises one successor per action edge and reuses it — exactly right for
+  deterministic game rules, and silently wrong for a stochastic model, where it pins the noise
+  and lets the search exploit the draw it is going to receive.
+
+  The new tree interposes a chance node between an action and its outcomes, and grows the number
+  of sampled successors by progressive widening (`ceil(k * visits^alpha)`, alpha 0.5 by default)
+  so each outcome still collects enough visits for its average to mean something. Environments
+  opt in by implementing the new `StochasticEnvironment` (an `ApplySample` that draws under a
+  given seed); `agents.SimulationEnvironment` does, and deterministic game environments
+  deliberately do not. `RunChanceMCTSSearch` is the one-shot entry point, and
+  `MCTSTreeIteration.ChanceNodes` selects it inside the partition pipeline.
+
+  Measured on the battery problem, averaging over six planning scenarios and replaying each plan
+  across eight others — the over-promise from planning in one's own scenario:
+
+  | simulations | pinned noise | chance nodes |
+  |---|---|---|
+  | 100 | 44.8 | −6.4 |
+  | 200 | 79.3 | −5.6 |
+  | 400 | 91.5 | 21.4 |
+  | 1600 | 91.5 | −8.1 |
+
+  Note the direction of the pinned column: **its bias grows with the search budget**, because
+  more search means more exploitation of the single realisation it can see. Spending more
+  simulations makes a pinned plan's number less trustworthy, not more. Chance-node plans earn
+  slightly less on this problem at equal budget (the sampling has to be paid for somewhere) and
+  predict what they earn.
+
 - **`mcts_planning`: planning over your own model, entirely as config.** The macro surface over
   `agents.SimulationEnvironment`. The dynamics are already partitions, so an action is a params
   injection (`actions:`, `action_partition`, `action_param`), a transition is one step of the
@@ -115,13 +144,12 @@ an exact version rather than assume stability across minors.
   finite-horizon per-step-reward problem terminates at the horizon and normalises its return
   into the `[0,1]` score UCB1 needs.
 
-  Seeding each transition from `(ScenarioSeed, state, action)` is common random numbers, and
-  it is an approximation rather than a free win: a planner solving a pinned scenario can
-  exploit the noise draw it is going to receive. `TestSimulationEnvironmentOptimismGap`
-  measures that instead of caveating it — planning under one scenario and replaying the same
-  actions under twelve others shows a **21% optimism gap** on the test problem. Averaging
-  over scenario seeds is the mitigation; a chance-node treatment would be the fix, and is not
-  built.
+  Seeding each transition from `(ScenarioSeed, state, action)` is common random numbers, which
+  is what makes `Apply` pure. On its own that is an approximation rather than a free win, since
+  a planner solving a pinned scenario can exploit the noise draw it is going to receive; the
+  environment therefore also implements `StochasticEnvironment`, so a chance-node search can
+  average over the distribution instead. See the `MCTSChanceTree` entry above for the measured
+  difference.
 
   Validated on battery arbitrage over a cyclic price, where selling requires having bought
   earlier at a price that looked bad at the time. The environment is deterministic, so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,66 @@ an exact version rather than assume stability across minors.
 
 ### Added
 
+- **`simulator.ReentrantSimulation`: running a simulation as a pure function of its inputs.**
+  `PartitionCoordinator` advances a simulation, `RunSeededEnsemble` runs several, and
+  `RunWithHarnesses` runs one under assertions. This is the fourth way to drive one —
+  evaluate it from an arbitrary starting state, under a chosen seed, and get the resulting
+  rows back, with the guarantee that the same inputs always produce the same output.
+
+  This was not previously possible. An iteration's mutable state, RNG included, lives in the
+  iteration object and is established by `Configure`, so anything that builds a coordinator
+  and steps it inherits whatever RNG state the iterations are already in.
+  `general.EmbeddedSimulationRunIteration` is a **stream** in exactly this sense: four calls
+  with identical inputs give four different answers. That is right for advancing a nested
+  simulation once per outer step, and wrong for anything that needs to evaluate the same
+  model twice — planning, particle propagation, or re-running a windowed model
+  reproducibly. Each of those had hand-rolled its own workaround.
+
+  What makes it work is a rule the framework already had: every iteration must
+  re-initialise all of its mutable state in `Configure`, which `RunWithHarnesses` enforces
+  by running a simulation twice and comparing. Reseeding via `ReseedIterations` therefore
+  restores the iterations to a state depending only on the seed. The invariant was already
+  there; nothing exploited it.
+
+- **`EmbeddedSimulationRunIteration.SetReseedBase`** opts an embedded run into that
+  behaviour, reseeding its inner iterations from the given base mixed with the outer step
+  number so a run becomes a function of its inputs. **Off by default** — enabling it changes
+  the numbers an existing configuration produces, since the inner noise stream is restarted
+  rather than continued. The macros (windowed likelihood, evolution strategy, SMC) are
+  untouched and keep streaming.
+
+- **`agents.SimulationEnvironment`: MCTS planning over a sub-simulation.** Where the
+  `pkg/api` environment registry lets a config *name* decision rules written in Go, this
+  needs no rules at all — the dynamics are already stated as partitions, so an action is a
+  params injection, a transition is one step of the sub-simulation, and the reward is read
+  off the resulting rows. It is built on `ReentrantSimulation`, which is what makes `Apply`
+  pure enough for a search that materialises a successor once per edge and reuses it.
+
+  It fits the existing `Environment` contract unchanged: the encoded state carries the step
+  index and accumulated discounted reward alongside every partition's row, so a
+  finite-horizon per-step-reward problem terminates at the horizon and normalises its return
+  into the `[0,1]` score UCB1 needs.
+
+  Seeding each transition from `(ScenarioSeed, state, action)` is common random numbers, and
+  it is an approximation rather than a free win: a planner solving a pinned scenario can
+  exploit the noise draw it is going to receive. `TestSimulationEnvironmentOptimismGap`
+  measures that instead of caveating it — planning under one scenario and replaying the same
+  actions under twelve others shows a **21% optimism gap** on the test problem. Averaging
+  over scenario seeds is the mitigation; a chance-node treatment would be the fix, and is not
+  built.
+
+  Validated on battery arbitrage over a cyclic price, where selling requires having bought
+  earlier at a price that looked bad at the time. The environment is deterministic, so the
+  optimum is found exactly by brute force over all action sequences, and MCTS recovers it
+  (160 against 0 for doing nothing). A transition costs ~1 µs.
+
+  Known limits, enforced or documented rather than silent: partitions must have
+  `state_history_depth` 1 (it panics otherwise), the sub-simulation must be Markov in its own
+  rows because the coordinator restarts each transition, and one environment per goroutine.
+  There is no `macros:`/YAML surface yet.
+
+### Added
+
 - **`mcts_self_play` is reachable from config, via a downstream environment registry.**
   MCTS was the last macro with no YAML spelling, because an `agents.Environment` is
   arbitrary decision rules rather than part of the framework catalogue. It is now split

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,9 @@ channels.
 ```
 pkg/
   simulator/   — Core engine: the Iteration interface, PartitionCoordinator, state/time
-                 histories, output & termination conditions, ConfigGenerator, run harnesses
+                 histories, output & termination conditions, ConfigGenerator, run harnesses,
+                 and ReentrantSimulation (running a sub-simulation as a *pure function* of
+                 a starting state and seed — see reentrant.go)
   api/         — YAML config loading, CLI arg parsing, code generation from templates
   continuous/  — Continuous-time processes (Wiener, GBM, Ornstein–Uhlenbeck, drift–diffusion…)
   discrete/    — Discrete / jump processes (Poisson, Bernoulli, Hawkes, categorical transitions…)
@@ -65,7 +67,11 @@ type Iteration interface {
 - `Iterate` runs each step, returning the partition's next state as `[]float64`.
 - **`Iterate` must not mutate `params`** — the test harness checks this.
 - **Keep iterations stateless between runs**: all mutable state must be re-initialisable in
-  `Configure`, because the harness runs a simulation twice and compares outputs.
+  `Configure`, because the harness runs a simulation twice and compares outputs. This rule
+  is load-bearing beyond the harness: it is what lets `simulator.ReentrantSimulation`
+  re-evaluate a model reproducibly by reseeding, which planning (MCTS) and any repeated
+  model evaluation depend on. An iteration that stashes state outside `Configure`'s reach
+  breaks both.
 
 ## How partitions fit together
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,8 +124,8 @@ Simulations are usually assembled with a `simulator.ConfigGenerator` (`SetPartit
      `StateTimeStorage` via `pkg/analysis`; each macro expands one
      of the `pkg/macros` constructors against it (`posterior_estimation`, `likelihood_comparison`,
      the aggregations, `scalar_regression_stats`) or runs live (`evolution_strategy_optimisation`,
-     `smc_inference`, `mcts_self_play`). Macro inputs are typed spec structs decoded straight
-     from YAML.
+     `smc_inference`, `mcts_self_play`, `mcts_planning`). Macro inputs are typed spec structs
+     decoded straight from YAML.
    - **Environments** — `pkg/api/registry_environment.go`, the one registry the engine leaves
      empty for downstreams to fill (`RegisterEnvironment`), backing the `mcts_self_play`
      macro's `env:`. See the Invariant A note below for why this one is a hook, not a spec.
@@ -147,6 +147,19 @@ The line this holds: naming a downstream component is data; **spelling decision 
 data is not**, and would mean growing a rules language inside the config. If a config ever
 needs to state `Legal`/`Apply`/`Terminal` themselves, that is a separate design question —
 not an extension of this hook.
+
+**Planning is the other side of that line, and it is in scope.** `mcts_planning` searches over
+the *forward model* rather than over authored rules: the dynamics are already partitions, so an
+action is a params injection, a transition is one step of the model, and the reward is another
+partition. Nothing has to be authored as rules, so no rules language appears — the decision
+problem is expressed in vocabulary the engine already owns. This is the same argument that puts
+`posterior_estimation` in scope: **search-as-forward-simulation**, a planner stepped as a
+partition, exactly as a posterior is. `agents.SimulationEnvironment` is the adapter, over
+`simulator.ReentrantSimulation`.
+
+So the two MCTS macros sit on opposite sides on purpose: `mcts_self_play` searches decision
+*rules* (downstream, named through the registry), `mcts_planning` searches a *model* (in scope,
+stated as data).
 
 ## Testing conventions
 

--- a/cfg/example_planning_config.yaml
+++ b/cfg/example_planning_config.yaml
@@ -10,12 +10,12 @@
 # while it is dear — worth 2 * (90 - 10) = 160 over these 8 steps. No myopic rule
 # gets there, because buying looks like a pure loss at the moment it must happen.
 #
-# CAVEAT worth understanding before trusting a number like that. The search plans
-# against a pinned noise realisation (see agents.SimulationEnvironment), so with a
-# stochastic model the return it predicts is optimistic relative to what the same
-# plan earns under other draws. Vary scenario_seed and aggregate — `run: {mode:
-# ensemble}` is the easy way — rather than reading one run's return as a forecast.
-# This example's model is deterministic, so here the figure is exact.
+# On stochastic models the search uses chance nodes by default: each action's
+# value is averaged over sampled successors rather than committed to the first
+# draw. That matters because the alternative — planning against one pinned
+# realisation — lets the search exploit the noise it is going to receive, and its
+# over-promise GROWS with sims_per_decision. Set `pinned_noise: true` to opt out;
+# it is faster and costs nothing when the model is deterministic, as here.
 macros:
 - type: mcts_planning
   name: plan

--- a/cfg/example_planning_config.yaml
+++ b/cfg/example_planning_config.yaml
@@ -1,0 +1,78 @@
+# Planning over a simulation, entirely as config.
+#
+# Where mcts_self_play searches over decision rules a downstream module wrote in
+# Go, this searches over the forward model itself: the dynamics are partitions,
+# an action is a params injection, and the reward is just another partition. So
+# nothing has to be named from outside and the whole decision problem is data.
+#
+# The problem is battery arbitrage. The price cycles 10, 10, 90, 90 and the
+# battery holds one unit, so the best play is to buy while it is cheap and sell
+# while it is dear — worth 2 * (90 - 10) = 160 over these 8 steps. No myopic rule
+# gets there, because buying looks like a pure loss at the moment it must happen.
+#
+# CAVEAT worth understanding before trusting a number like that. The search plans
+# against a pinned noise realisation (see agents.SimulationEnvironment), so with a
+# stochastic model the return it predicts is optimistic relative to what the same
+# plan earns under other draws. Vary scenario_seed and aggregate — `run: {mode:
+# ensemble}` is the easy way — rather than reading one run's return as a forecast.
+# This example's model is deterministic, so here the figure is exact.
+macros:
+- type: mcts_planning
+  name: plan
+  # Decisions to take, and how far each search looks ahead.
+  steps: 8
+  horizon: 8
+  sims_per_decision: 400
+  seed: 99
+  # UCB1 needs a bounded value scale, so returns are normalised against this.
+  # Widen it rather than letting returns clamp: a saturated score carries no
+  # gradient for the search.
+  return_range: [-400, 400]
+  # The discrete action set. Each entry is written to action_param on
+  # action_partition, so an action is whatever the model already reads as a
+  # parameter — here charge / hold / discharge.
+  actions: [[1], [0], [-1]]
+  action_partition: battery
+  action_param: dispatch
+  # The partition whose state[0] is the reward earned by the step just taken.
+  reward_partition: revenue
+  model:
+    partitions:
+    # Price cycles 10, 10, 90, 90. The phase is carried in the row because a
+    # planning run restarts the model every transition — it has to be Markov in
+    # its own state, with no reliance on the step counter.
+    - name: price
+      iteration:
+        type: expression
+        fields: [{name: price}, {name: phase}]
+        bindings:
+        - {name: nextphase, expr: "phase + 1 - 4 * floor((phase + 1) / 4)"}
+        outputs: ["where(nextphase < 2, 10, 90)", "nextphase"]
+      init_state_values: [90.0, 3.0]
+      state_history_depth: 1
+      seed: 0
+    # State of charge, clamped to [0, 1], reporting the flow that happened.
+    - name: battery
+      iteration:
+        type: expression
+        fields: [{name: soc}, {name: flow}]
+        bindings:
+        - {name: nextsoc, expr: "clamp(soc + dispatch, 0, 1)"}
+        outputs: ["nextsoc", "nextsoc - soc"]
+      params: {dispatch: [0.0]}
+      init_state_values: [0.0, 0.0]
+      state_history_depth: 1
+      seed: 0
+    # Reward: discharging (flow < 0) sells at the prevailing price.
+    - name: revenue
+      iteration:
+        type: expression
+        fields: [{name: r}]
+        outputs: ["0 - flow * price"]
+      params: {flow: [0.0], price: [0.0]}
+      params_from_upstream:
+        flow: {upstream: battery, indices: [1]}
+        price: {upstream: price, indices: [0]}
+      init_state_values: [0.0]
+      state_history_depth: 1
+      seed: 0

--- a/cfg/example_smc_config.yaml
+++ b/cfg/example_smc_config.yaml
@@ -1,6 +1,7 @@
-# Sequential Monte Carlo (particle filter) inference as config. The inner
-# per-particle model is a template: {particle} in partition names and upstream
-# refs is instantiated once per particle. Recovers the observed stream's mean.
+# Sequential Monte Carlo (particle filter) inference as config. The model under
+# `model.partitions` is written once and run once per particle, with each
+# particle's parameters routed in by `param_forwarding` and its random streams
+# seeded independently. Recovers the observed stream's mean.
 data:
   steps: 60
   timestep: 1.0
@@ -23,20 +24,20 @@ macros:
   param_names: [mean]
   model:
     observed_data: {name: observed_data, ref: {partition_name: obs}}
-    per_particle_partitions:
-    - name: "pred_{particle}"
+    partitions:
+    - name: "pred"
       iteration: {type: param_values}
       params: {param_values: [0.0]}
       init_state_values: [0.0]
       state_history_depth: 2
-    - name: "loglike_{particle}"
+    - name: "loglike"
       iteration: {type: data_comparison, likelihood: {type: normal}}
       params: {mean: [0.0], variance: [0.5], latest_data_values: [2.0], cumulative: [1], burn_in_steps: [0]}
       params_from_upstream:
-        mean: {upstream: "pred_{particle}"}
+        mean: {upstream: "pred"}
         latest_data_values: {upstream: observed_data}
       init_state_values: [0.0]
       state_history_depth: 2
-    loglike_partition: "loglike_{particle}"
+    loglike_partition: "loglike"
     param_forwarding:
-      "pred_{particle}/param_values": [0]
+      "pred/param_values": [0]

--- a/pkg/agents/doc.go
+++ b/pkg/agents/doc.go
@@ -18,6 +18,12 @@
 //     than failing, so raising the simulation count buys nothing.
 //   - Pluggable rollout functions (UniformRandomRollout, FromProgress,
 //     WinnerToTerminal)
+//   - Two search trees for two kinds of environment: MCTSTree commits to one
+//     successor per action edge, which is exactly right for deterministic game
+//     rules; MCTSChanceTree interposes chance nodes and averages over sampled
+//     successors, for environments implementing StochasticEnvironment. Using the
+//     deterministic tree on a stochastic model plans as though the dice were
+//     known, and the resulting over-promise grows with the search budget
 //   - MAST as an optional rollout strategy: a learning rollout policy backed
 //     by a separate aggregation partition holding running per-action-key
 //     (count, sum) state

--- a/pkg/agents/environment.go
+++ b/pkg/agents/environment.go
@@ -20,6 +20,29 @@ type Environment[S any, A any] interface {
 	Players(s S) int
 }
 
+// StochasticEnvironment is an Environment whose transitions can be resampled.
+//
+// Environment.Apply is deterministic by contract, because the search materialises
+// a successor once per edge and reuses it. For a genuinely stochastic process
+// that pins the noise: the planner ends up solving one realisation, and can
+// exploit the particular draw it is going to receive, so the value it computes is
+// optimistic relative to the true expectation.
+//
+// Implementing this interface says "there is a distribution here, and here is how
+// to draw from it". A search that recognises it can build chance nodes and average
+// over outcomes rather than committing to the first one — see MCTSChanceTree.
+// Environments that are actually deterministic (game rules) should not implement
+// it; they gain nothing and would pay for outcome nodes that never differ.
+type StochasticEnvironment[S any, A any] interface {
+	Environment[S, A]
+
+	// ApplySample draws one successor of (s, a) under the given sample seed.
+	// Distinct seeds must give draws from the transition distribution, and the
+	// same seed must reproduce its draw — the search caches outcomes and has to
+	// be able to revisit them.
+	ApplySample(s S, a A, seed uint64) (S, error)
+}
+
 // MCTSEdgeStat is per-action telemetry exposed at the root after a search.
 // Useful for JSON reports or logging the search's distribution over moves.
 type MCTSEdgeStat[A any] struct {

--- a/pkg/agents/mcts_chance_tree.go
+++ b/pkg/agents/mcts_chance_tree.go
@@ -5,41 +5,22 @@ import (
 	"math/rand/v2"
 )
 
-// MCTSChanceTree is the UCT tree for genuinely stochastic environments: it
-// separates a decision from its outcome, so a value is an average over sampled
-// successors rather than a commitment to the first one drawn.
+// MCTSChanceTree is the UCT tree for stochastic environments, where an action's
+// value is an average over sampled successors rather than the value of one.
 //
-// # Why this exists alongside MCTSTree
+// Levels alternate. A decision node holds a state and one chance child per legal
+// action. A chance node holds no state — it stands for "this action was taken,
+// and nature has not resolved yet" — and its children are sampled successors.
+// Action selection at a decision node is UCB1 over the chance children, whose
+// statistics are therefore averages over outcomes.
 //
-// MCTSTree materialises one successor per action edge and reuses it. For a
-// deterministic environment that is exactly right and costs nothing. For a
-// stochastic one it silently pins the noise: the search solves a single
-// realisation and can exploit the particular draw it is going to receive, so the
-// value it reports is optimistic relative to the expectation.
+// A chance node cannot enumerate its outcomes, so their number grows with visits
+// as ceil(k * visits^alpha), alpha in (0,1). Unbounded, every visit would draw a
+// fresh successor and no outcome would collect enough visits for its average to
+// mean anything.
 //
-// The two are kept separate rather than merged behind a flag because the game
-// path is deterministic, shipped, and would pay complexity for a case it never
-// hits — and because the algorithms genuinely differ, rather than one being a
-// parameterisation of the other.
-//
-// # Shape
-//
-// Levels alternate. A DECISION node holds a state and one chance child per legal
-// action. A CHANCE node holds no state; it stands for "action a was taken from
-// the parent's state, and nature has not resolved yet", and its children are
-// sampled successors. Action selection at a decision node is UCB1 over the chance
-// children's aggregate statistics — which are, by construction, averages over
-// outcomes. That is the whole point.
-//
-// # Progressive widening
-//
-// A chance node cannot enumerate its outcomes: for a continuous-noise model there
-// are infinitely many. Instead the number of sampled outcomes is allowed to grow
-// with the number of visits, as ceil(k * visits^alpha) with alpha in (0,1). Early
-// on a chance node commits to few outcomes so statistics accumulate; as it is
-// visited more, new draws are added and the average converges on the expectation.
-// Without the widening bound, every visit would sample a fresh successor and no
-// node would ever collect enough visits to be worth anything.
+// Use MCTSTree for deterministic environments: one successor per edge is exact
+// there, and outcome nodes whose samples never differ are pure cost.
 type MCTSChanceTree[S any, A any] struct {
 	nodes []chanceTreeNode[S]
 }

--- a/pkg/agents/mcts_chance_tree.go
+++ b/pkg/agents/mcts_chance_tree.go
@@ -1,0 +1,297 @@
+package agents
+
+import (
+	"math"
+	"math/rand/v2"
+)
+
+// MCTSChanceTree is the UCT tree for genuinely stochastic environments: it
+// separates a decision from its outcome, so a value is an average over sampled
+// successors rather than a commitment to the first one drawn.
+//
+// # Why this exists alongside MCTSTree
+//
+// MCTSTree materialises one successor per action edge and reuses it. For a
+// deterministic environment that is exactly right and costs nothing. For a
+// stochastic one it silently pins the noise: the search solves a single
+// realisation and can exploit the particular draw it is going to receive, so the
+// value it reports is optimistic relative to the expectation.
+//
+// The two are kept separate rather than merged behind a flag because the game
+// path is deterministic, shipped, and would pay complexity for a case it never
+// hits — and because the algorithms genuinely differ, rather than one being a
+// parameterisation of the other.
+//
+// # Shape
+//
+// Levels alternate. A DECISION node holds a state and one chance child per legal
+// action. A CHANCE node holds no state; it stands for "action a was taken from
+// the parent's state, and nature has not resolved yet", and its children are
+// sampled successors. Action selection at a decision node is UCB1 over the chance
+// children's aggregate statistics — which are, by construction, averages over
+// outcomes. That is the whole point.
+//
+// # Progressive widening
+//
+// A chance node cannot enumerate its outcomes: for a continuous-noise model there
+// are infinitely many. Instead the number of sampled outcomes is allowed to grow
+// with the number of visits, as ceil(k * visits^alpha) with alpha in (0,1). Early
+// on a chance node commits to few outcomes so statistics accumulate; as it is
+// visited more, new draws are added and the average converges on the expectation.
+// Without the widening bound, every visit would sample a fresh successor and no
+// node would ever collect enough visits to be worth anything.
+type MCTSChanceTree[S any, A any] struct {
+	nodes []chanceTreeNode[S]
+}
+
+// chanceTreeNode is one node of MCTSChanceTree. The isChance flag distinguishes
+// the two levels; state is meaningful only on decision nodes.
+type chanceTreeNode[S any] struct {
+	state    S
+	parent   int
+	isChance bool
+	// legalIdx is the parent's legal-action index that created this node
+	// (chance nodes only; -1 on decision nodes).
+	legalIdx int
+	// actor is who chose the action leading here, so backups credit the right
+	// player. A chance node inherits its deciding player's index.
+	actor    int
+	visits   int
+	wins     float64
+	children []int
+	expanded bool
+	// sampleCount counts draws taken at a chance node, so each new outcome gets
+	// a distinct sample seed.
+	sampleCount int
+}
+
+// Default progressive-widening parameters. alpha = 0.5 is the usual choice: the
+// outcome count grows as the square root of the visit count, which keeps enough
+// visits per outcome for their averages to mean something.
+const (
+	MCTSDefaultChanceWideningFactor   = 1.0
+	MCTSDefaultChanceWideningExponent = 0.5
+)
+
+// NewMCTSChanceTree returns a tree with a single decision node at root.
+func NewMCTSChanceTree[S any, A any](root S) *MCTSChanceTree[S, A] {
+	return &MCTSChanceTree[S, A]{
+		nodes: []chanceTreeNode[S]{{state: root, parent: -1, legalIdx: -1}},
+	}
+}
+
+// Reset replaces the tree with a fresh root.
+func (t *MCTSChanceTree[S, A]) Reset(root S) {
+	t.nodes = t.nodes[:0]
+	t.nodes = append(t.nodes, chanceTreeNode[S]{state: root, parent: -1, legalIdx: -1})
+}
+
+// Root returns the root state.
+func (t *MCTSChanceTree[S, A]) Root() S { return t.nodes[0].state }
+
+// NodeCount returns the number of nodes, decision and chance alike.
+func (t *MCTSChanceTree[S, A]) NodeCount() int { return len(t.nodes) }
+
+// SelectLeafWithOutcome walks from the root to a leaf, alternating UCB1 action
+// choices at decision nodes with sampled outcomes at chance nodes, and reports
+// why it stopped. It mirrors MCTSTree.SelectLeafWithOutcome so the same
+// backup rules apply, and pairs with BackupScores / BackupVisits.
+func (t *MCTSChanceTree[S, A]) SelectLeafWithOutcome(
+	env Environment[S, A],
+	cfg *MCTSConfig[S, A],
+	rng *rand.Rand,
+) (path []int, leafState S, leafIdx int, outcome MCTSLeafOutcome) {
+	cfg.applyDefaults()
+	sampler, ok := env.(StochasticEnvironment[S, A])
+	if !ok {
+		// Without a way to resample there are no chance nodes to build. Fail
+		// loudly rather than silently degrading to a pinned-noise search, which
+		// is the bias this type exists to remove.
+		panic("agents.MCTSChanceTree: env must implement StochasticEnvironment")
+	}
+	factor, exponent := chanceWidening(cfg)
+
+	path = make([]int, 0, 32)
+	cur := 0
+	depth := 0
+	for {
+		node := &t.nodes[cur]
+		if !node.isChance {
+			if _, done := env.Terminal(node.state); done {
+				return path, node.state, cur, MCTSLeafTerminal
+			}
+			if depth >= cfg.MaxTreeDepth {
+				return path, node.state, cur, MCTSLeafDepthCapped
+			}
+			legal := env.Legal(node.state)
+			if len(legal) == 0 {
+				return path, node.state, cur, MCTSLeafNoLegalActions
+			}
+			if !node.expanded {
+				node.children = make([]int, len(legal))
+				for i := range node.children {
+					node.children[i] = -1
+				}
+				node.expanded = true
+			}
+			pick := t.bestAction(cur, cfg.Exploration)
+			if node.children[pick] < 0 {
+				// Creating a chance node costs nothing: no state, no env call.
+				// Nature resolves on the next iteration of this loop.
+				child := len(t.nodes)
+				t.nodes = append(t.nodes, chanceTreeNode[S]{
+					parent:   cur,
+					isChance: true,
+					legalIdx: pick,
+					actor:    env.Actor(node.state),
+				})
+				t.nodes[cur].children[pick] = child
+			}
+			next := t.nodes[cur].children[pick]
+			path = append(path, next)
+			cur = next
+			continue
+		}
+
+		// Chance node: either widen with a fresh draw, or revisit an outcome.
+		parent := &t.nodes[node.parent]
+		legal := env.Legal(parent.state)
+		if node.legalIdx >= len(legal) {
+			return path, parent.state, cur, MCTSLeafApplyFailed
+		}
+		allowed := int(math.Ceil(factor * math.Pow(float64(node.visits+1), exponent)))
+		if allowed < 1 {
+			allowed = 1
+		}
+		if len(node.children) < allowed {
+			node.sampleCount++
+			// Seed from the node's identity and draw index so a given outcome is
+			// reproducible, and two outcomes of one chance node never coincide.
+			seed := uint64(cur+1)*0x9e3779b97f4a7c15 ^ uint64(node.sampleCount)
+			sampled, err := sampler.ApplySample(parent.state, legal[node.legalIdx], seed)
+			if err != nil {
+				return path, parent.state, cur, MCTSLeafApplyFailed
+			}
+			child := len(t.nodes)
+			t.nodes = append(t.nodes, chanceTreeNode[S]{
+				state:    sampled,
+				parent:   cur,
+				legalIdx: -1,
+				actor:    t.nodes[cur].actor,
+			})
+			t.nodes[cur].children = append(t.nodes[cur].children, child)
+			path = append(path, child)
+			return path, sampled, child, MCTSLeafExpanded
+		}
+		// Revisit an existing outcome, uniformly. Each was drawn from the
+		// transition distribution, so visiting them equally keeps the running
+		// average an unbiased estimate of the expectation.
+		pick := node.children[rng.IntN(len(node.children))]
+		path = append(path, pick)
+		cur = pick
+		depth++
+	}
+}
+
+// SelectLeaf is the boolean-shaped form, matching MCTSTree.SelectLeaf.
+func (t *MCTSChanceTree[S, A]) SelectLeaf(
+	env Environment[S, A],
+	cfg *MCTSConfig[S, A],
+	rng *rand.Rand,
+) (path []int, leafState S, leafIdx int, ok bool) {
+	path, leafState, leafIdx, outcome := t.SelectLeafWithOutcome(env, cfg, rng)
+	return path, leafState, leafIdx, outcome == MCTSLeafExpanded
+}
+
+// BackupScores credits each node on path with its actor's score.
+func (t *MCTSChanceTree[S, A]) BackupScores(path []int, scores []float64) {
+	if len(scores) == 0 {
+		return
+	}
+	t.BackupVisits(path, scores)
+}
+
+// BackupVisits increments visits along path, crediting wins only when scores are
+// present — the no-signal-tolerant form, for the same reason as MCTSTree's.
+func (t *MCTSChanceTree[S, A]) BackupVisits(path []int, scores []float64) {
+	for _, index := range path {
+		node := &t.nodes[index]
+		node.visits++
+		if scores != nil && node.actor >= 0 && node.actor < len(scores) {
+			node.wins += scores[node.actor]
+		}
+	}
+}
+
+// RootStatsByLegalIdx returns per-action visits and win sums at the root, padded
+// to maxLegalActions. The statistics come from the chance children, so each is
+// already an average over that action's sampled outcomes.
+func (t *MCTSChanceTree[S, A]) RootStatsByLegalIdx(
+	maxLegalActions int,
+) (visits, wins []float64) {
+	visits = make([]float64, maxLegalActions)
+	wins = make([]float64, maxLegalActions)
+	root := &t.nodes[0]
+	for action, child := range root.children {
+		if action >= maxLegalActions || child < 0 {
+			continue
+		}
+		visits[action] = float64(t.nodes[child].visits)
+		wins[action] = t.nodes[child].wins
+	}
+	return visits, wins
+}
+
+// RootBestLegalIdx returns the most-visited action at the root.
+func (t *MCTSChanceTree[S, A]) RootBestLegalIdx() (int, bool) {
+	root := &t.nodes[0]
+	best, bestVisits := -1, -1
+	for action, child := range root.children {
+		if child < 0 {
+			continue
+		}
+		if visits := t.nodes[child].visits; visits > bestVisits {
+			best, bestVisits = action, visits
+		}
+	}
+	return best, best >= 0
+}
+
+// bestAction picks the root-to-leaf action at a decision node: any never-tried
+// action first, then UCB1 over the chance children's averages.
+func (t *MCTSChanceTree[S, A]) bestAction(parent int, exploration float64) int {
+	node := &t.nodes[parent]
+	for action, child := range node.children {
+		if child < 0 || t.nodes[child].visits == 0 {
+			return action
+		}
+	}
+	best, bestScore := 0, math.Inf(-1)
+	total := 0
+	for _, child := range node.children {
+		total += t.nodes[child].visits
+	}
+	logTotal := math.Log(float64(max(total, 1)))
+	for action, child := range node.children {
+		stats := &t.nodes[child]
+		mean := stats.wins / float64(stats.visits)
+		score := mean + exploration*math.Sqrt(logTotal/float64(stats.visits))
+		if score > bestScore {
+			best, bestScore = action, score
+		}
+	}
+	return best
+}
+
+// chanceWidening resolves the progressive-widening parameters, defaulting when
+// unset so a bare MCTSConfig works.
+func chanceWidening[S any, A any](cfg *MCTSConfig[S, A]) (factor, exponent float64) {
+	factor, exponent = cfg.ChanceWideningFactor, cfg.ChanceWideningExponent
+	if factor <= 0 {
+		factor = MCTSDefaultChanceWideningFactor
+	}
+	if exponent <= 0 || exponent >= 1 {
+		exponent = MCTSDefaultChanceWideningExponent
+	}
+	return factor, exponent
+}

--- a/pkg/agents/mcts_chance_tree_internal_test.go
+++ b/pkg/agents/mcts_chance_tree_internal_test.go
@@ -1,0 +1,150 @@
+package agents
+
+// Internal tests for MCTSChanceTree: they reach into the node array, because the
+// property that matters — that a chance node accumulates SEVERAL successors for
+// one action, at a controlled rate — is invisible from the public surface.
+
+import (
+	"math"
+	"math/rand/v2"
+	"testing"
+)
+
+// coinEnv is a minimal stochastic environment: the state is a running total, and
+// each action adds a draw that depends on the sample seed. Two actions, so a
+// decision node has two chance children.
+type coinEnv struct{ horizon float64 }
+
+func (e coinEnv) Legal(s []float64) []int {
+	if s[0] >= e.horizon {
+		return nil
+	}
+	return []int{0, 1}
+}
+
+func (e coinEnv) Apply(s []float64, a int) ([]float64, error) {
+	return e.ApplySample(s, a, 0)
+}
+
+func (e coinEnv) ApplySample(s []float64, a int, seed uint64) ([]float64, error) {
+	rng := rand.New(rand.NewPCG(seed, uint64(a)+1))
+	return []float64{s[0] + 1, s[1] + float64(a)*rng.Float64()}, nil
+}
+
+func (e coinEnv) Terminal(s []float64) ([]float64, bool) {
+	if s[0] < e.horizon {
+		return nil, false
+	}
+	return []float64{math.Min(1, math.Max(0, s[1]/e.horizon))}, true
+}
+
+func (e coinEnv) Actor([]float64) int   { return 0 }
+func (e coinEnv) Players([]float64) int { return 1 }
+
+var _ StochasticEnvironment[[]float64, int] = coinEnv{}
+
+// runChanceIterations drives the tree the way RunChanceMCTSSearch does.
+func runChanceIterations(
+	tree *MCTSChanceTree[[]float64, int],
+	env StochasticEnvironment[[]float64, int],
+	cfg *MCTSConfig[[]float64, int],
+	sims int,
+) {
+	for i := 0; i < sims; i++ {
+		rng := rand.New(rand.NewPCG(uint64(i+1), uint64(i)*7+1))
+		path, leaf, _, outcome := tree.SelectLeafWithOutcome(env, cfg, rng)
+		switch outcome {
+		case MCTSLeafTerminal:
+			if scores, done := env.Terminal(leaf); done {
+				tree.BackupScores(path, scores)
+			}
+		case MCTSLeafExpanded, MCTSLeafDepthCapped, MCTSLeafNoLegalActions:
+			scores, ok, _ := cfg.Rollout(env, leaf, cfg.RolloutMaxSteps, rng.Uint64())
+			if !ok {
+				scores = nil
+			}
+			tree.BackupVisits(path, scores)
+		}
+	}
+}
+
+// TestChanceNodesAccumulateSeveralOutcomes is the defining behaviour: one action
+// leads to MANY sampled successors, which is what makes its value an average over
+// the transition distribution rather than a single draw.
+func TestChanceNodesAccumulateSeveralOutcomes(t *testing.T) {
+	env := coinEnv{horizon: 4}
+	tree := NewMCTSChanceTree[[]float64, int]([]float64{0, 0})
+	cfg := &MCTSConfig[[]float64, int]{
+		MaxTreeDepth:    6,
+		RolloutMaxSteps: 6,
+		Rollout:         UniformRandomRollout[[]float64, int](),
+	}
+	runChanceIterations(tree, env, cfg, 400)
+
+	root := tree.nodes[0]
+	if len(root.children) != 2 {
+		t.Fatalf("root should have one chance child per action, got %d", len(root.children))
+	}
+	for action, child := range root.children {
+		chance := tree.nodes[child]
+		if !chance.isChance {
+			t.Fatalf("root child %d should be a chance node", action)
+		}
+		if len(chance.children) < 2 {
+			t.Errorf("action %d accumulated only %d outcome(s) over %d visits; "+
+				"without several the value is still one draw, not an average",
+				action, len(chance.children), chance.visits)
+		}
+		// Distinct draws must actually differ, or the "distribution" is a point
+		// mass and the sample seed is not reaching the environment.
+		seen := make(map[float64]bool)
+		for _, outcome := range chance.children {
+			seen[tree.nodes[outcome].state[1]] = true
+		}
+		if action == 1 && len(seen) < 2 {
+			t.Errorf("action %d: %d outcomes but only %d distinct successor states",
+				action, len(chance.children), len(seen))
+		}
+	}
+}
+
+// TestChanceWideningRespectsItsBound pins the growth rule. Unbounded widening
+// would draw a fresh successor on every visit, so no outcome would ever collect
+// enough visits for its average to mean anything.
+func TestChanceWideningRespectsItsBound(t *testing.T) {
+	env := coinEnv{horizon: 4}
+	cfg := &MCTSConfig[[]float64, int]{
+		MaxTreeDepth:           6,
+		RolloutMaxSteps:        6,
+		Rollout:                UniformRandomRollout[[]float64, int](),
+		ChanceWideningFactor:   1.0,
+		ChanceWideningExponent: 0.5,
+	}
+	tree := NewMCTSChanceTree[[]float64, int]([]float64{0, 0})
+	runChanceIterations(tree, env, cfg, 600)
+
+	for index, node := range tree.nodes {
+		if !node.isChance {
+			continue
+		}
+		bound := int(math.Ceil(1.0 * math.Pow(float64(node.visits+1), 0.5)))
+		if len(node.children) > bound {
+			t.Errorf("chance node %d has %d outcomes after %d visits, above the "+
+				"widening bound of %d", index, len(node.children), node.visits, bound)
+		}
+	}
+}
+
+// TestChanceTreeRejectsDeterministicEnvironment checks the search fails loudly
+// rather than quietly degrading to a pinned-noise tree, which is the bias it
+// exists to remove.
+func TestChanceTreeRejectsDeterministicEnvironment(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected a panic when the env cannot resample")
+		}
+	}()
+	tree := NewMCTSChanceTree[TTTState, TTTAction](TTTState{})
+	cfg := &MCTSConfig[TTTState, TTTAction]{}
+	tree.SelectLeafWithOutcome(&TTTGame{}, cfg, rand.New(rand.NewPCG(1, 2)))
+}

--- a/pkg/agents/mcts_chance_tree_internal_test.go
+++ b/pkg/agents/mcts_chance_tree_internal_test.go
@@ -148,3 +148,69 @@ func TestChanceTreeRejectsDeterministicEnvironment(t *testing.T) {
 	cfg := &MCTSConfig[TTTState, TTTAction]{}
 	tree.SelectLeafWithOutcome(&TTTGame{}, cfg, rand.New(rand.NewPCG(1, 2)))
 }
+
+// TestChanceTreeAccessors covers the small surface MCTSTreeIteration drives it
+// through, including Reset — which the self-play pipeline calls whenever the
+// game advances and the old tree no longer applies.
+func TestChanceTreeAccessors(t *testing.T) {
+	env := coinEnv{horizon: 4}
+	tree := NewMCTSChanceTree[[]float64, int]([]float64{0, 0})
+	cfg := &MCTSConfig[[]float64, int]{
+		MaxTreeDepth:    6,
+		RolloutMaxSteps: 6,
+		Rollout:         UniformRandomRollout[[]float64, int](),
+	}
+	if tree.NodeCount() != 1 || tree.Root()[0] != 0 {
+		t.Fatalf("fresh tree should be a lone root, got %d nodes rooted at %v",
+			tree.NodeCount(), tree.Root())
+	}
+	runChanceIterations(tree, env, cfg, 200)
+	if tree.NodeCount() <= 1 {
+		t.Fatal("the tree did not grow")
+	}
+
+	visits, wins := tree.RootStatsByLegalIdx(5)
+	if len(visits) != 5 || len(wins) != 5 {
+		t.Fatalf("stats should be padded to the requested width, got %d/%d",
+			len(visits), len(wins))
+	}
+	total := 0.0
+	for _, v := range visits {
+		total += v
+	}
+	if total == 0 {
+		t.Error("root actions recorded no visits")
+	}
+	if visits[2] != 0 || wins[2] != 0 {
+		t.Errorf("padding slots should stay zero, got %v/%v", visits[2], wins[2])
+	}
+
+	// SelectLeaf is the boolean-shaped wrapper: true only on a real expansion.
+	_, _, _, ok := tree.SelectLeaf(env, cfg, rand.New(rand.NewPCG(5, 6)))
+	_ = ok
+
+	tree.Reset([]float64{2, 0})
+	if tree.NodeCount() != 1 || tree.Root()[0] != 2 {
+		t.Fatalf("Reset should leave a lone root at the new state, got %d nodes at %v",
+			tree.NodeCount(), tree.Root())
+	}
+	if visits, _ := tree.RootStatsByLegalIdx(2); visits[0] != 0 || visits[1] != 0 {
+		t.Errorf("Reset should clear root statistics, got %v", visits)
+	}
+}
+
+// TestRunChanceMCTSSearchGuards covers the two ways a search can be asked for
+// something it cannot answer.
+func TestRunChanceMCTSSearchGuards(t *testing.T) {
+	cfg := MCTSConfig[[]float64, int]{Rollout: UniformRandomRollout[[]float64, int]()}
+
+	if _, _, err := RunChanceMCTSSearch[[]float64, int](
+		nil, []float64{0, 0}, cfg, 1, 10); err == nil {
+		t.Error("expected an error for a nil environment")
+	}
+	// A terminal root offers no legal actions, so there is nothing to choose.
+	if _, _, err := RunChanceMCTSSearch[[]float64, int](
+		coinEnv{horizon: 4}, []float64{4, 0}, cfg, 1, 10); err == nil {
+		t.Error("expected an error when the root has no legal actions")
+	}
+}

--- a/pkg/agents/mcts_config.go
+++ b/pkg/agents/mcts_config.go
@@ -25,6 +25,16 @@ type MCTSConfig[S any, A any] struct {
 	RolloutMaxSteps int
 	Rollout         MCTSRolloutFn[S, A]
 	Progress        func(s S, player int) (float64, bool)
+
+	// ChanceWideningFactor and ChanceWideningExponent tune progressive widening
+	// in MCTSChanceTree: a chance node holds up to
+	// ceil(factor * visits^exponent) sampled outcomes. Ignored by MCTSTree,
+	// which has no chance nodes. Zero selects the package defaults.
+	//
+	// A larger factor or exponent averages over more outcomes per node but
+	// spreads the same visits more thinly, so each average is noisier.
+	ChanceWideningFactor   float64
+	ChanceWideningExponent float64
 }
 
 // ApplyDefaults fills in zero-valued hyperparameters with the package

--- a/pkg/agents/mcts_run_chance_search.go
+++ b/pkg/agents/mcts_run_chance_search.go
@@ -1,0 +1,91 @@
+package agents
+
+import (
+	"fmt"
+	"math/rand/v2"
+)
+
+// RunChanceMCTSSearch is RunMCTSSearch for stochastic environments: it searches
+// an MCTSChanceTree, so each action's value is an average over sampled outcomes
+// rather than the value of the single successor that happened to be drawn first.
+//
+// Use it when the environment genuinely has a transition distribution and the
+// number it reports is going to be believed. The deterministic search is faster
+// and perfectly correct for game rules, but against a stochastic model it plans
+// as though it knew which way the dice would fall.
+func RunChanceMCTSSearch[S any, A any](
+	env StochasticEnvironment[S, A],
+	root S,
+	cfg MCTSConfig[S, A],
+	baseSeed uint64,
+	sims int,
+) (A, []MCTSEdgeStat[A], error) {
+	var zero A
+	if env == nil {
+		return zero, nil, fmt.Errorf("mcts: env is nil")
+	}
+	cfg.applyDefaults()
+	if cfg.Rollout == nil {
+		cfg.Rollout = UniformRandomRollout[S, A]()
+	}
+	if sims < 1 {
+		sims = cfg.Simulations
+	}
+	legal := env.Legal(root)
+	if len(legal) == 0 {
+		return zero, nil, fmt.Errorf("mcts: no legal actions")
+	}
+
+	tree := NewMCTSChanceTree[S, A](root)
+	for i := 0; i < sims; i++ {
+		rng := rand.New(rand.NewPCG(
+			baseSeed^uint64(i+1),
+			uint64(i)*0x9e3779b97f4a7c15+1,
+		))
+		path, leafState, _, outcome := tree.SelectLeafWithOutcome(env, &cfg, rng)
+		switch outcome {
+		case MCTSLeafTerminal:
+			// Exact scores from the environment; no rollout needed.
+			if scores, done := env.Terminal(leafState); done {
+				tree.BackupScores(path, scores)
+			}
+		case MCTSLeafExpanded, MCTSLeafDepthCapped, MCTSLeafNoLegalActions:
+			scores, ok, _ := cfg.Rollout(env, leafState, cfg.RolloutMaxSteps, rng.Uint64())
+			if !ok {
+				scores = nil
+			}
+			tree.BackupVisits(path, scores)
+		case MCTSLeafApplyFailed:
+			// An environment fault, not a search result: back up nothing.
+		}
+	}
+
+	best, ok := tree.RootBestLegalIdx()
+	if !ok || best < 0 || best >= len(legal) {
+		return legal[0], nil, nil
+	}
+	return legal[best], tree.rootEdgeStats(legal), nil
+}
+
+// rootEdgeStats reports per-action telemetry at the root, mirroring
+// MCTSTree.RootEdgeStats.
+func (t *MCTSChanceTree[S, A]) rootEdgeStats(legal []A) []MCTSEdgeStat[A] {
+	stats := make([]MCTSEdgeStat[A], 0, len(legal))
+	root := &t.nodes[0]
+	for action, child := range root.children {
+		if action >= len(legal) || child < 0 {
+			continue
+		}
+		node := &t.nodes[child]
+		mean := 0.0
+		if node.visits > 0 {
+			mean = node.wins / float64(node.visits)
+		}
+		stats = append(stats, MCTSEdgeStat[A]{
+			Action:       legal[action],
+			Visits:       node.visits,
+			MeanForActor: mean,
+		})
+	}
+	return stats
+}

--- a/pkg/agents/mcts_run_chance_search.go
+++ b/pkg/agents/mcts_run_chance_search.go
@@ -5,14 +5,9 @@ import (
 	"math/rand/v2"
 )
 
-// RunChanceMCTSSearch is RunMCTSSearch for stochastic environments: it searches
-// an MCTSChanceTree, so each action's value is an average over sampled outcomes
-// rather than the value of the single successor that happened to be drawn first.
-//
-// Use it when the environment genuinely has a transition distribution and the
-// number it reports is going to be believed. The deterministic search is faster
-// and perfectly correct for game rules, but against a stochastic model it plans
-// as though it knew which way the dice would fall.
+// RunChanceMCTSSearch is RunMCTSSearch over an MCTSChanceTree, so each action's
+// value averages over sampled outcomes. Prefer it whenever the environment has a
+// real transition distribution and the value it reports will be believed.
 func RunChanceMCTSSearch[S any, A any](
 	env StochasticEnvironment[S, A],
 	root S,

--- a/pkg/agents/mcts_tree.go
+++ b/pkg/agents/mcts_tree.go
@@ -575,8 +575,18 @@ type MCTSTreeIteration[S any, A any] struct {
 	MaxLegalActions int
 	StateWidth      int
 	Players         int
+	// ChanceNodes searches an MCTSChanceTree instead, averaging each action's
+	// value over sampled successors rather than committing to the first one
+	// drawn. Requires Env to implement StochasticEnvironment.
+	//
+	// Leave it off for deterministic environments: they gain nothing and would
+	// pay for outcome nodes whose samples never differ. Turn it on whenever the
+	// value the search reports is going to be believed — against a stochastic
+	// model the deterministic search plans as though it knew which way the dice
+	// would fall, and its over-promise grows with the simulation budget.
+	ChanceNodes bool
 
-	tree        *MCTSTree[S, A]
+	tree        mctsSearchTree[S, A]
 	pendingPath []int // path selected last step, awaiting scores this step
 	seed        uint64
 	root        S
@@ -677,7 +687,15 @@ func (m *MCTSTreeIteration[S, A]) Configure(partitionIndex int, settings *simula
 	}
 	m.root = root
 	m.rootEncoded = encoded
-	m.tree = NewMCTSTree[S, A](root)
+	if m.ChanceNodes {
+		if _, ok := m.Env.(StochasticEnvironment[S, A]); !ok {
+			panic("agents.MCTSTreeIteration: ChanceNodes needs an Env implementing " +
+				"StochasticEnvironment (there is no way to resample a transition)")
+		}
+		m.tree = NewMCTSChanceTree[S, A](root)
+	} else {
+		m.tree = NewMCTSTree[S, A](root)
+	}
 	m.pendingPath = nil
 	m.seed = is.Seed
 }
@@ -718,11 +736,11 @@ func (m *MCTSTreeIteration[S, A]) Iterate(
 	// step N) and applies the backup here.
 	if m.pendingPath != nil {
 		if scores, ok := readUpstreamScores(params, stateHistories, m.Players); ok {
-			m.tree.backupScores(m.pendingPath, scores)
+			m.tree.BackupScores(m.pendingPath, scores)
 		} else {
 			// No-signal-tolerant: count visits even when scores are absent.
 			// See MCTSTree.backupVisits docstring for why.
-			m.tree.backupVisits(m.pendingPath, nil)
+			m.tree.BackupVisits(m.pendingPath, nil)
 		}
 		m.pendingPath = nil
 	}
@@ -753,7 +771,7 @@ func (m *MCTSTreeIteration[S, A]) Iterate(
 		// The environment scores a finished position exactly, so back it up now
 		// rather than paying a rollout round-trip for an already-known result.
 		if scores, done := m.Env.Terminal(leafState); done {
-			m.tree.backupScores(path, scores)
+			m.tree.BackupScores(path, scores)
 		}
 		leafState = m.root
 	case MCTSLeafApplyFailed:
@@ -830,7 +848,43 @@ func readUpstreamScores(
 	return out, true
 }
 
-// MCTSTree exposes the underlying search tree (typically for telemetry).
+// MCTSTree exposes the underlying deterministic search tree (typically for
+// telemetry). It returns nil when ChanceNodes is set, since the partition is then
+// driving an MCTSChanceTree instead — use SearchTree for the common surface.
 func (m *MCTSTreeIteration[S, A]) MCTSTree() *MCTSTree[S, A] {
+	tree, _ := m.tree.(*MCTSTree[S, A])
+	return tree
+}
+
+// SearchTree exposes whichever tree this partition is driving, for the telemetry
+// both kinds share (root statistics, node count).
+func (m *MCTSTreeIteration[S, A]) SearchTree() interface {
+	Root() S
+	NodeCount() int
+	RootStatsByLegalIdx(maxLegalActions int) (visits, wins []float64)
+	RootBestLegalIdx() (int, bool)
+} {
 	return m.tree
 }
+
+// mctsSearchTree is the surface MCTSTreeIteration drives, so the same partition
+// can host either the deterministic tree or the chance-node one. Both apply the
+// same backup rules to a selected path; they differ in what the path traverses
+// and in whether a successor is committed to or resampled.
+type mctsSearchTree[S any, A any] interface {
+	Reset(root S)
+	Root() S
+	NodeCount() int
+	SelectLeafWithOutcome(
+		env Environment[S, A], cfg *MCTSConfig[S, A], rng *rand.Rand,
+	) (path []int, leafState S, leafIdx int, outcome MCTSLeafOutcome)
+	BackupScores(path []int, scores []float64)
+	BackupVisits(path []int, scores []float64)
+	RootStatsByLegalIdx(maxLegalActions int) (visits, wins []float64)
+	RootBestLegalIdx() (int, bool)
+}
+
+var (
+	_ mctsSearchTree[int, int] = (*MCTSTree[int, int])(nil)
+	_ mctsSearchTree[int, int] = (*MCTSChanceTree[int, int])(nil)
+)

--- a/pkg/agents/mcts_tree_test.go
+++ b/pkg/agents/mcts_tree_test.go
@@ -499,18 +499,14 @@ func TestMCTSTreeIterationTerminalRootEmitsHasLeafFalse(t *testing.T) {
 }
 
 // TestMCTSTreeIterationBacksUpTerminalSelections pins the decomposed pipeline's
-// terminal handling against MCTSTree.RunOne's.
-//
-// When SelectLeaf walks into an already-terminal node it returns ok=false. The
-// partition used to discard that path entirely — no visit, no score — so once a
-// tree saturated (endgames, shallow games) it stopped accumulating statistics
-// and raising the simulation count bought nothing. RunOne has always backed the
-// terminal scores up instead, which is why the one-shot RunMCTSSearch found
-// wins the partitioned self-play stack missed.
+// terminal handling against MCTSTree.RunOne's: a selection reaching an
+// already-terminal node must back up that node's exact scores, not be discarded.
 //
 // The position has three empty cells, so the tree saturates within a handful of
 // steps and almost every later selection lands on a terminal node. Root visits
-// must therefore keep tracking the step count.
+// must therefore keep tracking the step count; dropping them would leave a
+// saturated tree accumulating nothing, so raising the simulation count would buy
+// nothing either.
 func TestMCTSTreeIterationBacksUpTerminalSelections(t *testing.T) {
 	const steps = 60
 	tree := newMCTSTreeIteration()
@@ -557,15 +553,13 @@ func TestMCTSTreeIterationBacksUpTerminalSelections(t *testing.T) {
 	}
 }
 
-// TestMCTSTreeIterationBacksUpDepthCappedSelections is the depth-cap counterpart
-// to the terminal test above: MCTSTree.RunOne rolls out from a depth-capped node
-// and backs the result up, so the decomposed pipeline must publish that node as a
-// leaf rather than drop the iteration.
+// TestMCTSTreeIterationBacksUpDepthCappedSelections is the depth-cap counterpart:
+// RunOne rolls out from a depth-capped node and backs the result up, so the
+// decomposed pipeline must publish that node as a leaf rather than drop it.
 //
 // MaxTreeDepth is 1, so once every root child has been expanded, every further
 // selection descends one level and stops at the cap. Root visits must keep
-// tracking the step count; before the fix they plateaued at roughly the number of
-// root children, which is why raising SimsPerPly bought nothing on deep searches.
+// tracking the step count rather than plateauing at the number of root children.
 func TestMCTSTreeIterationBacksUpDepthCappedSelections(t *testing.T) {
 	const steps = 60
 	tree := &agents.MCTSTreeIteration[agents.TTTState, agents.TTTAction]{

--- a/pkg/agents/simulation_environment.go
+++ b/pkg/agents/simulation_environment.go
@@ -1,0 +1,288 @@
+package agents
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/umbralcalc/stochadex/pkg/simulator"
+)
+
+// SimulationEnvironment adapts a stochadex sub-simulation into an
+// Environment[[]float64, int], so MCTS can plan over the same forward model the
+// rest of the engine simulates and calibrates — rather than over game rules
+// written by hand.
+//
+// This is the counterpart to the environment registry in pkg/api. That hook lets
+// a config NAME decision rules a downstream module wrote in Go; this type needs
+// no rules at all, because the dynamics are already stated as partitions. An
+// action is a params injection, a transition is one step of the sub-simulation,
+// and the reward is read off the resulting rows.
+//
+// # State encoding
+//
+//	s[0]                 step index within the episode
+//	s[1]                 accumulated (discounted) reward so far
+//	s[2 .. 2+totalWidth] every partition's current row, concatenated in
+//	                     partition order
+//
+// Carrying the accumulated reward in the state is what lets a finite-horizon,
+// per-step-reward problem satisfy the existing Environment contract without
+// changing it: Terminal fires at the horizon and normalises the accumulated
+// reward into the [0,1] score the UCT backups expect. ReturnRange declares the
+// normalisation bounds, since UCB1 is only meaningful on a bounded value scale.
+//
+// # Determinism, and the approximation it encodes
+//
+// Apply must be pure — MCTS materialises a child state once per edge and reuses
+// it on every later visit — but a stochastic sub-simulation is not. This type
+// resolves that by deriving each transition's seed from (ScenarioSeed, state,
+// action) and re-Configuring the iterations before every step. Two calls with
+// the same arguments therefore return the same successor.
+//
+// That is common random numbers: the noise is pinned as a function of where you
+// are and what you do, turning the stochastic model into a deterministic
+// surrogate that the existing tree searches exactly. It is a real modelling
+// choice, not a free win — a planner solving a pinned scenario can exploit the
+// particular noise draw it is going to receive, which biases values optimistic
+// relative to the true stochastic optimum. Average over ScenarioSeed values to
+// measure that gap rather than assume it away; TestSimulationEnvironmentOptimismGap
+// quantifies it on a known-answer problem.
+//
+// # Requirements and limits
+//
+//   - Every partition must have StateHistoryDepth 1. Deeper windows are part of
+//     the state and would have to be encoded too; NewSimulationEnvironment
+//     rejects them rather than silently planning from a truncated state.
+//   - The iterations must honour the framework rule that all mutable state is
+//     re-initialisable in Configure (which RunWithHarnesses already enforces).
+//     That rule is exactly what makes a pure Apply possible.
+//   - Not safe for concurrent use: the sub-simulation's iteration objects are
+//     shared and re-Configured per transition. Build one SimulationEnvironment
+//     per goroutine.
+type SimulationEnvironment struct {
+	settings        *simulator.Settings
+	implementations *simulator.Implementations
+	spec            SimulationEnvironmentSpec
+	partitionWidths []int
+	totalWidth      int
+	actionPartition int
+}
+
+// SimulationEnvironmentSpec configures a SimulationEnvironment.
+type SimulationEnvironmentSpec struct {
+	// Actions is the discrete action set. Each entry is the params value
+	// injected under ActionParam on ActionPartition, so actions are whatever
+	// the model already reads as parameters — a dispatch rate, a policy
+	// threshold, an intervention size.
+	Actions [][]float64
+	// ActionPartition names the partition receiving the action, and ActionParam
+	// the params key it is written to.
+	ActionPartition string
+	ActionParam     string
+	// Horizon is the episode length in steps.
+	Horizon int
+	// Reward scores one transition from the post-step rows, addressed by
+	// partition name. Returning the per-step reward (not the cumulative one)
+	// keeps the discounting in one place.
+	Reward func(rows map[string][]float64) float64
+	// Discount is the per-step discount factor applied to rewards. Zero means
+	// undiscounted (treated as 1).
+	Discount float64
+	// MinReturn and MaxReturn bound the achievable accumulated reward and are
+	// used to normalise it into the [0,1] score UCB1 needs. A return outside
+	// the range is clamped — widen the range rather than leaving it clamped,
+	// since a saturated score carries no gradient for the search.
+	MinReturn, MaxReturn float64
+	// ScenarioSeed pins the noise realisation this environment plans against.
+	ScenarioSeed uint64
+	// Legal optionally restricts the action set given the decoded rows. Nil
+	// means every action is always legal.
+	Legal func(rows map[string][]float64) []int
+}
+
+// NewSimulationEnvironment validates the spec against the sub-simulation and
+// returns the environment. It panics on a misconfiguration, matching the rest of
+// the config-assembly tier: these are programming errors caught before any
+// search starts, and a silently misshapen environment would produce plausible
+// but meaningless recommendations.
+func NewSimulationEnvironment(
+	settings *simulator.Settings,
+	implementations *simulator.Implementations,
+	spec SimulationEnvironmentSpec,
+) *SimulationEnvironment {
+	if len(spec.Actions) == 0 {
+		panic("agents.NewSimulationEnvironment: at least one action is required")
+	}
+	if spec.Horizon <= 0 {
+		panic("agents.NewSimulationEnvironment: Horizon must be > 0")
+	}
+	if spec.Reward == nil {
+		panic("agents.NewSimulationEnvironment: Reward is required")
+	}
+	if spec.MaxReturn <= spec.MinReturn {
+		panic("agents.NewSimulationEnvironment: MaxReturn must exceed MinReturn")
+	}
+	actionPartition := -1
+	widths := make([]int, len(settings.Iterations))
+	total := 0
+	for index, iteration := range settings.Iterations {
+		if iteration.StateHistoryDepth != 1 {
+			panic(fmt.Sprintf(
+				"agents.NewSimulationEnvironment: partition %q has state_history_depth "+
+					"%d; only depth 1 is supported, because a deeper window is part of "+
+					"the state and this encoding does not carry it",
+				iteration.Name, iteration.StateHistoryDepth,
+			))
+		}
+		widths[index] = iteration.StateWidth
+		total += iteration.StateWidth
+		if iteration.Name == spec.ActionPartition {
+			actionPartition = index
+		}
+	}
+	if actionPartition < 0 {
+		panic(fmt.Sprintf(
+			"agents.NewSimulationEnvironment: no partition named %q to receive the action",
+			spec.ActionPartition,
+		))
+	}
+	if spec.Discount == 0 {
+		spec.Discount = 1.0
+	}
+	return &SimulationEnvironment{
+		settings:        settings,
+		implementations: implementations,
+		spec:            spec,
+		partitionWidths: widths,
+		totalWidth:      total,
+		actionPartition: actionPartition,
+	}
+}
+
+// StateWidth is the encoded state width: the step index, the accumulated
+// reward, and every partition's row.
+func (e *SimulationEnvironment) StateWidth() int { return 2 + e.totalWidth }
+
+// InitialState encodes the sub-simulation's configured initial rows as the
+// episode's starting state.
+func (e *SimulationEnvironment) InitialState() []float64 {
+	state := make([]float64, e.StateWidth())
+	offset := 2
+	for index := range e.settings.Iterations {
+		copy(state[offset:], e.settings.Iterations[index].InitStateValues)
+		offset += e.partitionWidths[index]
+	}
+	return state
+}
+
+// rowsByName decodes the per-partition rows out of an encoded state.
+func (e *SimulationEnvironment) rowsByName(s []float64) map[string][]float64 {
+	rows := make(map[string][]float64, len(e.partitionWidths))
+	offset := 2
+	for index, width := range e.partitionWidths {
+		rows[e.settings.Iterations[index].Name] = s[offset : offset+width]
+		offset += width
+	}
+	return rows
+}
+
+// Legal implements Environment.
+func (e *SimulationEnvironment) Legal(s []float64) []int {
+	if _, done := e.Terminal(s); done {
+		return nil
+	}
+	if e.spec.Legal != nil {
+		return e.spec.Legal(e.rowsByName(s))
+	}
+	actions := make([]int, len(e.spec.Actions))
+	for index := range actions {
+		actions[index] = index
+	}
+	return actions
+}
+
+// Apply implements Environment: one step of the sub-simulation under action a.
+//
+// The transition is pure. Its seed is derived from the scenario seed, the
+// encoded state and the action, so the same arguments always give the same
+// successor — see the type docs for what that pins and what it costs.
+func (e *SimulationEnvironment) Apply(s []float64, a int) ([]float64, error) {
+	if a < 0 || a >= len(e.spec.Actions) {
+		return nil, fmt.Errorf("agents: action %d out of range", a)
+	}
+	if len(s) != e.StateWidth() {
+		return nil, fmt.Errorf(
+			"agents: encoded state width %d, want %d", len(s), e.StateWidth())
+	}
+
+	// Seed every partition from (scenario, state, action) and re-Configure, so
+	// the iterations' RNGs are restored to a state that depends only on those.
+	base := mixSeed(e.spec.ScenarioSeed, s, a)
+	offset := 2
+	for index := range e.settings.Iterations {
+		e.settings.Iterations[index].Seed = base ^ (uint64(index+1) * 0x9e3779b97f4a7c15)
+		e.settings.Iterations[index].InitStateValues = append(
+			[]float64(nil), s[offset:offset+e.partitionWidths[index]]...)
+		offset += e.partitionWidths[index]
+	}
+	e.settings.Iterations[e.actionPartition].Params.Set(
+		e.spec.ActionParam, e.spec.Actions[a])
+	for index, iteration := range e.implementations.Iterations {
+		iteration.Configure(index, e.settings)
+	}
+
+	coordinator := simulator.NewPartitionCoordinator(e.settings, e.implementations)
+	stepper := coordinator.NewStepper()
+	stepper.Step()
+	stepper.Close()
+
+	next := make([]float64, e.StateWidth())
+	step := s[0] + 1
+	next[0] = step
+	writeOffset := 2
+	for index := range e.partitionWidths {
+		copy(next[writeOffset:], coordinator.Shared.StateHistories[index].Values.RawRowView(0))
+		writeOffset += e.partitionWidths[index]
+	}
+	// Discount by the step the reward was earned on, so a path's accumulated
+	// value does not depend on the order the tree happened to visit it in.
+	next[1] = s[1] + math.Pow(e.spec.Discount, s[0])*e.spec.Reward(e.rowsByName(next))
+	return next, nil
+}
+
+// Terminal implements Environment: the episode ends at the horizon, scored by
+// the accumulated reward normalised into [0,1].
+func (e *SimulationEnvironment) Terminal(s []float64) ([]float64, bool) {
+	if int(s[0]) < e.spec.Horizon {
+		return nil, false
+	}
+	span := e.spec.MaxReturn - e.spec.MinReturn
+	score := (s[1] - e.spec.MinReturn) / span
+	return []float64{math.Min(1, math.Max(0, score))}, true
+}
+
+// Actor implements Environment. A planning problem has a single decision maker.
+func (e *SimulationEnvironment) Actor([]float64) int { return 0 }
+
+// Players implements Environment.
+func (e *SimulationEnvironment) Players([]float64) int { return 1 }
+
+// Return reads the accumulated (discounted) reward out of an encoded state,
+// which is the quantity a caller actually wants to report — the [0,1] score is
+// an artefact of the UCB1 value scale.
+func (e *SimulationEnvironment) Return(s []float64) float64 { return s[1] }
+
+// mixSeed derives a transition seed from the scenario seed, the encoded state
+// and the action, using an FNV-1a style mix over the state's bit patterns. Two
+// paths arriving at the same state under the same action therefore share a noise
+// draw, which is what makes the surrogate consistent.
+func mixSeed(scenario uint64, s []float64, a int) uint64 {
+	const prime = 0x100000001b3
+	hash := uint64(0xcbf29ce484222325) ^ scenario
+	for _, value := range s {
+		hash = (hash ^ math.Float64bits(value)) * prime
+	}
+	return (hash ^ uint64(a+1)) * prime
+}
+
+var _ Environment[[]float64, int] = (*SimulationEnvironment)(nil)

--- a/pkg/agents/simulation_environment.go
+++ b/pkg/agents/simulation_environment.go
@@ -42,12 +42,17 @@ import (
 //
 // That is common random numbers: the noise is pinned as a function of where you
 // are and what you do, turning the stochastic model into a deterministic
-// surrogate that the existing tree searches exactly. It is a real modelling
-// choice, not a free win — a planner solving a pinned scenario can exploit the
-// particular noise draw it is going to receive, which biases values optimistic
-// relative to the true stochastic optimum. Average over ScenarioSeed values to
-// measure that gap rather than assume it away; TestSimulationEnvironmentOptimismGap
-// quantifies it on a known-answer problem.
+// surrogate that MCTSTree searches exactly. It is a real modelling choice, not a
+// free win — a planner solving a pinned scenario can exploit the particular noise
+// draw it is going to receive, which biases its values optimistic. On the battery
+// test problem that over-promise reaches tens of percent and *grows* with the
+// simulation budget, since more search means more exploitation of the one
+// realisation it can see.
+//
+// This type therefore also implements StochasticEnvironment, via ApplySample. A
+// search that uses it (MCTSChanceTree) builds chance nodes and averages over
+// sampled successors, which removes most of the bias:
+// TestChanceNodesReduceOptimism measures both on the same problem.
 //
 // # Requirements and limits
 //
@@ -216,6 +221,17 @@ func (e *SimulationEnvironment) Legal(s []float64) []int {
 // encoded state and the action, so the same arguments always give the same
 // successor — see the type docs for what that pins and what it costs.
 func (e *SimulationEnvironment) Apply(s []float64, a int) ([]float64, error) {
+	return e.apply(s, a, 0)
+}
+
+// apply is the shared transition. sampleSeed selects which draw from the
+// transition distribution is taken: zero is Apply's pinned scenario draw, and any
+// other value is one of the alternatives a chance-node search averages over.
+func (e *SimulationEnvironment) apply(
+	s []float64,
+	a int,
+	sampleSeed uint64,
+) ([]float64, error) {
 	if a < 0 || a >= len(e.spec.Actions) {
 		return nil, fmt.Errorf("agents: action %d out of range", a)
 	}
@@ -231,9 +247,14 @@ func (e *SimulationEnvironment) Apply(s []float64, a int) ([]float64, error) {
 		offset += width
 	}
 	e.simulation.SetParam(e.actionPartition, e.spec.ActionParam, e.spec.Actions[a])
-	// Seeding from (scenario, state, action) is what makes the transition pure;
-	// ReentrantSimulation reseeds the iterations from it before stepping.
-	advanced := e.simulation.Advance(rows, mixSeed(e.spec.ScenarioSeed, s, a), 1)
+	// Seeding from (scenario, state, action, sample) is what makes the transition
+	// reproducible; ReentrantSimulation reseeds the iterations from it before
+	// stepping.
+	seed := mixSeed(e.spec.ScenarioSeed, s, a)
+	if sampleSeed != 0 {
+		seed = simulator.DeriveSeed(seed^sampleSeed, int(sampleSeed&0xffff))
+	}
+	advanced := e.simulation.Advance(rows, seed, 1)
 
 	next := make([]float64, e.StateWidth())
 	next[0] = s[0] + 1
@@ -246,6 +267,17 @@ func (e *SimulationEnvironment) Apply(s []float64, a int) ([]float64, error) {
 	// value does not depend on the order the tree happened to visit it in.
 	next[1] = s[1] + math.Pow(e.spec.Discount, s[0])*e.spec.Reward(e.rowsByName(next))
 	return next, nil
+}
+
+// ApplySample implements StochasticEnvironment: one transition under an explicit
+// sample seed, so a search can draw more than one successor of the same
+// (state, action) and average over them instead of committing to the first.
+//
+// Apply is ApplySample with the sample seed fixed at zero. That is the whole
+// difference between planning against a pinned scenario and planning against the
+// distribution.
+func (e *SimulationEnvironment) ApplySample(s []float64, a int, seed uint64) ([]float64, error) {
+	return e.apply(s, a, seed)
 }
 
 // Terminal implements Environment: the episode ends at the horizon, scored by

--- a/pkg/agents/simulation_environment.go
+++ b/pkg/agents/simulation_environment.go
@@ -34,10 +34,11 @@ import (
 // # Determinism, and the approximation it encodes
 //
 // Apply must be pure — MCTS materialises a child state once per edge and reuses
-// it on every later visit — but a stochastic sub-simulation is not. This type
-// resolves that by deriving each transition's seed from (ScenarioSeed, state,
-// action) and re-Configuring the iterations before every step. Two calls with
-// the same arguments therefore return the same successor.
+// it on every later visit — but a stochastic sub-simulation is not. That is not
+// a problem this type solves for itself: it delegates to
+// simulator.ReentrantSimulation, the engine's re-entrant evaluation tier, and
+// supplies a seed derived from (ScenarioSeed, state, action). Two calls with the
+// same arguments therefore return the same successor.
 //
 // That is common random numbers: the noise is pinned as a function of where you
 // are and what you do, turning the stochastic model into a deterministic
@@ -60,10 +61,11 @@ import (
 //     shared and re-Configured per transition. Build one SimulationEnvironment
 //     per goroutine.
 type SimulationEnvironment struct {
-	settings        *simulator.Settings
-	implementations *simulator.Implementations
+	simulation      *simulator.ReentrantSimulation
 	spec            SimulationEnvironmentSpec
+	partitionNames  []string
 	partitionWidths []int
+	initRows        [][]float64
 	totalWidth      int
 	actionPartition int
 }
@@ -123,7 +125,9 @@ func NewSimulationEnvironment(
 		panic("agents.NewSimulationEnvironment: MaxReturn must exceed MinReturn")
 	}
 	actionPartition := -1
+	names := make([]string, len(settings.Iterations))
 	widths := make([]int, len(settings.Iterations))
+	initRows := make([][]float64, len(settings.Iterations))
 	total := 0
 	for index, iteration := range settings.Iterations {
 		if iteration.StateHistoryDepth != 1 {
@@ -134,7 +138,11 @@ func NewSimulationEnvironment(
 				iteration.Name, iteration.StateHistoryDepth,
 			))
 		}
+		names[index] = iteration.Name
 		widths[index] = iteration.StateWidth
+		// Copied, because ReentrantSimulation.Advance overwrites the settings'
+		// initial values on every transition.
+		initRows[index] = append([]float64(nil), iteration.InitStateValues...)
 		total += iteration.StateWidth
 		if iteration.Name == spec.ActionPartition {
 			actionPartition = index
@@ -150,10 +158,11 @@ func NewSimulationEnvironment(
 		spec.Discount = 1.0
 	}
 	return &SimulationEnvironment{
-		settings:        settings,
-		implementations: implementations,
+		simulation:      simulator.NewReentrantSimulation(settings, implementations),
 		spec:            spec,
+		partitionNames:  names,
 		partitionWidths: widths,
+		initRows:        initRows,
 		totalWidth:      total,
 		actionPartition: actionPartition,
 	}
@@ -168,8 +177,8 @@ func (e *SimulationEnvironment) StateWidth() int { return 2 + e.totalWidth }
 func (e *SimulationEnvironment) InitialState() []float64 {
 	state := make([]float64, e.StateWidth())
 	offset := 2
-	for index := range e.settings.Iterations {
-		copy(state[offset:], e.settings.Iterations[index].InitStateValues)
+	for index, row := range e.initRows {
+		copy(state[offset:], row)
 		offset += e.partitionWidths[index]
 	}
 	return state
@@ -180,7 +189,7 @@ func (e *SimulationEnvironment) rowsByName(s []float64) map[string][]float64 {
 	rows := make(map[string][]float64, len(e.partitionWidths))
 	offset := 2
 	for index, width := range e.partitionWidths {
-		rows[e.settings.Iterations[index].Name] = s[offset : offset+width]
+		rows[e.partitionNames[index]] = s[offset : offset+width]
 		offset += width
 	}
 	return rows
@@ -215,33 +224,22 @@ func (e *SimulationEnvironment) Apply(s []float64, a int) ([]float64, error) {
 			"agents: encoded state width %d, want %d", len(s), e.StateWidth())
 	}
 
-	// Seed every partition from (scenario, state, action) and re-Configure, so
-	// the iterations' RNGs are restored to a state that depends only on those.
-	base := mixSeed(e.spec.ScenarioSeed, s, a)
+	rows := make([][]float64, len(e.partitionWidths))
 	offset := 2
-	for index := range e.settings.Iterations {
-		e.settings.Iterations[index].Seed = base ^ (uint64(index+1) * 0x9e3779b97f4a7c15)
-		e.settings.Iterations[index].InitStateValues = append(
-			[]float64(nil), s[offset:offset+e.partitionWidths[index]]...)
-		offset += e.partitionWidths[index]
+	for index, width := range e.partitionWidths {
+		rows[index] = s[offset : offset+width]
+		offset += width
 	}
-	e.settings.Iterations[e.actionPartition].Params.Set(
-		e.spec.ActionParam, e.spec.Actions[a])
-	for index, iteration := range e.implementations.Iterations {
-		iteration.Configure(index, e.settings)
-	}
-
-	coordinator := simulator.NewPartitionCoordinator(e.settings, e.implementations)
-	stepper := coordinator.NewStepper()
-	stepper.Step()
-	stepper.Close()
+	e.simulation.SetParam(e.actionPartition, e.spec.ActionParam, e.spec.Actions[a])
+	// Seeding from (scenario, state, action) is what makes the transition pure;
+	// ReentrantSimulation reseeds the iterations from it before stepping.
+	advanced := e.simulation.Advance(rows, mixSeed(e.spec.ScenarioSeed, s, a), 1)
 
 	next := make([]float64, e.StateWidth())
-	step := s[0] + 1
-	next[0] = step
+	next[0] = s[0] + 1
 	writeOffset := 2
 	for index := range e.partitionWidths {
-		copy(next[writeOffset:], coordinator.Shared.StateHistories[index].Values.RawRowView(0))
+		copy(next[writeOffset:], advanced[index])
 		writeOffset += e.partitionWidths[index]
 	}
 	// Discount by the step the reward was earned on, so a path's accumulated

--- a/pkg/agents/simulation_environment.go
+++ b/pkg/agents/simulation_environment.go
@@ -22,7 +22,8 @@ import (
 //
 //	s[0]                 step index within the episode
 //	s[1]                 accumulated (discounted) reward so far
-//	s[2 .. 2+totalWidth] every partition's current row, concatenated in
+//	s[2 .. 2+totalWidth] every partition's state-history window, flattened
+//	                     row-major with the latest row first, concatenated in
 //	                     partition order
 //
 // Carrying the accumulated reward in the state is what lets a finite-horizon,
@@ -56,9 +57,10 @@ import (
 //
 // # Requirements and limits
 //
-//   - Every partition must have StateHistoryDepth 1. Deeper windows are part of
-//     the state and would have to be encoded too; NewSimulationEnvironment
-//     rejects them rather than silently planning from a truncated state.
+//   - A partition's whole state-history window is carried in the encoded state,
+//     so models whose iterations read further back than one step work — a
+//     10-minute rolling count, say. Deep windows cost encoded width: the state
+//     grows as sum(depth * width) over partitions.
 //   - The iterations must honour the framework rule that all mutable state is
 //     re-initialisable in Configure (which RunWithHarnesses already enforces).
 //     That rule is exactly what makes a pure Apply possible.
@@ -70,6 +72,9 @@ type SimulationEnvironment struct {
 	spec            SimulationEnvironmentSpec
 	partitionNames  []string
 	partitionWidths []int
+	partitionDepths []int
+	// windowWidths[i] = depth*width, the encoded size of partition i's window.
+	windowWidths    []int
 	initRows        [][]float64
 	totalWidth      int
 	actionPartition int
@@ -130,25 +135,30 @@ func NewSimulationEnvironment(
 		panic("agents.NewSimulationEnvironment: MaxReturn must exceed MinReturn")
 	}
 	actionPartition := -1
-	names := make([]string, len(settings.Iterations))
-	widths := make([]int, len(settings.Iterations))
-	initRows := make([][]float64, len(settings.Iterations))
+	count := len(settings.Iterations)
+	names := make([]string, count)
+	widths := make([]int, count)
+	depths := make([]int, count)
+	windowWidths := make([]int, count)
+	initRows := make([][]float64, count)
 	total := 0
 	for index, iteration := range settings.Iterations {
-		if iteration.StateHistoryDepth != 1 {
-			panic(fmt.Sprintf(
-				"agents.NewSimulationEnvironment: partition %q has state_history_depth "+
-					"%d; only depth 1 is supported, because a deeper window is part of "+
-					"the state and this encoding does not carry it",
-				iteration.Name, iteration.StateHistoryDepth,
-			))
+		depth := iteration.StateHistoryDepth
+		if depth < 1 {
+			depth = 1
 		}
 		names[index] = iteration.Name
 		widths[index] = iteration.StateWidth
-		// Copied, because ReentrantSimulation.Advance overwrites the settings'
-		// initial values on every transition.
-		initRows[index] = append([]float64(nil), iteration.InitStateValues...)
-		total += iteration.StateWidth
+		depths[index] = depth
+		windowWidths[index] = depth * iteration.StateWidth
+		// The initial window repeats the configured row: before the run starts
+		// there is no history, and this is what a coordinator would begin from.
+		window := make([]float64, 0, windowWidths[index])
+		for row := 0; row < depth; row++ {
+			window = append(window, iteration.InitStateValues...)
+		}
+		initRows[index] = window
+		total += windowWidths[index]
 		if iteration.Name == spec.ActionPartition {
 			actionPartition = index
 		}
@@ -167,6 +177,8 @@ func NewSimulationEnvironment(
 		spec:            spec,
 		partitionNames:  names,
 		partitionWidths: widths,
+		partitionDepths: depths,
+		windowWidths:    windowWidths,
 		initRows:        initRows,
 		totalWidth:      total,
 		actionPartition: actionPartition,
@@ -182,9 +194,9 @@ func (e *SimulationEnvironment) StateWidth() int { return 2 + e.totalWidth }
 func (e *SimulationEnvironment) InitialState() []float64 {
 	state := make([]float64, e.StateWidth())
 	offset := 2
-	for index, row := range e.initRows {
-		copy(state[offset:], row)
-		offset += e.partitionWidths[index]
+	for index, window := range e.initRows {
+		copy(state[offset:], window)
+		offset += e.windowWidths[index]
 	}
 	return state
 }
@@ -194,8 +206,9 @@ func (e *SimulationEnvironment) rowsByName(s []float64) map[string][]float64 {
 	rows := make(map[string][]float64, len(e.partitionWidths))
 	offset := 2
 	for index, width := range e.partitionWidths {
+		// The latest row, which is what a reward is written against.
 		rows[e.partitionNames[index]] = s[offset : offset+width]
-		offset += width
+		offset += e.windowWidths[index]
 	}
 	return rows
 }
@@ -240,11 +253,14 @@ func (e *SimulationEnvironment) apply(
 			"agents: encoded state width %d, want %d", len(s), e.StateWidth())
 	}
 
-	rows := make([][]float64, len(e.partitionWidths))
+	// Hand back each partition's whole window, so an iteration that reads several
+	// steps into the past resumes from the history it actually had.
+	histories := make(map[int]*simulator.StateHistory, len(e.partitionWidths))
 	offset := 2
 	for index, width := range e.partitionWidths {
-		rows[index] = s[offset : offset+width]
-		offset += width
+		histories[index] = simulator.NewStateHistoryFromWindow(
+			s[offset:offset+e.windowWidths[index]], width, e.partitionDepths[index])
+		offset += e.windowWidths[index]
 	}
 	e.simulation.SetParam(e.actionPartition, e.spec.ActionParam, e.spec.Actions[a])
 	// Seeding from (scenario, state, action, sample) is what makes the transition
@@ -254,14 +270,18 @@ func (e *SimulationEnvironment) apply(
 	if sampleSeed != 0 {
 		seed = simulator.DeriveSeed(seed^sampleSeed, int(sampleSeed&0xffff))
 	}
-	advanced := e.simulation.Advance(rows, seed, 1)
+	advanced := e.simulation.RunWindows(simulator.ReentrantRun{
+		Histories: histories,
+		Seed:      &seed,
+		Steps:     1,
+	})
 
 	next := make([]float64, e.StateWidth())
 	next[0] = s[0] + 1
 	writeOffset := 2
 	for index := range e.partitionWidths {
 		copy(next[writeOffset:], advanced[index])
-		writeOffset += e.partitionWidths[index]
+		writeOffset += e.windowWidths[index]
 	}
 	// Discount by the step the reward was earned on, so a path's accumulated
 	// value does not depend on the order the tree happened to visit it in.

--- a/pkg/agents/simulation_environment_test.go
+++ b/pkg/agents/simulation_environment_test.go
@@ -1,0 +1,436 @@
+package agents_test
+
+// Validation for SimulationEnvironment against a known-answer planning problem:
+// battery arbitrage over a cyclic price. The environment is deterministic (its
+// noise is pinned by the state-action seed), so the optimal return can be found
+// exactly by brute force over every action sequence — which is what these tests
+// compare the search against, rather than a hand-reasoned figure.
+//
+// The problem is deliberately one where a myopic policy loses: selling requires
+// having bought earlier, at a price that looked bad at the time.
+
+import (
+	"math"
+	"math/rand/v2"
+	"testing"
+
+	"github.com/umbralcalc/stochadex/pkg/agents"
+	"github.com/umbralcalc/stochadex/pkg/simulator"
+)
+
+// priceCycle is the repeating price path: two cheap steps, then two dear ones.
+var priceCycle = []float64{10, 10, 90, 90}
+
+// cyclicPriceIteration walks priceCycle. The phase is carried in the row rather
+// than read from the coordinator's step counter, because SimulationEnvironment
+// restarts the coordinator for every transition — the sub-simulation has to be
+// Markov in its own rows.
+//
+// Row: [price, phase].
+type cyclicPriceIteration struct{}
+
+func (p *cyclicPriceIteration) Configure(int, *simulator.Settings) {}
+
+func (p *cyclicPriceIteration) Iterate(
+	params *simulator.Params,
+	partitionIndex int,
+	stateHistories []*simulator.StateHistory,
+	timestepsHistory *simulator.CumulativeTimestepsHistory,
+) []float64 {
+	row := stateHistories[partitionIndex].Values.RawRowView(0)
+	phase := math.Mod(row[1]+1, float64(len(priceCycle)))
+	return []float64{priceCycle[int(phase)], phase}
+}
+
+// batteryIteration applies the dispatch action to the state of charge, clamped
+// to [0, capacity], and reports the flow that actually happened.
+//
+// Row: [soc, flow]; params: "dispatch" of +1 charge / 0 hold / -1 discharge.
+type batteryIteration struct{ capacity float64 }
+
+func (b *batteryIteration) Configure(int, *simulator.Settings) {}
+
+func (b *batteryIteration) Iterate(
+	params *simulator.Params,
+	partitionIndex int,
+	stateHistories []*simulator.StateHistory,
+	timestepsHistory *simulator.CumulativeTimestepsHistory,
+) []float64 {
+	row := stateHistories[partitionIndex].Values.RawRowView(0)
+	soc := row[0]
+	next := math.Min(b.capacity, math.Max(0, soc+params.GetIndex("dispatch", 0)))
+	return []float64{next, next - soc}
+}
+
+const testHorizon = 8
+
+func newBatteryEnvironment(t *testing.T, scenarioSeed uint64) *agents.SimulationEnvironment {
+	t.Helper()
+	gen := simulator.NewConfigGenerator()
+	gen.SetSimulation(&simulator.SimulationConfig{
+		OutputCondition:      &simulator.NilOutputCondition{},
+		OutputFunction:       &simulator.NilOutputFunction{},
+		TerminationCondition: &simulator.NumberOfStepsTerminationCondition{MaxNumberOfSteps: 1},
+		TimestepFunction:     &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+		InitTimeValue:        0,
+	})
+	gen.SetPartition(&simulator.PartitionConfig{
+		Name:      "price",
+		Iteration: &cyclicPriceIteration{},
+		// Start at phase 3 so the first transition lands on phase 0 (cheap).
+		InitStateValues:   []float64{priceCycle[3], 3},
+		StateHistoryDepth: 1,
+		Seed:              0,
+	})
+	gen.SetPartition(&simulator.PartitionConfig{
+		Name:              "battery",
+		Iteration:         &batteryIteration{capacity: 1},
+		Params:            simulator.NewParams(map[string][]float64{"dispatch": {0}}),
+		InitStateValues:   []float64{0, 0},
+		StateHistoryDepth: 1,
+		Seed:              0,
+	})
+	settings, impl := gen.GenerateConfigs()
+	impl.ExecutionStrategy = &simulator.InlineExecution{}
+
+	return agents.NewSimulationEnvironment(settings, impl, agents.SimulationEnvironmentSpec{
+		Actions:         [][]float64{{1}, {0}, {-1}}, // charge / hold / discharge
+		ActionPartition: "battery",
+		ActionParam:     "dispatch",
+		Horizon:         testHorizon,
+		// Revenue: discharging (flow < 0) sells at the prevailing price.
+		Reward: func(rows map[string][]float64) float64 {
+			return -rows["battery"][1] * rows["price"][0]
+		},
+		MinReturn:    -400,
+		MaxReturn:    400,
+		ScenarioSeed: scenarioSeed,
+	})
+}
+
+// bestReturnByBruteForce enumerates every action sequence and returns the best
+// achievable accumulated reward. Exact, because the environment is deterministic.
+func bestReturnByBruteForce(t *testing.T, env *agents.SimulationEnvironment) float64 {
+	t.Helper()
+	best := math.Inf(-1)
+	var walk func(state []float64, depth int)
+	walk = func(state []float64, depth int) {
+		if _, done := env.Terminal(state); done {
+			best = math.Max(best, env.Return(state))
+			return
+		}
+		for _, action := range env.Legal(state) {
+			next, err := env.Apply(state, action)
+			if err != nil {
+				t.Fatalf("Apply: %v", err)
+			}
+			walk(next, depth+1)
+		}
+	}
+	walk(env.InitialState(), 0)
+	return best
+}
+
+func TestSimulationEnvironmentApplyIsPure(t *testing.T) {
+	env := newBatteryEnvironment(t, 1)
+	state := env.InitialState()
+	first, err := env.Apply(state, 0)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	// Interleave other transitions, then repeat the original.
+	if _, err := env.Apply(state, 2); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if _, err := env.Apply(first, 1); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	again, err := env.Apply(state, 0)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	for i := range first {
+		if first[i] != again[i] {
+			t.Fatalf("Apply is not pure: %v vs %v", first, again)
+		}
+	}
+	// And it must not have mutated the state it was given.
+	for i, value := range env.InitialState() {
+		if state[i] != value {
+			t.Fatalf("Apply mutated its input state at %d: %v", i, state)
+		}
+	}
+}
+
+// TestSimulationEnvironmentMCTSFindsOptimalPlan is the headline check: planning
+// with MCTS over a sub-simulation recovers the brute-force optimum. The battery
+// must be charged while the price is low to have anything to sell when it is
+// high, so a myopic policy cannot reach this return — the comparison against
+// hold-forever and greedy-discharge below is what makes that concrete.
+func TestSimulationEnvironmentMCTSFindsOptimalPlan(t *testing.T) {
+	env := newBatteryEnvironment(t, 1)
+	optimal := bestReturnByBruteForce(t, env)
+	if optimal <= 0 {
+		t.Fatalf("problem is degenerate: brute-force optimum is %v", optimal)
+	}
+
+	cfg := agents.MCTSConfig[[]float64, int]{
+		Simulations:     400,
+		MaxTreeDepth:    testHorizon + 1,
+		RolloutMaxSteps: testHorizon + 1,
+		Rollout:         agents.UniformRandomRollout[[]float64, int](),
+	}
+
+	// Replan from each state reached, MPC-style: the search chooses one action,
+	// the environment advances, and the search runs again.
+	state := env.InitialState()
+	for step := 0; ; step++ {
+		if _, done := env.Terminal(state); done {
+			break
+		}
+		best, _, err := agents.RunMCTSSearch(env, state, cfg, uint64(step)+99, cfg.Simulations)
+		if err != nil {
+			t.Fatalf("RunMCTSSearch: %v", err)
+		}
+		state, err = env.Apply(state, best)
+		if err != nil {
+			t.Fatalf("Apply: %v", err)
+		}
+	}
+	planned := env.Return(state)
+
+	holdReturn := fixedPolicyReturn(t, env, 1)
+	t.Logf("brute-force optimum %.0f, MCTS %.0f, hold-forever %.0f", optimal, planned, holdReturn)
+	if planned < optimal {
+		t.Logf("MCTS left %.0f on the table (%.1f%% of optimum)",
+			optimal-planned, 100*planned/optimal)
+	}
+	if planned < 0.9*optimal {
+		t.Errorf("MCTS plan returned %v, want at least 90%% of the optimum %v", planned, optimal)
+	}
+	if planned <= holdReturn {
+		t.Errorf("MCTS (%v) did no better than doing nothing (%v)", planned, holdReturn)
+	}
+}
+
+// fixedPolicyReturn runs one action for the whole episode, as a floor to beat.
+func fixedPolicyReturn(t *testing.T, env *agents.SimulationEnvironment, action int) float64 {
+	t.Helper()
+	state := env.InitialState()
+	for {
+		if _, done := env.Terminal(state); done {
+			return env.Return(state)
+		}
+		next, err := env.Apply(state, action)
+		if err != nil {
+			t.Fatalf("Apply: %v", err)
+		}
+		state = next
+	}
+}
+
+func TestSimulationEnvironmentRejectsDeepHistory(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected a panic for state_history_depth > 1")
+		}
+	}()
+	gen := simulator.NewConfigGenerator()
+	gen.SetSimulation(&simulator.SimulationConfig{
+		OutputCondition:      &simulator.NilOutputCondition{},
+		OutputFunction:       &simulator.NilOutputFunction{},
+		TerminationCondition: &simulator.NumberOfStepsTerminationCondition{MaxNumberOfSteps: 1},
+		TimestepFunction:     &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+		InitTimeValue:        0,
+	})
+	gen.SetPartition(&simulator.PartitionConfig{
+		Name:              "battery",
+		Iteration:         &batteryIteration{capacity: 1},
+		Params:            simulator.NewParams(map[string][]float64{"dispatch": {0}}),
+		InitStateValues:   []float64{0, 0},
+		StateHistoryDepth: 3,
+		Seed:              0,
+	})
+	settings, impl := gen.GenerateConfigs()
+	agents.NewSimulationEnvironment(settings, impl, agents.SimulationEnvironmentSpec{
+		Actions:         [][]float64{{0}},
+		ActionPartition: "battery",
+		ActionParam:     "dispatch",
+		Horizon:         2,
+		Reward:          func(map[string][]float64) float64 { return 0 },
+		MinReturn:       -1,
+		MaxReturn:       1,
+	})
+}
+
+// noisyPriceIteration is cyclicPriceIteration with Gaussian noise on the price.
+// The RNG is rebuilt in Configure from the partition seed, which is exactly the
+// contract SimulationEnvironment relies on: because the environment derives that
+// seed from (scenario, state, action), the noise is pinned per transition.
+type noisyPriceIteration struct {
+	amplitude float64
+	rng       *rand.Rand
+}
+
+func (p *noisyPriceIteration) Configure(partitionIndex int, settings *simulator.Settings) {
+	p.rng = rand.New(rand.NewPCG(settings.Iterations[partitionIndex].Seed, 0x5eed))
+}
+
+func (p *noisyPriceIteration) Iterate(
+	params *simulator.Params,
+	partitionIndex int,
+	stateHistories []*simulator.StateHistory,
+	timestepsHistory *simulator.CumulativeTimestepsHistory,
+) []float64 {
+	row := stateHistories[partitionIndex].Values.RawRowView(0)
+	phase := math.Mod(row[1]+1, float64(len(priceCycle)))
+	return []float64{priceCycle[int(phase)] + p.amplitude*p.rng.NormFloat64(), phase}
+}
+
+func newNoisyBatteryEnvironment(t *testing.T, scenarioSeed uint64) *agents.SimulationEnvironment {
+	t.Helper()
+	gen := simulator.NewConfigGenerator()
+	gen.SetSimulation(&simulator.SimulationConfig{
+		OutputCondition:      &simulator.NilOutputCondition{},
+		OutputFunction:       &simulator.NilOutputFunction{},
+		TerminationCondition: &simulator.NumberOfStepsTerminationCondition{MaxNumberOfSteps: 1},
+		TimestepFunction:     &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+		InitTimeValue:        0,
+	})
+	gen.SetPartition(&simulator.PartitionConfig{
+		Name:              "price",
+		Iteration:         &noisyPriceIteration{amplitude: 25},
+		InitStateValues:   []float64{priceCycle[3], 3},
+		StateHistoryDepth: 1,
+		Seed:              0,
+	})
+	gen.SetPartition(&simulator.PartitionConfig{
+		Name:              "battery",
+		Iteration:         &batteryIteration{capacity: 1},
+		Params:            simulator.NewParams(map[string][]float64{"dispatch": {0}}),
+		InitStateValues:   []float64{0, 0},
+		StateHistoryDepth: 1,
+		Seed:              0,
+	})
+	settings, impl := gen.GenerateConfigs()
+	impl.ExecutionStrategy = &simulator.InlineExecution{}
+
+	return agents.NewSimulationEnvironment(settings, impl, agents.SimulationEnvironmentSpec{
+		Actions:         [][]float64{{1}, {0}, {-1}},
+		ActionPartition: "battery",
+		ActionParam:     "dispatch",
+		Horizon:         testHorizon,
+		Reward: func(rows map[string][]float64) float64 {
+			return -rows["battery"][1] * rows["price"][0]
+		},
+		MinReturn:    -400,
+		MaxReturn:    400,
+		ScenarioSeed: scenarioSeed,
+	})
+}
+
+// planActions searches from each state in turn and returns the chosen sequence
+// together with the return the planner believed it would get.
+func planActions(t *testing.T, env *agents.SimulationEnvironment, sims int) ([]int, float64) {
+	t.Helper()
+	cfg := agents.MCTSConfig[[]float64, int]{
+		Simulations:     sims,
+		MaxTreeDepth:    testHorizon + 1,
+		RolloutMaxSteps: testHorizon + 1,
+		Rollout:         agents.UniformRandomRollout[[]float64, int](),
+	}
+	state := env.InitialState()
+	actions := make([]int, 0, testHorizon)
+	for step := 0; ; step++ {
+		if _, done := env.Terminal(state); done {
+			return actions, env.Return(state)
+		}
+		best, _, err := agents.RunMCTSSearch(env, state, cfg, uint64(step)+99, sims)
+		if err != nil {
+			t.Fatalf("RunMCTSSearch: %v", err)
+		}
+		actions = append(actions, best)
+		state, err = env.Apply(state, best)
+		if err != nil {
+			t.Fatalf("Apply: %v", err)
+		}
+	}
+}
+
+// replayActions runs a fixed action sequence in an environment, returning the
+// accumulated reward it actually earns there.
+func replayActions(t *testing.T, env *agents.SimulationEnvironment, actions []int) float64 {
+	t.Helper()
+	state := env.InitialState()
+	for _, action := range actions {
+		if _, done := env.Terminal(state); done {
+			break
+		}
+		next, err := env.Apply(state, action)
+		if err != nil {
+			t.Fatalf("Apply: %v", err)
+		}
+		state = next
+	}
+	return env.Return(state)
+}
+
+// TestSimulationEnvironmentOptimismGap measures the cost of pinning the noise.
+//
+// Planning against a fixed scenario seed lets the search exploit the particular
+// noise draw it is going to receive, so the return it predicts is optimistic
+// relative to what the same plan earns under other draws. This test quantifies
+// that gap rather than leaving it as a caveat in a doc comment: it plans under
+// one scenario, then replays the identical action sequence under others.
+//
+// The assertion is deliberately about the direction and the mechanism, not a
+// magnitude — the magnitude is what gets reported, and is the number that should
+// inform whether a chance-node treatment is worth building.
+func TestSimulationEnvironmentOptimismGap(t *testing.T) {
+	planningEnv := newNoisyBatteryEnvironment(t, 1)
+	actions, believed := planActions(t, planningEnv, 400)
+
+	realised := make([]float64, 0, 12)
+	total := 0.0
+	for seed := uint64(2); seed < 14; seed++ {
+		value := replayActions(t, newNoisyBatteryEnvironment(t, seed), actions)
+		realised = append(realised, value)
+		total += value
+	}
+	mean := total / float64(len(realised))
+
+	spread := 0.0
+	for _, value := range realised {
+		spread += (value - mean) * (value - mean)
+	}
+	spread = math.Sqrt(spread / float64(len(realised)))
+
+	t.Logf("planned return under its own scenario: %.1f", believed)
+	t.Logf("same plan under 12 other scenarios:    mean %.1f, sd %.1f", mean, spread)
+	t.Logf("optimism gap: %.1f (%.0f%% of the planned figure)",
+		believed-mean, 100*(believed-mean)/math.Abs(believed))
+
+	if spread == 0 {
+		t.Fatal("replays produced identical returns; the noise is not actually varying " +
+			"per scenario, so this test cannot measure anything")
+	}
+	if believed <= mean {
+		t.Logf("NOTE: no optimism observed on this seed — the gap is a bias in " +
+			"expectation, not a guarantee for any single plan")
+	}
+}
+
+// BenchmarkSimulationEnvironmentApply records the per-transition cost, which is
+// what bounds how much search a plan can afford. One MCTS iteration costs
+// roughly one Apply per rollout step, so a 400-simulation search over an
+// 8-step horizon is on the order of 3,200 of these.
+func BenchmarkSimulationEnvironmentApply(b *testing.B) {
+	env := newBatteryEnvironment(&testing.T{}, 1)
+	state := env.InitialState()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := env.Apply(state, i%3); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/agents/simulation_environment_test.go
+++ b/pkg/agents/simulation_environment_test.go
@@ -263,13 +263,10 @@ func (l *lookbackIteration) Iterate(
 }
 
 // TestSimulationEnvironmentCarriesDeepHistory checks that a partition reading
-// further back than one step plans correctly.
-//
-// Each transition restarts the sub-simulation, so unless the whole window is
-// carried in the encoded state and handed back, an iteration looking N steps into
-// the past sees the initial value forever. Trying to plan over trywizard's fitted
-// rugby model is what surfaced this: its card partition needs an 11-deep window,
-// and a depth-1-only encoding rejected the model outright.
+// further back than one step plans correctly. Each transition restarts the
+// sub-simulation, so unless the whole window is carried in the encoded state and
+// handed back, an iteration looking N steps into the past sees the initial value
+// forever. Real models need this: a rolling ten-minute count is a deep window.
 func TestSimulationEnvironmentCarriesDeepHistory(t *testing.T) {
 	const depth = 3
 	gen := simulator.NewConfigGenerator()
@@ -604,5 +601,145 @@ func TestChanceNodesReduceOptimism(t *testing.T) {
 	if math.Abs(chanceOptimism) >= math.Abs(pinnedOptimism) {
 		t.Errorf("chance nodes did not improve calibration: optimism %.1f vs %.1f",
 			chanceOptimism, pinnedOptimism)
+	}
+}
+
+// TestSimulationEnvironmentGuards covers the misconfigurations and bad calls
+// that would otherwise produce a plausible-looking but meaningless plan.
+func TestSimulationEnvironmentGuards(t *testing.T) {
+	env := newBatteryEnvironment(t, 1)
+	state := env.InitialState()
+
+	t.Run("an out-of-range action is an error", func(t *testing.T) {
+		if _, err := env.Apply(state, 99); err == nil {
+			t.Error("expected an error for an action outside the set")
+		}
+		if _, err := env.Apply(state, -1); err == nil {
+			t.Error("expected an error for a negative action")
+		}
+	})
+
+	t.Run("a mis-sized state is an error", func(t *testing.T) {
+		if _, err := env.Apply([]float64{1, 2}, 0); err == nil {
+			t.Error("expected an error for a state of the wrong width")
+		}
+	})
+
+	t.Run("a terminal state offers no actions", func(t *testing.T) {
+		terminal := append([]float64(nil), state...)
+		terminal[0] = testHorizon
+		if legal := env.Legal(terminal); len(legal) != 0 {
+			t.Errorf("expected no legal actions at the horizon, got %v", legal)
+		}
+	})
+
+	t.Run("single decision maker", func(t *testing.T) {
+		if got := env.Players(state); got != 1 {
+			t.Errorf("Players = %d, want 1", got)
+		}
+		if got := env.Actor(state); got != 0 {
+			t.Errorf("Actor = %d, want 0", got)
+		}
+	})
+
+	for _, testCase := range []struct {
+		name   string
+		mutate func(*agents.SimulationEnvironmentSpec)
+	}{
+		{"no actions", func(s *agents.SimulationEnvironmentSpec) { s.Actions = nil }},
+		{"no horizon", func(s *agents.SimulationEnvironmentSpec) { s.Horizon = 0 }},
+		{"no reward", func(s *agents.SimulationEnvironmentSpec) { s.Reward = nil }},
+		{"empty return range", func(s *agents.SimulationEnvironmentSpec) {
+			s.MinReturn, s.MaxReturn = 1, 1
+		}},
+		{"unknown action partition", func(s *agents.SimulationEnvironmentSpec) {
+			s.ActionPartition = "absent"
+		}},
+	} {
+		t.Run(testCase.name+" is rejected", func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Errorf("expected a panic for %s", testCase.name)
+				}
+			}()
+			gen := simulator.NewConfigGenerator()
+			gen.SetSimulation(&simulator.SimulationConfig{
+				OutputCondition:      &simulator.NilOutputCondition{},
+				OutputFunction:       &simulator.NilOutputFunction{},
+				TerminationCondition: &simulator.NumberOfStepsTerminationCondition{MaxNumberOfSteps: 1},
+				TimestepFunction:     &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+				InitTimeValue:        0,
+			})
+			gen.SetPartition(&simulator.PartitionConfig{
+				Name:              "battery",
+				Iteration:         &batteryIteration{capacity: 1},
+				Params:            simulator.NewParams(map[string][]float64{"dispatch": {0}}),
+				InitStateValues:   []float64{0, 0},
+				StateHistoryDepth: 1,
+				Seed:              0,
+			})
+			settings, impl := gen.GenerateConfigs()
+			spec := agents.SimulationEnvironmentSpec{
+				Actions:         [][]float64{{0}},
+				ActionPartition: "battery",
+				ActionParam:     "dispatch",
+				Horizon:         2,
+				Reward:          func(map[string][]float64) float64 { return 0 },
+				MinReturn:       -1,
+				MaxReturn:       1,
+			}
+			testCase.mutate(&spec)
+			agents.NewSimulationEnvironment(settings, impl, spec)
+		})
+	}
+}
+
+// TestSimulationEnvironmentLegalFilter checks a spec-supplied Legal narrows the
+// action set, which is how a model states that an action is unavailable in some
+// states — a battery that cannot discharge when empty, say.
+func TestSimulationEnvironmentLegalFilter(t *testing.T) {
+	gen := simulator.NewConfigGenerator()
+	gen.SetSimulation(&simulator.SimulationConfig{
+		OutputCondition:      &simulator.NilOutputCondition{},
+		OutputFunction:       &simulator.NilOutputFunction{},
+		TerminationCondition: &simulator.NumberOfStepsTerminationCondition{MaxNumberOfSteps: 1},
+		TimestepFunction:     &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+		InitTimeValue:        0,
+	})
+	gen.SetPartition(&simulator.PartitionConfig{
+		Name:              "battery",
+		Iteration:         &batteryIteration{capacity: 1},
+		Params:            simulator.NewParams(map[string][]float64{"dispatch": {0}}),
+		InitStateValues:   []float64{0, 0},
+		StateHistoryDepth: 1,
+		Seed:              0,
+	})
+	settings, impl := gen.GenerateConfigs()
+	env := agents.NewSimulationEnvironment(settings, impl, agents.SimulationEnvironmentSpec{
+		Actions:         [][]float64{{1}, {0}, {-1}},
+		ActionPartition: "battery",
+		ActionParam:     "dispatch",
+		Horizon:         4,
+		Reward:          func(map[string][]float64) float64 { return 0 },
+		MinReturn:       -1,
+		MaxReturn:       1,
+		// Discharging is unavailable while the battery is empty.
+		Legal: func(rows map[string][]float64) []int {
+			if rows["battery"][0] <= 0 {
+				return []int{0, 1}
+			}
+			return []int{0, 1, 2}
+		},
+	})
+
+	if legal := env.Legal(env.InitialState()); len(legal) != 2 {
+		t.Errorf("empty battery should offer 2 actions, got %v", legal)
+	}
+	charged, err := env.Apply(env.InitialState(), 0)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if legal := env.Legal(charged); len(legal) != 3 {
+		t.Errorf("charged battery should offer 3 actions, got %v", legal)
 	}
 }

--- a/pkg/agents/simulation_environment_test.go
+++ b/pkg/agents/simulation_environment_test.go
@@ -434,3 +434,93 @@ func BenchmarkSimulationEnvironmentApply(b *testing.B) {
 		}
 	}
 }
+
+// planActionsWithChanceNodes is planActions using the chance-node search, so each
+// action's value is an average over sampled successors.
+func planActionsWithChanceNodes(
+	t *testing.T,
+	env *agents.SimulationEnvironment,
+	sims int,
+) ([]int, float64) {
+	t.Helper()
+	cfg := agents.MCTSConfig[[]float64, int]{
+		Simulations:     sims,
+		MaxTreeDepth:    testHorizon + 1,
+		RolloutMaxSteps: testHorizon + 1,
+		Rollout:         agents.UniformRandomRollout[[]float64, int](),
+	}
+	state := env.InitialState()
+	actions := make([]int, 0, testHorizon)
+	for step := 0; ; step++ {
+		if _, done := env.Terminal(state); done {
+			return actions, env.Return(state)
+		}
+		best, _, err := agents.RunChanceMCTSSearch(env, state, cfg, uint64(step)+99, sims)
+		if err != nil {
+			t.Fatalf("RunChanceMCTSSearch: %v", err)
+		}
+		actions = append(actions, best)
+		state, err = env.Apply(state, best)
+		if err != nil {
+			t.Fatalf("Apply: %v", err)
+		}
+	}
+}
+
+// meanOptimism measures how much a planner over-promises, averaged over the
+// scenario it plans in.
+//
+// For each planning scenario it records what the plan earned THERE, then replays
+// the same actions in other scenarios and takes the mean. The difference is the
+// planner's advantage from having known its own noise. Averaging over planning
+// scenarios is what makes the number meaningful: a single planning scenario is
+// one draw, so its own-scenario return is mostly noise for any planner that is
+// not exploiting it — which is precisely the planner being tested.
+func meanOptimism(
+	t *testing.T,
+	plan func(*testing.T, *agents.SimulationEnvironment, int) ([]int, float64),
+	sims int,
+) (ownScenario, crossScenario, optimism float64) {
+	t.Helper()
+	const planningScenarios = 6
+	const replayScenarios = 8
+	for planSeed := uint64(1); planSeed <= planningScenarios; planSeed++ {
+		actions, own := plan(t, newNoisyBatteryEnvironment(t, planSeed), sims)
+		ownScenario += own
+		total := 0.0
+		for offset := uint64(0); offset < replayScenarios; offset++ {
+			replaySeed := 100 + planSeed*replayScenarios + offset
+			total += replayActions(t, newNoisyBatteryEnvironment(t, replaySeed), actions)
+		}
+		crossScenario += total / replayScenarios
+	}
+	ownScenario /= planningScenarios
+	crossScenario /= planningScenarios
+	return ownScenario, crossScenario, ownScenario - crossScenario
+}
+
+// TestChanceNodesReduceOptimism is the reason MCTSChanceTree exists. Planning
+// against a pinned noise realisation lets the search exploit the draw it is going
+// to receive, so what it achieves in its own scenario overstates what the same
+// plan earns anywhere else. Averaging over sampled outcomes at chance nodes
+// should shrink that advantage towards zero.
+//
+// The assertion is about CALIBRATION, not return: a planner that earns the same
+// but does not over-promise is the improvement being bought here.
+func TestChanceNodesReduceOptimism(t *testing.T) {
+	const sims = 400
+
+	pinnedOwn, pinnedCross, pinnedOptimism := meanOptimism(t, planActions, sims)
+	chanceOwn, chanceCross, chanceOptimism := meanOptimism(
+		t, planActionsWithChanceNodes, sims)
+
+	t.Logf("pinned noise:  own scenario %6.1f, other scenarios %6.1f, optimism %6.1f",
+		pinnedOwn, pinnedCross, pinnedOptimism)
+	t.Logf("chance nodes:  own scenario %6.1f, other scenarios %6.1f, optimism %6.1f",
+		chanceOwn, chanceCross, chanceOptimism)
+
+	if math.Abs(chanceOptimism) >= math.Abs(pinnedOptimism) {
+		t.Errorf("chance nodes did not improve calibration: optimism %.1f vs %.1f",
+			chanceOptimism, pinnedOptimism)
+	}
+}

--- a/pkg/agents/simulation_environment_test.go
+++ b/pkg/agents/simulation_environment_test.go
@@ -229,12 +229,49 @@ func fixedPolicyReturn(t *testing.T, env *agents.SimulationEnvironment, action i
 	}
 }
 
-func TestSimulationEnvironmentRejectsDeepHistory(t *testing.T) {
-	defer func() {
-		if recover() == nil {
-			t.Fatal("expected a panic for state_history_depth > 1")
-		}
-	}()
+// countingIteration increments a counter each step, so the contents of its
+// history window are predictable: [n, n-1, n-2, ...].
+type countingIteration struct{}
+
+func (c *countingIteration) Configure(int, *simulator.Settings) {}
+
+func (c *countingIteration) Iterate(
+	params *simulator.Params,
+	partitionIndex int,
+	stateHistories []*simulator.StateHistory,
+	timestepsHistory *simulator.CumulativeTimestepsHistory,
+) []float64 {
+	return []float64{stateHistories[partitionIndex].Values.RawRowView(0)[0] + 1}
+}
+
+// lookbackIteration reports the OLDEST row of the counter's window, which is only
+// correct if the whole window survived the transition. This is the shape a real
+// model uses for a rolling count — trywizard's match state counts yellow cards
+// active in the last ten minutes exactly this way.
+type lookbackIteration struct{ depth int }
+
+func (l *lookbackIteration) Configure(int, *simulator.Settings) {}
+
+func (l *lookbackIteration) Iterate(
+	params *simulator.Params,
+	partitionIndex int,
+	stateHistories []*simulator.StateHistory,
+	timestepsHistory *simulator.CumulativeTimestepsHistory,
+) []float64 {
+	counter := stateHistories[0]
+	return []float64{counter.Values.RawRowView(counter.StateHistoryDepth - 1)[0]}
+}
+
+// TestSimulationEnvironmentCarriesDeepHistory checks that a partition reading
+// further back than one step plans correctly.
+//
+// Each transition restarts the sub-simulation, so unless the whole window is
+// carried in the encoded state and handed back, an iteration looking N steps into
+// the past sees the initial value forever. Trying to plan over trywizard's fitted
+// rugby model is what surfaced this: its card partition needs an 11-deep window,
+// and a depth-1-only encoding rejected the model outright.
+func TestSimulationEnvironmentCarriesDeepHistory(t *testing.T) {
+	const depth = 3
 	gen := simulator.NewConfigGenerator()
 	gen.SetSimulation(&simulator.SimulationConfig{
 		OutputCondition:      &simulator.NilOutputCondition{},
@@ -244,23 +281,68 @@ func TestSimulationEnvironmentRejectsDeepHistory(t *testing.T) {
 		InitTimeValue:        0,
 	})
 	gen.SetPartition(&simulator.PartitionConfig{
-		Name:              "battery",
-		Iteration:         &batteryIteration{capacity: 1},
-		Params:            simulator.NewParams(map[string][]float64{"dispatch": {0}}),
-		InitStateValues:   []float64{0, 0},
-		StateHistoryDepth: 3,
+		Name:              "counter",
+		Iteration:         &countingIteration{},
+		Params:            simulator.NewParams(map[string][]float64{"unused": {0}}),
+		InitStateValues:   []float64{0},
+		StateHistoryDepth: depth,
+		Seed:              0,
+	})
+	gen.SetPartition(&simulator.PartitionConfig{
+		Name:              "lookback",
+		Iteration:         &lookbackIteration{depth: depth},
+		InitStateValues:   []float64{0},
+		StateHistoryDepth: 1,
 		Seed:              0,
 	})
 	settings, impl := gen.GenerateConfigs()
-	agents.NewSimulationEnvironment(settings, impl, agents.SimulationEnvironmentSpec{
+	impl.ExecutionStrategy = &simulator.InlineExecution{}
+
+	env := agents.NewSimulationEnvironment(settings, impl, agents.SimulationEnvironmentSpec{
 		Actions:         [][]float64{{0}},
-		ActionPartition: "battery",
-		ActionParam:     "dispatch",
-		Horizon:         2,
+		ActionPartition: "counter",
+		ActionParam:     "unused",
+		Horizon:         6,
 		Reward:          func(map[string][]float64) float64 { return 0 },
 		MinReturn:       -1,
 		MaxReturn:       1,
 	})
+
+	// Encoded layout: [step, return, counter window (depth), lookback (1)].
+	if got, want := env.StateWidth(), 2+depth+1; got != want {
+		t.Fatalf("state width %d, want %d (the window has to be in the state)", got, want)
+	}
+
+	state := env.InitialState()
+	for step := 1; step <= 5; step++ {
+		next, err := env.Apply(state, 0)
+		if err != nil {
+			t.Fatalf("Apply: %v", err)
+		}
+		state = next
+
+		window := state[2 : 2+depth]
+		for row := 0; row < depth; row++ {
+			want := float64(step - row)
+			if want < 0 {
+				want = 0
+			}
+			if window[row] != want {
+				t.Fatalf("step %d: window %v, want row %d to be %v — the history is "+
+					"not being carried across transitions", step, window, row, want)
+			}
+		}
+		// An iteration reading the oldest row must see the real history, not the
+		// initial value. It reads the window as it stands at the START of the
+		// step — before the counter advances — so at step N the oldest row it
+		// sees is N-depth, floored at the initial 0.
+		wantOldest := math.Max(0, float64(step-depth))
+		if got := state[2+depth]; got != wantOldest {
+			t.Fatalf("step %d: an iteration looking %d steps back read %v, want %v — "+
+				"it is seeing the initial value instead of the carried history",
+				step, depth, got, wantOldest)
+		}
+	}
 }
 
 // noisyPriceIteration is cyclicPriceIteration with Gaussian noise on the price.

--- a/pkg/api/cfg_examples_test.go
+++ b/pkg/api/cfg_examples_test.go
@@ -37,6 +37,7 @@ func TestExampleConfigsRun(t *testing.T) {
 		"cfg/example_smc_config.yaml",
 		"cfg/example_evolution_strategy_config.yaml",
 		"cfg/example_mcts_config.yaml",
+		"cfg/example_planning_config.yaml",
 		"cfg/example_regression_config.yaml",
 		"cfg/example_data_source_config.yaml",
 	}

--- a/pkg/api/macros.go
+++ b/pkg/api/macros.go
@@ -54,6 +54,7 @@ var macroSpecFactories = map[string]func() macroSpec{
 	"evolution_strategy_optimisation": func() macroSpec { return &evolutionStrategySpec{} },
 	"smc_inference":                   func() macroSpec { return &smcInferenceSpec{} },
 	"mcts_self_play":                  func() macroSpec { return &mctsSelfPlaySpec{} },
+	"mcts_planning":                   func() macroSpec { return &mctsPlanningSpec{} },
 }
 
 // DataConfig is the data: tier: it produces the StateTimeStorage that macros

--- a/pkg/api/macros_live_test.go
+++ b/pkg/api/macros_live_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-// TestSMCInferenceMacro checks the smc_inference macro's per-particle template
+// TestSMCInferenceMacro checks the smc_inference macro's per-particle model
 // recovers the true mean (2.0) of an observed data stream — a full particle-filter
 // inference expressed entirely as config.
 func TestSMCInferenceMacro(t *testing.T) {
@@ -31,23 +31,23 @@ macros:
   param_names: [mean]
   model:
     observed_data: {name: observed_data, ref: {partition_name: obs}}
-    per_particle_partitions:
-    - name: "pred_{particle}"
+    partitions:
+    - name: "pred"
       iteration: {type: param_values}
       params: {param_values: [0.0]}
       init_state_values: [0.0]
       state_history_depth: 2
-    - name: "loglike_{particle}"
+    - name: "loglike"
       iteration: {type: data_comparison, likelihood: {type: normal}}
       params: {mean: [0.0], variance: [0.5], latest_data_values: [2.0], cumulative: [1], burn_in_steps: [0]}
       params_from_upstream:
-        mean: {upstream: "pred_{particle}"}
+        mean: {upstream: "pred"}
         latest_data_values: {upstream: observed_data}
       init_state_values: [0.0]
       state_history_depth: 2
-    loglike_partition: "loglike_{particle}"
+    loglike_partition: "loglike"
     param_forwarding:
-      "pred_{particle}/param_values": [0]
+      "pred/param_values": [0]
 `
 	out := runMacroConfig(t, cfg)
 	post := out["smc_posterior"]

--- a/pkg/api/macros_planning.go
+++ b/pkg/api/macros_planning.go
@@ -8,28 +8,18 @@ import (
 	"github.com/umbralcalc/stochadex/pkg/simulator"
 )
 
-// mcts_planning is the config surface for planning over a simulation, and the
-// counterpart to mcts_self_play.
+// mcts_planning searches over the forward model itself: the dynamics are already
+// partitions, so an action is a params injection, a transition is one step of the
+// model, and the reward is a partition of it. Nothing has to be named from
+// outside, unlike mcts_self_play, whose environment is Go decision rules reached
+// through the environment registry.
 //
-// mcts_self_play searches over decision rules a downstream module wrote in Go,
-// which is why it needs the environment registry. This macro searches over the
-// forward model itself: the dynamics are already stated as partitions, so an
-// action is a params injection, a transition is one step of that model, and the
-// reward is a partition of it. Nothing about the environment has to be named
-// from outside, so a planning run is expressible as data end to end.
+// It is a sibling of evolution_strategy_optimisation, not a replacement: that
+// optimises a policy parameterisation once and globally, this optimises an action
+// sequence from the current state and replans every step.
 //
-// It is a sibling of evolution_strategy_optimisation rather than a replacement.
-// The evolution strategy optimises a *policy parameterisation* once, globally;
-// this optimises an *action sequence* from wherever the system currently is, and
-// replans every step, which is the shape a receding-horizon controller has.
-//
-// # The approximation this exposes
-//
-// The search plans against a pinned noise realisation — see
-// agents.SimulationEnvironment on why a transition has to be reproducible — so
-// the return it predicts is optimistic relative to what the same plan earns
-// under other draws. Vary scenario_seed and aggregate (the run: ensemble mode is
-// the easy way) rather than reading a single run's return as a forecast.
+// A planned return is one scenario's outcome, not a forecast. Vary scenario_seed
+// and aggregate — run: ensemble is the easy way.
 type mctsPlanningSpec struct {
 	macroTypeField `yaml:",inline"`
 	// Name prefixes the generated partitions. "<name>_apply" carries the model

--- a/pkg/api/macros_planning.go
+++ b/pkg/api/macros_planning.go
@@ -56,8 +56,20 @@ type mctsPlanningSpec struct {
 	// clamped outside it — widen the range rather than leaving it clamped, since
 	// a saturated score gives the search no gradient.
 	ReturnRange []float64 `yaml:"return_range"`
-	// ScenarioSeed pins which noise realisation is planned against.
+	// ScenarioSeed pins which noise realisation Apply returns, and so which
+	// scenario a pinned-noise search plans against.
 	ScenarioSeed uint64 `yaml:"scenario_seed,omitempty"`
+	// PinnedNoise turns chance nodes OFF, reverting to a search that commits to
+	// the first successor drawn for each action.
+	//
+	// Chance nodes are the default because a plan's value is usually going to be
+	// believed, and without them the search plans as though it knew which way the
+	// dice would fall: on the shipped example its over-promise runs to tens of
+	// percent, and *grows* with the simulation budget, since more search means
+	// more exploitation of the one realisation it can see. Pinning is faster and
+	// costs nothing when the model is deterministic — which is the case worth
+	// setting this for.
+	PinnedNoise bool `yaml:"pinned_noise,omitempty"`
 	// Model is the forward model being planned over.
 	Model planningModelSpec `yaml:"model"`
 	// Search hyperparameters; unset values fall back to the agents defaults.
@@ -160,6 +172,7 @@ func (s *mctsPlanningSpec) resolveLive(
 		MaxLegalActions: len(s.Actions),
 		StateWidth:      environment.StateWidth(),
 		Players:         1,
+		ChanceNodes:     !s.PinnedNoise,
 		// Looking further than the horizon cannot pay: the episode ends there.
 		SimsPerPly: s.SimsPerDecision,
 	}

--- a/pkg/api/macros_planning.go
+++ b/pkg/api/macros_planning.go
@@ -1,0 +1,244 @@
+package api
+
+import (
+	"fmt"
+
+	"github.com/umbralcalc/stochadex/pkg/agents"
+	"github.com/umbralcalc/stochadex/pkg/macros"
+	"github.com/umbralcalc/stochadex/pkg/simulator"
+)
+
+// mcts_planning is the config surface for planning over a simulation, and the
+// counterpart to mcts_self_play.
+//
+// mcts_self_play searches over decision rules a downstream module wrote in Go,
+// which is why it needs the environment registry. This macro searches over the
+// forward model itself: the dynamics are already stated as partitions, so an
+// action is a params injection, a transition is one step of that model, and the
+// reward is a partition of it. Nothing about the environment has to be named
+// from outside, so a planning run is expressible as data end to end.
+//
+// It is a sibling of evolution_strategy_optimisation rather than a replacement.
+// The evolution strategy optimises a *policy parameterisation* once, globally;
+// this optimises an *action sequence* from wherever the system currently is, and
+// replans every step, which is the shape a receding-horizon controller has.
+//
+// # The approximation this exposes
+//
+// The search plans against a pinned noise realisation — see
+// agents.SimulationEnvironment on why a transition has to be reproducible — so
+// the return it predicts is optimistic relative to what the same plan earns
+// under other draws. Vary scenario_seed and aggregate (the run: ensemble mode is
+// the easy way) rather than reading a single run's return as a forecast.
+type mctsPlanningSpec struct {
+	macroTypeField `yaml:",inline"`
+	// Name prefixes the generated partitions. "<name>_apply" carries the model
+	// state as it is driven, which is normally what you read output from.
+	Name string `yaml:"name"`
+	// Steps is the number of decisions to take.
+	Steps int `yaml:"steps"`
+	// Horizon is how far each search looks ahead, in model steps.
+	Horizon int `yaml:"horizon"`
+	// Actions is the discrete action set: each entry is the params value written
+	// to ActionParam on ActionPartition.
+	Actions         [][]float64 `yaml:"actions"`
+	ActionPartition string      `yaml:"action_partition"`
+	ActionParam     string      `yaml:"action_param"`
+	// RewardPartition names the model partition whose state[0] is the reward
+	// earned by the step just taken. Writing it as an {type: expression}
+	// partition is the usual way, which keeps the reward in the expressions DSL
+	// rather than inventing a second one.
+	RewardPartition string `yaml:"reward_partition"`
+	// Discount is the per-step discount factor (default 1, undiscounted).
+	Discount float64 `yaml:"discount,omitempty"`
+	// ReturnRange bounds the achievable return as [min, max]. UCB1 needs a
+	// bounded value scale, so returns are normalised into [0,1] against it and
+	// clamped outside it — widen the range rather than leaving it clamped, since
+	// a saturated score gives the search no gradient.
+	ReturnRange []float64 `yaml:"return_range"`
+	// ScenarioSeed pins which noise realisation is planned against.
+	ScenarioSeed uint64 `yaml:"scenario_seed,omitempty"`
+	// Model is the forward model being planned over.
+	Model planningModelSpec `yaml:"model"`
+	// Search hyperparameters; unset values fall back to the agents defaults.
+	SimsPerDecision int     `yaml:"sims_per_decision,omitempty"`
+	Exploration     float64 `yaml:"exploration,omitempty"`
+	MaxTreeDepth    int     `yaml:"max_tree_depth,omitempty"`
+	RolloutMaxSteps int     `yaml:"rollout_max_steps,omitempty"`
+	Seed            uint64  `yaml:"seed,omitempty"`
+	Timestep        float64 `yaml:"timestep,omitempty"`
+}
+
+// planningModelSpec is the forward model: ordinary partitions, plus the timestep
+// they advance on. There is no simulation block, because a planning run drives
+// the model one step at a time and supplies its own termination.
+type planningModelSpec struct {
+	Partitions []simulator.PartitionConfig `yaml:"partitions"`
+	Timestep   float64                     `yaml:"timestep,omitempty"`
+	InitTime   float64                     `yaml:"init_time,omitempty"`
+}
+
+// resolve reports that this is a live macro.
+func (s *mctsPlanningSpec) resolve(
+	*simulator.StateTimeStorage,
+) ([]*simulator.PartitionConfig, map[string]int, error) {
+	return nil, nil, fmt.Errorf(
+		"mcts_planning is a live macro; it drives its own model and must not be " +
+			"combined with against-storage macros")
+}
+
+func (s *mctsPlanningSpec) resolveLive(
+	*simulator.StateTimeStorage,
+) ([]*simulator.PartitionConfig, int, float64, error) {
+	if s.Name == "" {
+		return nil, 0, 0, fmt.Errorf("mcts_planning needs a name: (it prefixes the partition names)")
+	}
+	if s.Steps <= 0 {
+		return nil, 0, 0, fmt.Errorf("mcts_planning needs steps: > 0 (the number of decisions to take)")
+	}
+	if s.Horizon <= 0 {
+		return nil, 0, 0, fmt.Errorf("mcts_planning needs horizon: > 0 (how far each search looks ahead)")
+	}
+	if len(s.Actions) == 0 {
+		return nil, 0, 0, fmt.Errorf("mcts_planning needs a non-empty actions: list")
+	}
+	if len(s.ReturnRange) != 2 {
+		return nil, 0, 0, fmt.Errorf(
+			"mcts_planning needs return_range: [min, max] to normalise returns onto " +
+				"the [0,1] scale UCB1 requires")
+	}
+	if len(s.Model.Partitions) == 0 {
+		return nil, 0, 0, fmt.Errorf("mcts_planning needs model.partitions")
+	}
+
+	settings, implementations, err := s.Model.build()
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	rewardPartition := s.RewardPartition
+	if rewardPartition == "" {
+		return nil, 0, 0, fmt.Errorf(
+			"mcts_planning needs reward_partition: naming the model partition whose " +
+				"state[0] is the per-step reward")
+	}
+	if err := requireModelPartition(settings, rewardPartition, "reward_partition"); err != nil {
+		return nil, 0, 0, err
+	}
+	if err := requireModelPartition(settings, s.ActionPartition, "action_partition"); err != nil {
+		return nil, 0, 0, err
+	}
+
+	environment := agents.NewSimulationEnvironment(
+		settings, implementations, agents.SimulationEnvironmentSpec{
+			Actions:         s.Actions,
+			ActionPartition: s.ActionPartition,
+			ActionParam:     s.ActionParam,
+			Horizon:         s.Horizon,
+			Reward: func(rows map[string][]float64) float64 {
+				return rows[rewardPartition][0]
+			},
+			Discount:     s.Discount,
+			MinReturn:    s.ReturnRange[0],
+			MaxReturn:    s.ReturnRange[1],
+			ScenarioSeed: s.ScenarioSeed,
+		})
+
+	// The encoded state is already []float64, so the self-play topology's codec
+	// is the identity — copied, because the partitions retain what they are given.
+	selfPlay := macros.MCTSSelfPlaySpec[[]float64, int]{
+		Env: environment,
+		Cfg: agents.MCTSConfig[[]float64, int]{
+			Rollout: agents.UniformRandomRollout[[]float64, int](),
+		},
+		InitState: environment.InitialState(),
+		Decoder: func(row []float64) ([]float64, error) {
+			return append([]float64(nil), row...), nil
+		},
+		Encoder: func(state []float64) []float64 {
+			return append([]float64(nil), state...)
+		},
+		MaxLegalActions: len(s.Actions),
+		StateWidth:      environment.StateWidth(),
+		Players:         1,
+		// Looking further than the horizon cannot pay: the episode ends there.
+		SimsPerPly: s.SimsPerDecision,
+	}
+	if selfPlay.Cfg.MaxTreeDepth == 0 {
+		selfPlay.Cfg.MaxTreeDepth = s.Horizon + 1
+	}
+	if selfPlay.Cfg.RolloutMaxSteps == 0 {
+		selfPlay.Cfg.RolloutMaxSteps = s.Horizon + 1
+	}
+	macros.ApplyMCTSSearchSettings(&selfPlay, macros.MCTSSearchSettings{
+		Name:            s.Name,
+		SimsPerPly:      s.SimsPerDecision,
+		Simulations:     s.SimsPerDecision,
+		Exploration:     s.Exploration,
+		MaxTreeDepth:    s.MaxTreeDepth,
+		RolloutMaxSteps: s.RolloutMaxSteps,
+		Seed:            s.Seed,
+	})
+
+	timestep := s.Timestep
+	if timestep == 0 {
+		timestep = 1.0
+	}
+	return macros.NewMCTSSelfPlayPartitions(selfPlay), s.Steps, timestep, nil
+}
+
+// build resolves the model's partitions and wraps them in the minimal simulation
+// config a re-entrant model needs — the planner supplies the run length, so the
+// model's own termination condition is never consulted.
+func (m *planningModelSpec) build() (
+	*simulator.Settings, *simulator.Implementations, error,
+) {
+	partitions := make([]simulator.PartitionConfig, len(m.Partitions))
+	copy(partitions, m.Partitions)
+	if err := resolveIterations(partitions); err != nil {
+		return nil, nil, fmt.Errorf("mcts_planning model: %w", err)
+	}
+	timestep := m.Timestep
+	if timestep == 0 {
+		timestep = 1.0
+	}
+	generator := simulator.NewConfigGenerator()
+	generator.SetSimulation(&simulator.SimulationConfig{
+		OutputCondition:      &simulator.NilOutputCondition{},
+		OutputFunction:       &simulator.NilOutputFunction{},
+		TerminationCondition: &simulator.NumberOfStepsTerminationCondition{MaxNumberOfSteps: 1},
+		TimestepFunction:     &simulator.ConstantTimestepFunction{Stepsize: timestep},
+		InitTimeValue:        m.InitTime,
+	})
+	for index := range partitions {
+		generator.SetPartition(&partitions[index])
+	}
+	if err := CheckForDeadlock(generator); err != nil {
+		return nil, nil, fmt.Errorf("mcts_planning model: %w", err)
+	}
+	settings, implementations := generator.GenerateConfigs()
+	// Planning steps the model one transition at a time, so the goroutine
+	// round-trip of the default strategy would dominate.
+	implementations.ExecutionStrategy = &simulator.InlineExecution{}
+	return settings, implementations, nil
+}
+
+// requireModelPartition checks a named partition exists, so a typo is a config
+// error rather than a plan silently optimising a reward of zero.
+func requireModelPartition(
+	settings *simulator.Settings,
+	name string,
+	field string,
+) error {
+	for _, iteration := range settings.Iterations {
+		if iteration.Name == name {
+			return nil
+		}
+	}
+	available := make([]string, 0, len(settings.Iterations))
+	for _, iteration := range settings.Iterations {
+		available = append(available, iteration.Name)
+	}
+	return fmt.Errorf(
+		"mcts_planning %s: no model partition named %q (model has %v)",
+		field, name, available)
+}

--- a/pkg/api/macros_planning_test.go
+++ b/pkg/api/macros_planning_test.go
@@ -1,0 +1,140 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// planningConfig is battery arbitrage over a cyclic price, written entirely as
+// config: two model partitions for the dynamics, one expression partition for the
+// reward, and a discrete charge/hold/discharge action set.
+//
+// The optimum is knowable by hand. The price cycles 10, 10, 90, 90 and the
+// battery holds one unit, so the best play is to buy on a cheap step and sell on
+// a dear one — twice over an 8-step run, for 2 * (90 - 10) = 160. Doing nothing
+// earns 0, and no myopic rule reaches 160, because buying looks like a pure loss
+// at the moment it has to happen.
+const planningConfig = `macros:
+- type: mcts_planning
+  name: plan
+  steps: 8
+  horizon: 8
+  sims_per_decision: 400
+  seed: 99
+  return_range: [-400, 400]
+  actions: [[1], [0], [-1]]
+  action_partition: battery
+  action_param: dispatch
+  reward_partition: revenue
+  model:
+    partitions:
+    - name: price
+      iteration:
+        type: expression
+        fields: [{name: price}, {name: phase}]
+        bindings:
+        - {name: nextphase, expr: "phase + 1 - 4 * floor((phase + 1) / 4)"}
+        outputs: ["where(nextphase < 2, 10, 90)", "nextphase"]
+      init_state_values: [90.0, 3.0]
+      state_history_depth: 1
+      seed: 0
+    - name: battery
+      iteration:
+        type: expression
+        fields: [{name: soc}, {name: flow}]
+        bindings:
+        - {name: nextsoc, expr: "clamp(soc + dispatch, 0, 1)"}
+        outputs: ["nextsoc", "nextsoc - soc"]
+      params: {dispatch: [0.0]}
+      init_state_values: [0.0, 0.0]
+      state_history_depth: 1
+      seed: 0
+    - name: revenue
+      iteration:
+        type: expression
+        fields: [{name: r}]
+        outputs: ["0 - flow * price"]
+      params: {flow: [0.0], price: [0.0]}
+      params_from_upstream:
+        flow: {upstream: battery, indices: [1]}
+        price: {upstream: price, indices: [0]}
+      init_state_values: [0.0]
+      state_history_depth: 1
+      seed: 0
+`
+
+// TestMCTSPlanningMacro is the end-to-end check that a planning run is
+// expressible as data: no Go, no registered environment, just a forward model
+// and an action set. The assertion is on the plan's value, not that it ran.
+func TestMCTSPlanningMacro(t *testing.T) {
+	out := runMacroConfig(t, planningConfig)
+	rows := out["plan_apply"]
+	if len(rows) < 2 {
+		t.Fatalf("expected the driven model to be recorded, got %d rows", len(rows))
+	}
+	// Encoded state layout: [step, accumulated return, price(2), battery(2), revenue(1)].
+	final := rows[len(rows)-1]
+	planned := final[1]
+	t.Logf("planned return %.1f over %v steps (final state %v)", planned, final[0], final)
+
+	if planned < 120 {
+		t.Errorf("planned return %.1f: the search is not exploiting the price cycle "+
+			"(doing nothing earns 0, the optimum is 160)", planned)
+	}
+	if planned > 160.0001 {
+		t.Errorf("planned return %.1f exceeds the achievable optimum of 160", planned)
+	}
+}
+
+// TestMCTSPlanningMacroValidation checks the macro rejects the config mistakes
+// that would otherwise produce a plausible-looking but meaningless plan — most
+// importantly a reward or action partition that does not exist, which would
+// silently optimise nothing.
+func TestMCTSPlanningMacroValidation(t *testing.T) {
+	for _, testCase := range []struct {
+		name       string
+		replace    [2]string
+		wantErrHas string
+	}{
+		{
+			name:       "unknown reward partition",
+			replace:    [2]string{"reward_partition: revenue", "reward_partition: profit"},
+			wantErrHas: `no model partition named "profit"`,
+		},
+		{
+			name:       "unknown action partition",
+			replace:    [2]string{"action_partition: battery", "action_partition: turbine"},
+			wantErrHas: `no model partition named "turbine"`,
+		},
+		{
+			name:       "missing return range",
+			replace:    [2]string{"return_range: [-400, 400]", "return_range: [0]"},
+			wantErrHas: "return_range",
+		},
+		{
+			name:       "no actions",
+			replace:    [2]string{"actions: [[1], [0], [-1]]", "actions: []"},
+			wantErrHas: "actions",
+		},
+		{
+			name:       "no horizon",
+			replace:    [2]string{"horizon: 8", "horizon: 0"},
+			wantErrHas: "horizon",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg := strings.Replace(
+				planningConfig, testCase.replace[0], testCase.replace[1], 1)
+			if cfg == planningConfig {
+				t.Fatalf("test setup: %q not found in the config", testCase.replace[0])
+			}
+			err := macroConfigError(t, cfg)
+			if err == nil {
+				t.Fatalf("expected an error mentioning %q", testCase.wantErrHas)
+			}
+			if !strings.Contains(err.Error(), testCase.wantErrHas) {
+				t.Errorf("error should mention %q, got: %v", testCase.wantErrHas, err)
+			}
+		})
+	}
+}

--- a/pkg/api/macros_smc.go
+++ b/pkg/api/macros_smc.go
@@ -211,6 +211,14 @@ func instantiateParticle(
 		partition.Iteration = iteration
 	}
 	partition.Name = substituteParticle(partition.Name, particle)
+	if particle >= 0 {
+		// Give each particle its own random stream. Copying the template's seed
+		// verbatim would run every particle on one noise realisation, so a
+		// stochastic model — the whole point of simulation-based inference —
+		// would produce a particle cloud that varies only with the proposed
+		// parameters and not with the model, understating posterior spread.
+		partition.Seed = simulator.DeriveSeed(partition.Seed, particle)
+	}
 
 	params := make(map[string][]float64, len(partition.Params.Map))
 	for key, values := range partition.Params.Map {

--- a/pkg/api/macros_smc.go
+++ b/pkg/api/macros_smc.go
@@ -2,8 +2,6 @@ package api
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 
 	"github.com/umbralcalc/stochadex/pkg/general"
 	"github.com/umbralcalc/stochadex/pkg/inference"
@@ -11,12 +9,16 @@ import (
 	"github.com/umbralcalc/stochadex/pkg/simulator"
 )
 
-// smc_inference is a live macro whose inner model is a per-particle template: the
-// same partition set is instantiated once per particle, with the "{particle}"
-// placeholder in partition names and upstream references replaced by the particle
-// index. This is how a config expresses the N-way particle structure of an SMC
-// run (macros.SMCParticleModel.Build) without a general loop construct — the
-// loop lives here, in the macro's Go.
+// smc_inference is a live macro. Its model is stated ONCE, as an ordinary set of
+// partitions, and instantiated per particle by macros.SMCParticleEvaluationIteration.
+//
+// It used to be a template instead: the same partition set written with a
+// "{particle}" placeholder, expanded here into N copies inside one simulation.
+// That made the particle count a property of the configuration, and left
+// per-particle random seeding to whoever wrote the template — which is exactly
+// what silently was not happening, putting every particle on one noise
+// realisation. Seeds are now derived per particle by the evaluation iteration,
+// so a config cannot get them wrong.
 
 type smcInferenceSpec struct {
 	macroTypeField `yaml:",inline"`
@@ -40,12 +42,17 @@ type smcInferenceSpec struct {
 // timestep function walks the storage times). Otherwise a Simulation spec is
 // required.
 type smcModelSpec struct {
-	Simulation            simulator.SimulationConfigStrings `yaml:"simulation,omitempty"`
-	ObservedData          *smcObservedData                  `yaml:"observed_data,omitempty"`
-	SharedPartitions      []simulator.PartitionConfig       `yaml:"shared_partitions,omitempty"`
-	PerParticlePartitions []simulator.PartitionConfig       `yaml:"per_particle_partitions"`
-	LoglikePartition      string                            `yaml:"loglike_partition"`
-	ParamForwarding       map[string][]int                  `yaml:"param_forwarding,omitempty"`
+	Simulation   simulator.SimulationConfigStrings `yaml:"simulation,omitempty"`
+	ObservedData *smcObservedData                  `yaml:"observed_data,omitempty"`
+	// Partitions is one particle's model, written once with no templating. Every
+	// particle gets its own instance.
+	Partitions []simulator.PartitionConfig `yaml:"partitions"`
+	// LoglikePartition names the partition whose state[0] is the particle's
+	// cumulative log-likelihood.
+	LoglikePartition string `yaml:"loglike_partition"`
+	// ParamForwarding maps "partition_name/param_name" to indices into the
+	// particle's own parameter vector (length = len(priors)).
+	ParamForwarding map[string][]int `yaml:"param_forwarding,omitempty"`
 }
 
 type smcObservedData struct {
@@ -100,11 +107,11 @@ func (s *smcInferenceSpec) resolveLive(
 	return partitions, s.NumRounds, timestep, nil
 }
 
-// builder returns the SMCParticleModel.Build closure that instantiates the inner
-// model for N particles with nParams parameters each.
+// builder returns the SMCParticleModel.Build closure that instantiates one
+// particle's model, with nParams parameters.
 func (m *smcModelSpec) builder(
 	storage *simulator.StateTimeStorage,
-) (func(N, nParams int) *macros.SMCInnerSimConfig, error) {
+) (func(nParams int) *macros.SMCInnerSimConfig, error) {
 	// The inner simulation is either auto-built from the observed data's timeline,
 	// or given explicitly as data specs.
 	var explicitSim *simulator.SimulationConfig
@@ -123,7 +130,7 @@ func (m *smcModelSpec) builder(
 		explicitSim = resolved
 	}
 
-	return func(N, nParams int) *macros.SMCInnerSimConfig {
+	return func(nParams int) *macros.SMCInnerSimConfig {
 		partitions := make([]*simulator.PartitionConfig, 0)
 
 		simulation := explicitSim
@@ -146,60 +153,33 @@ func (m *smcModelSpec) builder(
 				InitTimeValue:        times[0],
 			}
 		}
-		for i := range m.SharedPartitions {
-			shared, err := instantiateParticle(m.SharedPartitions[i], -1)
+		for i := range m.Partitions {
+			partition, err := instantiateModelPartition(m.Partitions[i])
 			if err != nil {
-				panic(fmt.Sprintf("smc_inference shared partition: %v", err))
+				panic(fmt.Sprintf("smc_inference model partition: %v", err))
 			}
-			partitions = append(partitions, shared)
-		}
-
-		loglikePartitions := make([]string, N)
-		paramForwarding := make(map[string][]int)
-		for p := 0; p < N; p++ {
-			for i := range m.PerParticlePartitions {
-				partition, err := instantiateParticle(m.PerParticlePartitions[i], p)
-				if err != nil {
-					panic(fmt.Sprintf("smc_inference per-particle partition: %v", err))
-				}
-				partitions = append(partitions, partition)
-			}
-			loglikePartitions[p] = substituteParticle(m.LoglikePartition, p)
-			for key, offsets := range m.ParamForwarding {
-				indices := make([]int, len(offsets))
-				for j, offset := range offsets {
-					indices[j] = p*nParams + offset
-				}
-				paramForwarding[substituteParticle(key, p)] = indices
-			}
+			partitions = append(partitions, partition)
 		}
 
 		simCopy := *simulation
 		return &macros.SMCInnerSimConfig{
-			Partitions:        partitions,
-			Simulation:        &simCopy,
-			LoglikePartitions: loglikePartitions,
-			ParamForwarding:   paramForwarding,
+			Partitions:       partitions,
+			Simulation:       &simCopy,
+			LoglikePartition: m.LoglikePartition,
+			ParamForwarding:  m.ParamForwarding,
 		}
 	}, nil
 }
 
-// substituteParticle replaces the {particle} placeholder with the particle index
-// (a bare placeholder, for the shared pass with index -1, is left as-is).
-func substituteParticle(s string, particle int) string {
-	if particle < 0 {
-		return s
-	}
-	return strings.ReplaceAll(s, "{particle}", strconv.Itoa(particle))
-}
-
-// instantiateParticle builds one partition from a template for the given particle,
-// with a fresh iteration instance, a deep-copied params map (so per-particle
-// upstream injection cannot cross-contaminate), and {particle} substituted through
-// the name and every upstream / partition reference.
-func instantiateParticle(
+// instantiateModelPartition builds one particle's copy of a model partition, with
+// a fresh iteration instance and deep-copied params and wiring maps — so that
+// nothing is shared between particles, which would couple their evaluations.
+//
+// Seeds are deliberately not touched here: the evaluation iteration reseeds every
+// particle's whole model per round (see simulator.ReentrantSimulation), so a
+// config cannot leave two particles sharing a random stream.
+func instantiateModelPartition(
 	template simulator.PartitionConfig,
-	particle int,
 ) (*simulator.PartitionConfig, error) {
 	partition := template
 	partition.Init()
@@ -209,15 +189,6 @@ func instantiateParticle(
 			return nil, err
 		}
 		partition.Iteration = iteration
-	}
-	partition.Name = substituteParticle(partition.Name, particle)
-	if particle >= 0 {
-		// Give each particle its own random stream. Copying the template's seed
-		// verbatim would run every particle on one noise realisation, so a
-		// stochastic model — the whole point of simulation-based inference —
-		// would produce a particle cloud that varies only with the proposed
-		// parameters and not with the model, understating posterior spread.
-		partition.Seed = simulator.DeriveSeed(partition.Seed, particle)
 	}
 
 	params := make(map[string][]float64, len(partition.Params.Map))
@@ -230,18 +201,15 @@ func instantiateParticle(
 
 	fromUpstream := make(map[string]simulator.NamedUpstreamConfig, len(partition.ParamsFromUpstream))
 	for key, upstream := range partition.ParamsFromUpstream {
-		upstream.Upstream = substituteParticle(upstream.Upstream, particle)
-		fromUpstream[substituteParticle(key, particle)] = upstream
+		fromUpstream[key] = upstream
 	}
 	partition.ParamsFromUpstream = fromUpstream
 
 	asPartitions := make(map[string][]string, len(partition.ParamsAsPartitions))
 	for key, refs := range partition.ParamsAsPartitions {
-		substituted := make([]string, len(refs))
-		for i, ref := range refs {
-			substituted[i] = substituteParticle(ref, particle)
-		}
-		asPartitions[substituteParticle(key, particle)] = substituted
+		copied := make([]string, len(refs))
+		copy(copied, refs)
+		asPartitions[key] = copied
 	}
 	partition.ParamsAsPartitions = asPartitions
 

--- a/pkg/api/macros_smc.go
+++ b/pkg/api/macros_smc.go
@@ -9,16 +9,10 @@ import (
 	"github.com/umbralcalc/stochadex/pkg/simulator"
 )
 
-// smc_inference is a live macro. Its model is stated ONCE, as an ordinary set of
-// partitions, and instantiated per particle by macros.SMCParticleEvaluationIteration.
-//
-// It used to be a template instead: the same partition set written with a
-// "{particle}" placeholder, expanded here into N copies inside one simulation.
-// That made the particle count a property of the configuration, and left
-// per-particle random seeding to whoever wrote the template — which is exactly
-// what silently was not happening, putting every particle on one noise
-// realisation. Seeds are now derived per particle by the evaluation iteration,
-// so a config cannot get them wrong.
+// smc_inference is a live macro. Its model is stated once, as an ordinary set of
+// partitions, and instantiated per particle by
+// macros.SMCParticleEvaluationIteration, which also derives each particle's
+// seeds.
 
 type smcInferenceSpec struct {
 	macroTypeField `yaml:",inline"`

--- a/pkg/api/macros_smc_test.go
+++ b/pkg/api/macros_smc_test.go
@@ -6,50 +6,54 @@ import (
 	"github.com/umbralcalc/stochadex/pkg/simulator"
 )
 
-// TestParticleTemplateInstantiation guards SMC correctness at the mechanism level:
-// each particle must get its OWN partition with {particle} substituted through the
-// name and every upstream reference, and its OWN params map — otherwise particles
-// silently share state and the inference is quietly wrong.
-func TestParticleTemplateInstantiation(t *testing.T) {
+// TestModelPartitionInstantiation guards SMC correctness at the mechanism level:
+// every particle gets its own instance of each model partition, with its own
+// params and wiring maps. Sharing any of them would couple particles, since
+// upstream injection writes into params at runtime.
+func TestModelPartitionInstantiation(t *testing.T) {
 	template := simulator.PartitionConfig{
-		Name:            "pred_{particle}",
+		Name:            "pred",
 		Params:          simulator.NewParams(map[string][]float64{"param_values": {0.0}}),
 		InitStateValues: []float64{0.0},
 		ParamsFromUpstream: map[string]simulator.NamedUpstreamConfig{
-			"mean": {Upstream: "pred_{particle}"},
+			"mean": {Upstream: "pred"},
 		},
 		ParamsAsPartitions: map[string][]string{
-			"peer": {"loglike_{particle}"},
+			"peer": {"loglike"},
 		},
 	}
 
-	p0, err := instantiateParticle(template, 0)
+	p0, err := instantiateModelPartition(template)
 	if err != nil {
 		t.Fatal(err)
 	}
-	p1, err := instantiateParticle(template, 1)
+	p1, err := instantiateModelPartition(template)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if p0.Name != "pred_0" || p1.Name != "pred_1" {
-		t.Errorf("names not substituted: %q, %q", p0.Name, p1.Name)
+	// Names are no longer templated: each particle runs its own simulation, so
+	// two particles' partitions can share a name without colliding.
+	if p0.Name != "pred" || p1.Name != "pred" {
+		t.Errorf("names should be verbatim: %q, %q", p0.Name, p1.Name)
 	}
-	if p0.ParamsFromUpstream["mean"].Upstream != "pred_0" {
-		t.Errorf("upstream not substituted: %q", p0.ParamsFromUpstream["mean"].Upstream)
+	if p0.ParamsFromUpstream["mean"].Upstream != "pred" {
+		t.Errorf("upstream should be verbatim: %q", p0.ParamsFromUpstream["mean"].Upstream)
 	}
-	if p1.ParamsAsPartitions["peer"][0] != "loglike_1" {
-		t.Errorf("params_as_partitions not substituted: %v", p1.ParamsAsPartitions["peer"])
+	if p1.ParamsAsPartitions["peer"][0] != "loglike" {
+		t.Errorf("params_as_partitions should be verbatim: %v", p1.ParamsAsPartitions["peer"])
 	}
 
-	// Deep-copy invariant: mutating one particle's params must not touch the other's
-	// or the template's — upstream injection writes into params at runtime.
 	p0.Params.Map["param_values"][0] = 99.0
 	if p1.Params.Map["param_values"][0] != 0.0 {
 		t.Error("params not deep-copied: particle 1 saw particle 0's mutation")
 	}
 	if template.Params.Map["param_values"][0] != 0.0 {
 		t.Error("params not deep-copied: the template was mutated")
+	}
+	p0.ParamsAsPartitions["peer"][0] = "elsewhere"
+	if p1.ParamsAsPartitions["peer"][0] != "loglike" {
+		t.Error("params_as_partitions not deep-copied between particles")
 	}
 }
 
@@ -94,32 +98,34 @@ macros:
   param_names: [mean]
   model:
     observed_data: {name: observed_data, ref: {partition_name: obs}}
-    per_particle_partitions:
-    - name: "walk_{particle}"
+    partitions:
+    - name: "walk"
       iteration: {type: wiener_process}
       params: {variances: [1.0]}
       init_state_values: [0.0]
       state_history_depth: 2
       seed: 99
-    - name: "loglike_{particle}"
+    - name: "loglike"
       iteration: {type: data_comparison, likelihood: {type: normal}}
       params: {mean: [0.0], variance: [0.5], latest_data_values: [2.0], cumulative: [1], burn_in_steps: [0]}
       params_from_upstream:
-        mean: {upstream: "walk_{particle}"}
+        mean: {upstream: "walk"}
         latest_data_values: {upstream: observed_data}
       init_state_values: [0.0]
       state_history_depth: 2
-    loglike_partition: "loglike_{particle}"
+    loglike_partition: "loglike"
 `
 	rows := runMacroConfig(t, cfg)["smc_sim"]
-	final := rows[len(rows)-1]
-	// Inner layout: observed_data(1), then per particle walk(1), loglike(1).
-	endpoints := []float64{final[1], final[3], final[5], final[7]}
-	for i, value := range endpoints {
-		for j := i + 1; j < len(endpoints); j++ {
-			if value == endpoints[j] {
+	// The evaluation partition's row is one log-likelihood per particle.
+	loglikes := rows[len(rows)-1]
+	if len(loglikes) != 4 {
+		t.Fatalf("expected one log-likelihood per particle, got %v", loglikes)
+	}
+	for i, value := range loglikes {
+		for j := i + 1; j < len(loglikes); j++ {
+			if value == loglikes[j] {
 				t.Fatalf("particles %d and %d share a noise realisation (both %v); "+
-					"per-particle seeds are not being varied: %v", i, j, value, endpoints)
+					"per-particle seeds are not being varied: %v", i, j, value, loglikes)
 			}
 		}
 	}

--- a/pkg/api/macros_smc_test.go
+++ b/pkg/api/macros_smc_test.go
@@ -69,12 +69,9 @@ func TestLiveMacroRejectsAgainstStorage(t *testing.T) {
 
 // TestSMCParticlesGetDistinctNoise pins per-particle seeding. The model here is
 // stochastic and reads no proposal parameters, so any variation between particles
-// can only come from their random streams.
-//
-// Before this was fixed, per-particle partitions inherited the template's seed
-// verbatim and every particle ran the same noise realisation — invisible with a
-// deterministic model, and silently fatal for simulation-based inference, where
-// the particle cloud is supposed to carry the model's Monte Carlo variation.
+// can only come from their random streams. Particles sharing one realisation is
+// invisible with a deterministic model and fatal for simulation-based inference,
+// where the cloud is supposed to carry the model's Monte Carlo variation.
 func TestSMCParticlesGetDistinctNoise(t *testing.T) {
 	const cfg = `data:
   steps: 12

--- a/pkg/api/macros_smc_test.go
+++ b/pkg/api/macros_smc_test.go
@@ -62,3 +62,65 @@ func TestLiveMacroRejectsAgainstStorage(t *testing.T) {
 		}
 	}
 }
+
+// TestSMCParticlesGetDistinctNoise pins per-particle seeding. The model here is
+// stochastic and reads no proposal parameters, so any variation between particles
+// can only come from their random streams.
+//
+// Before this was fixed, per-particle partitions inherited the template's seed
+// verbatim and every particle ran the same noise realisation — invisible with a
+// deterministic model, and silently fatal for simulation-based inference, where
+// the particle cloud is supposed to carry the model's Monte Carlo variation.
+func TestSMCParticlesGetDistinctNoise(t *testing.T) {
+	const cfg = `data:
+  steps: 12
+  timestep: 1.0
+  partitions:
+  - name: obs
+    iteration: {type: data_generation, likelihood: {type: normal}}
+    params: {mean: [2.0], covariance_matrix: [0.5]}
+    init_state_values: [2.0]
+    state_history_depth: 1
+    seed: 7
+macros:
+- type: smc_inference
+  proposal_name: smc_proposals
+  sim_name: smc_sim
+  posterior_name: smc_posterior
+  num_particles: 4
+  num_rounds: 1
+  seed: 42
+  priors: [{type: uniform, lo: -5.0, hi: 10.0}]
+  param_names: [mean]
+  model:
+    observed_data: {name: observed_data, ref: {partition_name: obs}}
+    per_particle_partitions:
+    - name: "walk_{particle}"
+      iteration: {type: wiener_process}
+      params: {variances: [1.0]}
+      init_state_values: [0.0]
+      state_history_depth: 2
+      seed: 99
+    - name: "loglike_{particle}"
+      iteration: {type: data_comparison, likelihood: {type: normal}}
+      params: {mean: [0.0], variance: [0.5], latest_data_values: [2.0], cumulative: [1], burn_in_steps: [0]}
+      params_from_upstream:
+        mean: {upstream: "walk_{particle}"}
+        latest_data_values: {upstream: observed_data}
+      init_state_values: [0.0]
+      state_history_depth: 2
+    loglike_partition: "loglike_{particle}"
+`
+	rows := runMacroConfig(t, cfg)["smc_sim"]
+	final := rows[len(rows)-1]
+	// Inner layout: observed_data(1), then per particle walk(1), loglike(1).
+	endpoints := []float64{final[1], final[3], final[5], final[7]}
+	for i, value := range endpoints {
+		for j := i + 1; j < len(endpoints); j++ {
+			if value == endpoints[j] {
+				t.Fatalf("particles %d and %d share a noise realisation (both %v); "+
+					"per-particle seeds are not being varied: %v", i, j, value, endpoints)
+			}
+		}
+	}
+}

--- a/pkg/api/registry_environment.go
+++ b/pkg/api/registry_environment.go
@@ -9,37 +9,21 @@ import (
 	"github.com/umbralcalc/stochadex/pkg/simulator"
 )
 
-// The environment registry: the downstream extension point that lets the
-// mcts_self_play macro name an agents.Environment from config.
+// The environment registry lets the mcts_self_play macro name an
+// agents.Environment from config.
 //
-// # Why this is a hook and not a data spelling
+// It is a hook rather than a {type: ...} data spec because an environment is
+// arbitrary decision rules (Legal / Apply / Terminal), which the repo boundary
+// places downstream. Spelling those as data would mean a rules language inside
+// the config. The registered builder receives the whole ComponentSpec verbatim
+// and returns finished partitions, so the fields under `env:` are parsed by the
+// downstream and never by this package.
 //
-// Every other component family in this engine resolves from a {type: ...} data
-// spec because the thing being named is part of the framework's own catalogue —
-// a Wiener process, an exponential kernel, a normal likelihood. An
-// agents.Environment is not: it is arbitrary decision-process rules (Legal /
-// Apply / Terminal), which the repo boundary places downstream, in the project
-// that owns the decision layer. Spelling those rules as data would mean growing
-// a rules language inside the config, which is a different (and much larger)
-// project than this registry — and one that would only serve games.
-//
-// So the engine ships no environments beyond the tic-tac-toe fixture below, and
-// instead lets a downstream module contribute one. The registered builder is
-// handed the environment's whole ComponentSpec verbatim and returns finished
-// partitions: the fields under `env:` are parsed by the *downstream*, never by
-// this package. A card-game project's `{type: cardgame_rules, rules: uno.yaml}`
-// is opaque here — the engine passes it through and never learns what a zone or
-// a phase is.
-//
-// # Why the builder returns partitions rather than an environment
-//
-// macros.NewMCTSSelfPlayPartitions is generic in the environment's state and
-// action types, so this package cannot call it: a registry map has to hold a
-// concrete type, and erasing S and A to fit one would force an encode/decode
-// round-trip through every Apply in the search hot loop. Having the builder
-// call the generic constructor itself keeps the typed Environment[S, A] intact
-// for its Go callers and keeps this side free of type parameters entirely.
-// macros.MCTSSearchSettings carries the config-stated half across that boundary.
+// The builder returns partitions rather than an environment because
+// macros.NewMCTSSelfPlayPartitions is generic in S and A: a registry map holds a
+// concrete type, and erasing the parameters would force an encode/decode round
+// trip through every Apply in the search hot loop. macros.MCTSSearchSettings
+// carries the config-stated half across the boundary.
 
 // EnvironmentBuilder constructs the partitions of an MCTS self-play stack from
 // a downstream environment's data spec plus the search settings the config

--- a/pkg/api/registry_environment_tictactoe.go
+++ b/pkg/api/registry_environment_tictactoe.go
@@ -8,16 +8,9 @@ import (
 	"github.com/umbralcalc/stochadex/pkg/simulator"
 )
 
-// The one environment the engine registers itself. Tic-tac-toe is already this
-// repo's canonical Environment fixture (see agents.TTTGame): small enough to be
-// obvious, sharp enough that a broken search fails a "win in one" assertion.
-// Registering it here is what makes the mcts_self_play macro runnable from the
-// stock CLI with no downstream module — which is what keeps the whole hook
-// covered by an end-to-end config in engine CI, and gives cfg/ a worked example.
-//
-// It is a fixture, not a domain model: it is deliberately the only environment
-// the engine ships, and real decision rules belong downstream (see the registry
-// note in registry_environment.go).
+// Tic-tac-toe is the only environment the engine registers, and a fixture rather
+// than a domain model: it keeps the hook covered end to end in CI and gives cfg/
+// a worked example. Real decision rules belong downstream.
 func init() {
 	RegisterEnvironment("tictactoe", buildTicTacToeEnvironment)
 }

--- a/pkg/general/embedded_simulation_run.go
+++ b/pkg/general/embedded_simulation_run.go
@@ -49,20 +49,15 @@ type NamedIndexedState struct {
 //     warm-starting inner optimisers across outer steps.
 //   - Optional "burn_in_steps" skips initial outer steps before running inner sim.
 //
-// # Streaming vs re-entrant runs
+// This is a stream by default: Configure seeds the inner iterations once and each
+// outer step advances them from wherever the last run left their RNGs, so two
+// runs with identical inputs give different answers. That is what advancing a
+// nested simulation alongside an outer one wants.
 //
-// By default this is a STREAM: Configure seeds the inner iterations once, and
-// each outer step advances them from wherever the last run left their RNGs. Two
-// runs with identical inputs therefore give different answers, which is the
-// right behaviour for advancing a nested simulation alongside an outer one.
-//
-// SetReseedBase switches it to a re-entrant run instead: the inner iterations are
-// reseeded from that base mixed with the outer step number before every run, so
-// a run becomes a pure function of its inputs and repeats if driven again at the
-// same step. Use it when the nested simulation is being *evaluated* rather than
-// *advanced* — a model re-run over a window, a proposal scored more than once —
-// and reproducibility matters more than a continuing noise stream. See
-// simulator.ReentrantSimulation for the same capability as a standalone value.
+// SetReseedBase makes a run a pure function of its inputs instead, for when the
+// nested simulation is being evaluated rather than advanced — a model re-run over
+// a window, a proposal scored more than once. simulator.ReentrantSimulation is
+// the same capability as a standalone value.
 type EmbeddedSimulationRunIteration struct {
 	settings              *simulator.Settings
 	implementations       *simulator.Implementations
@@ -78,11 +73,10 @@ type EmbeddedSimulationRunIteration struct {
 }
 
 // SetReseedBase makes every run reseed its inner iterations from base mixed with
-// the outer step number, turning the embedded run from a stream into a pure
-// function of its inputs (see the type docs).
+// the outer step number, so a run becomes a pure function of its inputs.
 //
-// Off by default: enabling it changes the numbers an existing configuration
-// produces, because the inner noise stream is restarted rather than continued.
+// Off by default: enabling it changes the numbers a configuration produces,
+// because the inner noise stream is restarted rather than continued.
 func (e *EmbeddedSimulationRunIteration) SetReseedBase(base uint64) {
 	e.reseedBase = &base
 }

--- a/pkg/general/embedded_simulation_run.go
+++ b/pkg/general/embedded_simulation_run.go
@@ -73,6 +73,7 @@ type EmbeddedSimulationRunIteration struct {
 	timestepFunction      *FromHistoryTimestepFunction
 	burnInSteps           int
 	reseedBase            *uint64
+	simulation            *simulator.ReentrantSimulation
 }
 
 // SetReseedBase makes every run reseed its inner iterations from base mixed with
@@ -252,22 +253,9 @@ func (e *EmbeddedSimulationRunIteration) Iterate(
 		e.settings.InitTimeValue = t[0]
 	}
 
-	// restart the inner noise stream when this is a re-entrant run, so the run
-	// depends only on its inputs and the outer step it happens at
-	if e.reseedBase != nil {
-		simulator.ReseedIterations(
-			e.settings,
-			e.implementations,
-			simulator.DeriveSeed(*e.reseedBase, timestepsHistory.CurrentStepNumber),
-		)
-	}
-
-	// instantiate the embedded simulation
-	coordinator := simulator.NewPartitionCoordinator(
-		e.settings,
-		e.implementations,
-	)
-	// update any configured state histories to run the simulation from
+	// roll each configured window forward by one and drop in the outer
+	// partition's latest row, so the inner simulation starts from that history
+	histories := make(map[int]*simulator.StateHistory, len(e.initStatesFromHistory))
 	for inIndex, out := range e.initStatesFromHistory {
 		for i := out.History.StateHistoryDepth - 1; i > 0; i-- {
 			out.History.Values.SetRow(i, out.History.Values.RawRowView(i-1))
@@ -278,19 +266,32 @@ func (e *EmbeddedSimulationRunIteration) Iterate(
 					out.History.StateHistoryDepth,
 			),
 		)
-		coordinator.Shared.StateHistories[inIndex] = out.History
+		histories[inIndex] = out.History
 	}
-	// run the embedded simulation to termination
-	coordinator.Run()
+
+	// Reseeding, when enabled, restarts the inner noise stream so the run
+	// depends only on its inputs and the outer step it happens at. It goes
+	// through Configure, so any injected state memory is re-applied afterwards
+	// — an iteration whose Configure resets fields would otherwise lose it.
+	run := simulator.ReentrantRun{
+		Histories: histories,
+		// Steps 0: an embedded run's length is its own termination condition's
+		// to decide, not the caller's.
+		Steps: 0,
+	}
+	if e.reseedBase != nil {
+		seed := simulator.DeriveSeed(*e.reseedBase, timestepsHistory.CurrentStepNumber)
+		run.Seed = &seed
+		run.AfterConfigure = func() {
+			e.updateStateMemoryAndTime(stateHistories, timestepsHistory)
+		}
+	}
 
 	// prepare the returned state slice as the concatenated
 	// final states of all partitions
 	concatFinalStates := make([]float64, 0)
-	for _, stateHistory := range coordinator.Shared.StateHistories {
-		concatFinalStates = append(
-			concatFinalStates,
-			stateHistory.Values.RawRowView(0)...,
-		)
+	for _, row := range e.simulation.Run(run) {
+		concatFinalStates = append(concatFinalStates, row...)
 	}
 	return concatFinalStates
 }
@@ -304,5 +305,10 @@ func NewEmbeddedSimulationRunIteration(
 	return &EmbeddedSimulationRunIteration{
 		settings:        settings,
 		implementations: implementations,
+		// The re-entrant tier does the running; this iteration's own job is
+		// plumbing outer context into the inner simulation's starting
+		// conditions. They share one settings pointer, so the assignments this
+		// iteration makes are what the next run sees.
+		simulation: simulator.NewReentrantSimulation(settings, implementations),
 	}
 }

--- a/pkg/general/embedded_simulation_run.go
+++ b/pkg/general/embedded_simulation_run.go
@@ -74,6 +74,7 @@ type EmbeddedSimulationRunIteration struct {
 	burnInSteps           int
 	reseedBase            *uint64
 	simulation            *simulator.ReentrantSimulation
+	concatBuffer          []float64
 }
 
 // SetReseedBase makes every run reseed its inner iterations from base mixed with
@@ -287,13 +288,11 @@ func (e *EmbeddedSimulationRunIteration) Iterate(
 		}
 	}
 
-	// prepare the returned state slice as the concatenated
-	// final states of all partitions
-	concatFinalStates := make([]float64, 0)
-	for _, row := range e.simulation.Run(run) {
-		concatFinalStates = append(concatFinalStates, row...)
-	}
-	return concatFinalStates
+	// the returned state is the concatenated final states of all partitions,
+	// built into a buffer this iteration keeps so a run costs no per-partition
+	// allocation
+	e.concatBuffer = e.simulation.RunInto(run, e.concatBuffer)
+	return e.concatBuffer
 }
 
 // NewEmbeddedSimulationRunIteration constructs an embedded run iteration

--- a/pkg/general/embedded_simulation_run.go
+++ b/pkg/general/embedded_simulation_run.go
@@ -48,6 +48,21 @@ type NamedIndexedState struct {
 //     a slice of the outer partition's previous state at each step. Enables
 //     warm-starting inner optimisers across outer steps.
 //   - Optional "burn_in_steps" skips initial outer steps before running inner sim.
+//
+// # Streaming vs re-entrant runs
+//
+// By default this is a STREAM: Configure seeds the inner iterations once, and
+// each outer step advances them from wherever the last run left their RNGs. Two
+// runs with identical inputs therefore give different answers, which is the
+// right behaviour for advancing a nested simulation alongside an outer one.
+//
+// SetReseedBase switches it to a re-entrant run instead: the inner iterations are
+// reseeded from that base mixed with the outer step number before every run, so
+// a run becomes a pure function of its inputs and repeats if driven again at the
+// same step. Use it when the nested simulation is being *evaluated* rather than
+// *advanced* — a model re-run over a window, a proposal scored more than once —
+// and reproducibility matters more than a continuing noise stream. See
+// simulator.ReentrantSimulation for the same capability as a standalone value.
 type EmbeddedSimulationRunIteration struct {
 	settings              *simulator.Settings
 	implementations       *simulator.Implementations
@@ -57,6 +72,17 @@ type EmbeddedSimulationRunIteration struct {
 	warmStartConfigs      map[int][2]int
 	timestepFunction      *FromHistoryTimestepFunction
 	burnInSteps           int
+	reseedBase            *uint64
+}
+
+// SetReseedBase makes every run reseed its inner iterations from base mixed with
+// the outer step number, turning the embedded run from a stream into a pure
+// function of its inputs (see the type docs).
+//
+// Off by default: enabling it changes the numbers an existing configuration
+// produces, because the inner noise stream is restarted rather than continued.
+func (e *EmbeddedSimulationRunIteration) SetReseedBase(base uint64) {
+	e.reseedBase = &base
 }
 
 func (e *EmbeddedSimulationRunIteration) Configure(
@@ -224,6 +250,16 @@ func (e *EmbeddedSimulationRunIteration) Iterate(
 	}
 	if t, ok := params.GetOk("init_time_value"); ok {
 		e.settings.InitTimeValue = t[0]
+	}
+
+	// restart the inner noise stream when this is a re-entrant run, so the run
+	// depends only on its inputs and the outer step it happens at
+	if e.reseedBase != nil {
+		simulator.ReseedIterations(
+			e.settings,
+			e.implementations,
+			simulator.DeriveSeed(*e.reseedBase, timestepsHistory.CurrentStepNumber),
+		)
 	}
 
 	// instantiate the embedded simulation

--- a/pkg/general/embedded_simulation_run_test.go
+++ b/pkg/general/embedded_simulation_run_test.go
@@ -1,6 +1,7 @@
 package general
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/umbralcalc/stochadex/pkg/continuous"
@@ -190,4 +191,58 @@ func TestEmbeddedSimulationRunReseeding(t *testing.T) {
 			t.Errorf("reseed base is not reaching the inner iterations: %v", otherResults[0])
 		}
 	})
+}
+
+// BenchmarkEmbeddedSimulationRun guards the allocation behaviour of an embedded
+// run. The concatenated output goes into a buffer the iteration keeps, so the
+// per-run cost should not grow a slice per inner partition — the regression that
+// routing through simulator.ReentrantSimulation would otherwise have introduced.
+func BenchmarkEmbeddedSimulationRun(b *testing.B) {
+	inner := simulator.NewConfigGenerator()
+	inner.SetSimulation(&simulator.SimulationConfig{
+		OutputCondition:      &simulator.NilOutputCondition{},
+		OutputFunction:       &simulator.NilOutputFunction{},
+		TerminationCondition: &simulator.NumberOfStepsTerminationCondition{MaxNumberOfSteps: 1},
+		TimestepFunction:     &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+		InitTimeValue:        0,
+	})
+	const innerPartitions = 8
+	for i := 0; i < innerPartitions; i++ {
+		inner.SetPartition(&simulator.PartitionConfig{
+			Name:              fmt.Sprintf("walk_%d", i),
+			Iteration:         &continuous.WienerProcessIteration{},
+			Params:            simulator.NewParams(map[string][]float64{"variances": {1, 1, 1, 1}}),
+			InitStateValues:   []float64{0, 0, 0, 0},
+			StateHistoryDepth: 1,
+			Seed:              uint64(i + 1),
+		})
+	}
+	embedded := NewEmbeddedSimulationRunIteration(inner.GenerateConfigs())
+
+	outer := simulator.NewConfigGenerator()
+	outer.SetSimulation(&simulator.SimulationConfig{
+		OutputCondition:      &simulator.NilOutputCondition{},
+		OutputFunction:       &simulator.NilOutputFunction{},
+		TerminationCondition: &simulator.NumberOfStepsTerminationCondition{MaxNumberOfSteps: 1},
+		TimestepFunction:     &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+		InitTimeValue:        0,
+	})
+	outer.SetPartition(&simulator.PartitionConfig{
+		Name:              "embedded",
+		Iteration:         embedded,
+		Params:            simulator.NewParams(map[string][]float64{"burn_in_steps": {0}}),
+		InitStateValues:   make([]float64, innerPartitions*4),
+		StateHistoryDepth: 1,
+		Seed:              0,
+	})
+	outerSettings, outerImpl := outer.GenerateConfigs()
+	coordinator := simulator.NewPartitionCoordinator(outerSettings, outerImpl)
+	params := &outerSettings.Iterations[0].Params
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		embedded.Iterate(params, 0, coordinator.Shared.StateHistories,
+			coordinator.Shared.TimestepsHistory)
+	}
 }

--- a/pkg/general/embedded_simulation_run_test.go
+++ b/pkg/general/embedded_simulation_run_test.go
@@ -3,6 +3,7 @@ package general
 import (
 	"testing"
 
+	"github.com/umbralcalc/stochadex/pkg/continuous"
 	"github.com/umbralcalc/stochadex/pkg/simulator"
 )
 
@@ -98,4 +99,95 @@ func TestEmbeddedSimulationRunIteration(t *testing.T) {
 			}
 		},
 	)
+}
+
+// TestEmbeddedSimulationRunReseeding covers the opt-in re-entrant mode. The
+// default is a stream, so identical inputs give different answers as the inner
+// RNG advances; with a reseed base set, the run becomes a function of its inputs
+// and repeats. Both halves are asserted, because the default must not change.
+func TestEmbeddedSimulationRunReseeding(t *testing.T) {
+	build := func() (*EmbeddedSimulationRunIteration, *simulator.Params, *simulator.PartitionCoordinator) {
+		inner := simulator.NewConfigGenerator()
+		inner.SetSimulation(&simulator.SimulationConfig{
+			OutputCondition:      &simulator.NilOutputCondition{},
+			OutputFunction:       &simulator.NilOutputFunction{},
+			TerminationCondition: &simulator.NumberOfStepsTerminationCondition{MaxNumberOfSteps: 1},
+			TimestepFunction:     &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+			InitTimeValue:        0,
+		})
+		inner.SetPartition(&simulator.PartitionConfig{
+			Name:              "walk",
+			Iteration:         &continuous.WienerProcessIteration{},
+			Params:            simulator.NewParams(map[string][]float64{"variances": {1.0}}),
+			InitStateValues:   []float64{0},
+			StateHistoryDepth: 1,
+			Seed:              7,
+		})
+		embedded := NewEmbeddedSimulationRunIteration(inner.GenerateConfigs())
+
+		outer := simulator.NewConfigGenerator()
+		outer.SetSimulation(&simulator.SimulationConfig{
+			OutputCondition:      &simulator.NilOutputCondition{},
+			OutputFunction:       &simulator.NilOutputFunction{},
+			TerminationCondition: &simulator.NumberOfStepsTerminationCondition{MaxNumberOfSteps: 1},
+			TimestepFunction:     &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+			InitTimeValue:        0,
+		})
+		outer.SetPartition(&simulator.PartitionConfig{
+			Name:      "embedded",
+			Iteration: embedded,
+			Params: simulator.NewParams(map[string][]float64{
+				"burn_in_steps": {0}, "walk/init_state_values": {0},
+			}),
+			InitStateValues:   []float64{0},
+			StateHistoryDepth: 1,
+			Seed:              0,
+		})
+		outerSettings, outerImpl := outer.GenerateConfigs()
+		coordinator := simulator.NewPartitionCoordinator(outerSettings, outerImpl)
+		return embedded, &outerSettings.Iterations[0].Params, coordinator
+	}
+
+	runFourTimes := func(
+		embedded *EmbeddedSimulationRunIteration,
+		params *simulator.Params,
+		coordinator *simulator.PartitionCoordinator,
+	) []float64 {
+		out := make([]float64, 0, 4)
+		for i := 0; i < 4; i++ {
+			row := embedded.Iterate(
+				params, 0, coordinator.Shared.StateHistories, coordinator.Shared.TimestepsHistory)
+			out = append(out, row[0])
+		}
+		return out
+	}
+
+	t.Run("the default stays a stream", func(t *testing.T) {
+		results := runFourTimes(build())
+		for _, value := range results[1:] {
+			if value != results[0] {
+				return // differing values are the expected stream behaviour
+			}
+		}
+		t.Fatalf("identical results %v; the default must keep advancing the inner "+
+			"RNG, or existing configs silently change", results)
+	})
+
+	t.Run("a reseed base makes runs reproducible", func(t *testing.T) {
+		embedded, params, coordinator := build()
+		embedded.SetReseedBase(99)
+		results := runFourTimes(embedded, params, coordinator)
+		for _, value := range results[1:] {
+			if value != results[0] {
+				t.Fatalf("reseeded runs must repeat for identical inputs, got %v", results)
+			}
+		}
+
+		// A different base must give a different answer, or the base is inert.
+		other, otherParams, otherCoordinator := build()
+		other.SetReseedBase(100)
+		if otherResults := runFourTimes(other, otherParams, otherCoordinator); otherResults[0] == results[0] {
+			t.Errorf("reseed base is not reaching the inner iterations: %v", otherResults[0])
+		}
+	})
 }

--- a/pkg/macros/doc.go
+++ b/pkg/macros/doc.go
@@ -35,7 +35,9 @@
 //     windowed likelihood, i.e. inference run as forward simulation.
 //   - optimisation.go  — evolution-strategy optimisation over a windowed reward.
 //   - smc.go           — sequential Monte Carlo inference, including the live
-//     RunSMCInference driver.
+//     RunSMCInference driver. smc_particles.go holds the evaluator that runs one
+//     model per particle over simulator.ReentrantSimulation, which is why the
+//     model is stated once rather than replicated per particle.
 //   - regression.go    — ScalarRegressionStatsIteration, the one true Iteration
 //     in this package, streaming OLS sufficient statistics alongside a run.
 //   - mcts.go          — MCTS self-play topology over a pkg/agents Environment.

--- a/pkg/macros/mcts.go
+++ b/pkg/macros/mcts.go
@@ -74,6 +74,11 @@ type MCTSSelfPlaySpec[S any, A any] struct {
 	Players int
 	// Seed is the base RNG seed for both inner partitions.
 	Seed uint64
+	// ChanceNodes searches an agents.MCTSChanceTree, averaging each action's
+	// value over sampled successors instead of committing to the first one drawn.
+	// Requires Env to implement agents.StochasticEnvironment. See the field on
+	// agents.MCTSTreeIteration for when it is worth the extra sampling.
+	ChanceNodes bool
 }
 
 // MCTSSearchSettings is the env-independent half of MCTSSelfPlaySpec: the
@@ -202,6 +207,7 @@ func NewMCTSSelfPlayPartitions[S any, A any](spec MCTSSelfPlaySpec[S, A]) []*sim
 			MaxLegalActions: spec.MaxLegalActions,
 			StateWidth:      spec.StateWidth,
 			Players:         spec.Players,
+			ChanceNodes:     spec.ChanceNodes,
 		},
 		// MCTSTree reads rollout's previous-step scores via state-history
 		// mode (params_as_partitions). This breaks the within-step

--- a/pkg/macros/smc.go
+++ b/pkg/macros/smc.go
@@ -4,36 +4,35 @@ import (
 	"math"
 
 	"github.com/umbralcalc/stochadex/pkg/analysis"
-	"github.com/umbralcalc/stochadex/pkg/general"
 	"github.com/umbralcalc/stochadex/pkg/inference"
 	"github.com/umbralcalc/stochadex/pkg/simulator"
 )
 
-// SMCInnerSimConfig describes the inner simulation that evaluates
-// N particles through data.
+// SMCInnerSimConfig describes the model ONE particle runs.
+//
+// The model is stated once and instantiated per particle (see
+// SMCParticleEvaluationIteration), rather than replicated into a single
+// simulation with names templated by particle index.
 type SMCInnerSimConfig struct {
-	// Partitions for the inner simulation (data, model, loglike, etc.).
+	// Partitions for one particle's model (data, model, loglike, etc.).
 	// They are registered in the order given.
 	Partitions []*simulator.PartitionConfig
-	// Simulation config for the inner simulation.
+	// Simulation config for one particle's run.
 	Simulation *simulator.SimulationConfig
-	// LoglikePartitions lists, for each particle p (length N), the name
-	// of the inner partition whose state[0] is the cumulative
-	// log-likelihood for that particle.
-	LoglikePartitions []string
-	// ParamForwarding maps "innerPartitionName/paramName" to indices
-	// into the N*d flat proposal state. These are forwarded from the
-	// proposal partition to inner partitions via the embedded sim.
-	// Partition and param names must be alphanumeric+underscore only.
+	// LoglikePartition names the partition whose state[0] is that particle's
+	// cumulative log-likelihood.
+	LoglikePartition string
+	// ParamForwarding maps "partitionName/paramName" to indices into the
+	// particle's own d-length parameter vector.
 	ParamForwarding map[string][]int
 }
 
-// SMCParticleModel describes a user-defined model for particle
-// evaluation inside the SMC inner simulation.
+// SMCParticleModel describes a user-defined model for particle evaluation.
 type SMCParticleModel struct {
-	// Build creates the inner simulation configuration for N particles
-	// with nParams parameters each.
-	Build func(N int, nParams int) *SMCInnerSimConfig
+	// Build creates one particle's model, with nParams parameters. It is called
+	// once per particle, so it must return a fresh, independent configuration
+	// each time — sharing iteration objects between particles would couple them.
+	Build func(nParams int) *SMCInnerSimConfig
 }
 
 // AppliedSMCInference configures batch SMC (Sequential Monte Carlo)
@@ -67,48 +66,16 @@ func NewSMCInferencePartitions(
 	}
 	priorTypes, priorParams := inference.EncodePriors(applied.Priors)
 
-	// Build inner simulation
-	innerConfig := applied.Model.Build(N, d)
+	// One model per particle, evaluated in parallel each round. The particle
+	// count is a property of this run rather than of the model's configuration.
+	evaluation := NewSMCParticleEvaluationIteration(
+		func() *SMCInnerSimConfig { return applied.Model.Build(d) }, N, d,
+	)
 
-	// Use ConfigGenerator to produce inner Settings/Implementations
-	generator := simulator.NewConfigGenerator()
-	generator.SetSimulation(innerConfig.Simulation)
-	for _, partition := range innerConfig.Partitions {
-		generator.SetPartition(partition)
-	}
-	innerSettings, innerImpl := generator.GenerateConfigs()
-
-	// Compute embedded state width as sum of inner partition init state widths
-	embeddedWidth := 0
-	for _, partition := range innerConfig.Partitions {
-		embeddedWidth += len(partition.InitStateValues)
-	}
-
-	// Compute loglike extraction indices from inner partition layout.
-	// The concatenated output is ordered by partition registration order.
-	partitionOffsets := make(map[string]int)
-	offset := 0
-	for _, partition := range innerConfig.Partitions {
-		partitionOffsets[partition.Name] = offset
-		offset += len(partition.InitStateValues)
-	}
-	loglikeIndices := make([]int, N)
-	for p, name := range innerConfig.LoglikePartitions {
-		loglikeIndices[p] = partitionOffsets[name] // state[0] of that partition
-	}
-
-	// Convert ParamForwarding to NamedUpstreamConfig pointing at proposal
-	embeddedParamsFromUpstream := make(map[string]simulator.NamedUpstreamConfig)
-	for key, indices := range innerConfig.ParamForwarding {
-		embeddedParamsFromUpstream[key] = simulator.NamedUpstreamConfig{
-			Upstream: applied.ProposalName,
-			Indices:  indices,
-		}
-	}
-
-	// Init states
+	// Init states. The evaluation partition's row is one log-likelihood per
+	// particle, so the posterior reads it whole.
 	proposalInit := make([]float64, N*d)
-	embeddedInit := make([]float64, embeddedWidth)
+	evaluationInit := make([]float64, N)
 	posteriorInit := make([]float64, posteriorWidth)
 	for j := range d {
 		posteriorInit[d+j*d+j] = 1.0 // identity covariance
@@ -136,21 +103,20 @@ func NewSMCInferencePartitions(
 		Seed:              applied.Seed,
 	})
 
-	// [1] Embedded simulation
-	embeddedParams := simulator.NewParams(map[string][]float64{
-		"init_time_value": {innerSettings.InitTimeValue},
-		"burn_in_steps":   {0},
-	})
+	// [1] Particle evaluation
 	partitions = append(partitions, &simulator.PartitionConfig{
-		Name: applied.SimName,
-		Iteration: general.NewEmbeddedSimulationRunIteration(
-			innerSettings, innerImpl,
-		),
-		Params:             embeddedParams,
-		ParamsFromUpstream: embeddedParamsFromUpstream,
-		InitStateValues:    embeddedInit,
-		StateHistoryDepth:  2,
-		Seed:               applied.Seed + 100,
+		Name:      applied.SimName,
+		Iteration: evaluation,
+		Params: simulator.NewParams(map[string][]float64{
+			"particle_params": make([]float64, N*d),
+		}),
+		ParamsFromUpstream: map[string]simulator.NamedUpstreamConfig{
+			"particle_params": {Upstream: applied.ProposalName},
+		},
+		InitStateValues:   evaluationInit,
+		StateHistoryDepth: 2,
+		// The base every particle's per-round seed is derived from.
+		Seed: applied.Seed + 100,
 	})
 
 	// [2] Posterior
@@ -167,10 +133,9 @@ func NewSMCInferencePartitions(
 			"particle_params":   make([]float64, N*d),
 		}),
 		ParamsFromUpstream: map[string]simulator.NamedUpstreamConfig{
-			"particle_loglikes": {
-				Upstream: applied.SimName,
-				Indices:  loglikeIndices,
-			},
+			// The evaluation partition's row is exactly one log-likelihood per
+			// particle, so it is read whole.
+			"particle_loglikes": {Upstream: applied.SimName},
 			"particle_params": {
 				Upstream: applied.ProposalName,
 			},
@@ -217,20 +182,12 @@ func RunSMCInference(
 		copy(particleParams[p], finalProposal[p*d:(p+1)*d])
 	}
 
-	// Final round log-likelihoods — compute loglike indices from inner sim
-	innerConfig := applied.Model.Build(N, d)
-	partitionOffsets := make(map[string]int)
-	offset := 0
-	for _, partition := range innerConfig.Partitions {
-		partitionOffsets[partition.Name] = offset
-		offset += len(partition.InitStateValues)
-	}
-
+	// Final round log-likelihoods. The evaluation partition's row is one per
+	// particle, so no layout arithmetic over the inner model is needed.
 	finalSim := simVals[len(simVals)-1]
 	logLiks := make([]float64, N)
-	for p, name := range innerConfig.LoglikePartitions {
-		idx := partitionOffsets[name]
-		ll := finalSim[idx]
+	for p := range N {
+		ll := finalSim[p]
 		if math.IsNaN(ll) {
 			ll = math.Inf(-1)
 		}

--- a/pkg/macros/smc_particles.go
+++ b/pkg/macros/smc_particles.go
@@ -1,0 +1,187 @@
+package macros
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/umbralcalc/stochadex/pkg/simulator"
+)
+
+// SMCParticleEvaluationIteration scores every particle by running one model per
+// particle and reading its log-likelihood.
+//
+// # Why this is not one simulation with N copies of the model
+//
+// SMC used to express its particle structure by replicating the model N times
+// inside a single inner simulation, with names templated by particle index. That
+// works, but it makes the particle count a property of the *configuration*: the
+// partition set grows with N, every particle's wiring is generated, and the
+// per-particle random seeds have to be varied by whoever writes the template —
+// which is exactly what was silently not happening, leaving every particle on
+// one noise realisation.
+//
+// Evaluating a model repeatedly is what simulator.ReentrantSimulation is for, so
+// the model is now stated once and evaluated N times. The particle count becomes
+// a property of the run instead of the config, per-particle seeds are derived
+// here rather than being the config author's problem, and the particles
+// synchronise once per round rather than at every inner step.
+//
+// # Row layout
+//
+//	row[p] = the log-likelihood particle p accumulated over the model run.
+//
+// Params:
+//   - particle_params: the flat N*d proposal vector, normally wired from the
+//     proposal partition via params_from_upstream.
+type SMCParticleEvaluationIteration struct {
+	// Simulations holds one independent model per particle. They are separate
+	// values because they are evaluated concurrently and a ReentrantSimulation
+	// is not safe to share.
+	Simulations []*simulator.ReentrantSimulation
+	// Forwarding says how a particle's parameter vector reaches its model.
+	Forwarding []SMCParamForwarding
+	// LoglikeIndex is the partition whose row[0] carries the log-likelihood.
+	LoglikeIndex int
+	// NumParams is each particle's parameter count.
+	NumParams int
+
+	seed uint64
+	out  []float64
+}
+
+// SMCParamForwarding routes part of a particle's parameter vector into one of
+// its model's params.
+type SMCParamForwarding struct {
+	// Partition and Param name the destination.
+	Partition int
+	Param     string
+	// Indices selects which of the particle's d parameters to send, in order.
+	Indices []int
+}
+
+// Configure implements simulator.Iteration.
+func (s *SMCParticleEvaluationIteration) Configure(
+	partitionIndex int,
+	settings *simulator.Settings,
+) {
+	if len(s.Simulations) == 0 {
+		panic("macros.SMCParticleEvaluationIteration: no particle simulations")
+	}
+	if s.NumParams <= 0 {
+		panic("macros.SMCParticleEvaluationIteration: NumParams must be > 0")
+	}
+	s.seed = settings.Iterations[partitionIndex].Seed
+	s.out = make([]float64, len(s.Simulations))
+}
+
+// Iterate implements simulator.Iteration: one round of particle evaluation.
+func (s *SMCParticleEvaluationIteration) Iterate(
+	params *simulator.Params,
+	partitionIndex int,
+	stateHistories []*simulator.StateHistory,
+	timestepsHistory *simulator.CumulativeTimestepsHistory,
+) []float64 {
+	particleParams := params.Get("particle_params")
+	round := uint64(timestepsHistory.CurrentStepNumber)
+
+	var group sync.WaitGroup
+	for particle := range s.Simulations {
+		group.Add(1)
+		go func(particle int) {
+			defer group.Done()
+			simulation := s.Simulations[particle]
+			offset := particle * s.NumParams
+			for _, forward := range s.Forwarding {
+				values := make([]float64, len(forward.Indices))
+				for i, index := range forward.Indices {
+					if slot := offset + index; slot < len(particleParams) {
+						values[i] = particleParams[slot]
+					}
+				}
+				simulation.SetParam(forward.Partition, forward.Param, values)
+			}
+			// Vary the seed by both round and particle: sharing either would
+			// put particles on one noise realisation, or repeat the same one
+			// every round.
+			seed := simulator.DeriveSeed(
+				simulator.DeriveSeed(s.seed, int(round)), particle)
+			rows := simulation.Run(simulator.ReentrantRun{Seed: &seed})
+			s.out[particle] = rows[s.LoglikeIndex][0]
+		}(particle)
+	}
+	group.Wait()
+	return s.out
+}
+
+// NewSMCParticleEvaluationIteration builds the per-particle evaluator from a
+// single-particle model, instantiating it once per particle.
+func NewSMCParticleEvaluationIteration(
+	build func() *SMCInnerSimConfig,
+	numParticles int,
+	numParams int,
+) *SMCParticleEvaluationIteration {
+	simulations := make([]*simulator.ReentrantSimulation, numParticles)
+	var forwarding []SMCParamForwarding
+	loglikeIndex := -1
+
+	for particle := 0; particle < numParticles; particle++ {
+		config := build()
+		generator := simulator.NewConfigGenerator()
+		generator.SetSimulation(config.Simulation)
+		for _, partition := range config.Partitions {
+			generator.SetPartition(partition)
+		}
+		settings, implementations := generator.GenerateConfigs()
+		simulations[particle] = simulator.NewReentrantSimulation(settings, implementations)
+
+		if particle > 0 {
+			continue
+		}
+		// The model has the same shape for every particle, so resolve names to
+		// indices once against the first instance.
+		index, ok := simulations[0].PartitionIndex(config.LoglikePartition)
+		if !ok {
+			panic(fmt.Sprintf(
+				"macros: SMC loglike partition %q is not in the particle model",
+				config.LoglikePartition))
+		}
+		loglikeIndex = index
+		forwarding = make([]SMCParamForwarding, 0, len(config.ParamForwarding))
+		for target, indices := range config.ParamForwarding {
+			partitionName, paramName, ok := splitForwardingTarget(target)
+			if !ok {
+				panic(fmt.Sprintf(
+					"macros: SMC param forwarding key %q must be "+
+						"\"partition_name/param_name\"", target))
+			}
+			partitionIndex, ok := simulations[0].PartitionIndex(partitionName)
+			if !ok {
+				panic(fmt.Sprintf(
+					"macros: SMC param forwarding names partition %q, which is not "+
+						"in the particle model", partitionName))
+			}
+			forwarding = append(forwarding, SMCParamForwarding{
+				Partition: partitionIndex,
+				Param:     paramName,
+				Indices:   indices,
+			})
+		}
+	}
+
+	return &SMCParticleEvaluationIteration{
+		Simulations:  simulations,
+		Forwarding:   forwarding,
+		LoglikeIndex: loglikeIndex,
+		NumParams:    numParams,
+	}
+}
+
+// splitForwardingTarget splits "partition_name/param_name" at the last slash.
+func splitForwardingTarget(target string) (partition, param string, ok bool) {
+	for i := len(target) - 1; i >= 0; i-- {
+		if target[i] == '/' {
+			return target[:i], target[i+1:], i > 0 && i < len(target)-1
+		}
+	}
+	return "", "", false
+}

--- a/pkg/macros/smc_particles.go
+++ b/pkg/macros/smc_particles.go
@@ -10,21 +10,11 @@ import (
 // SMCParticleEvaluationIteration scores every particle by running one model per
 // particle and reading its log-likelihood.
 //
-// # Why this is not one simulation with N copies of the model
-//
-// SMC used to express its particle structure by replicating the model N times
-// inside a single inner simulation, with names templated by particle index. That
-// works, but it makes the particle count a property of the *configuration*: the
-// partition set grows with N, every particle's wiring is generated, and the
-// per-particle random seeds have to be varied by whoever writes the template —
-// which is exactly what was silently not happening, leaving every particle on
-// one noise realisation.
-//
-// Evaluating a model repeatedly is what simulator.ReentrantSimulation is for, so
-// the model is now stated once and evaluated N times. The particle count becomes
-// a property of the run instead of the config, per-particle seeds are derived
-// here rather than being the config author's problem, and the particles
-// synchronise once per round rather than at every inner step.
+// The model is stated once and instantiated per particle, so the particle count
+// is a property of the run rather than of the configuration. Seeds are derived
+// here, per particle and per round, so no config can leave two particles sharing
+// a random stream. Particles are evaluated concurrently and synchronise once per
+// round.
 //
 // # Row layout
 //

--- a/pkg/macros/smc_test.go
+++ b/pkg/macros/smc_test.go
@@ -140,3 +140,125 @@ func TestRunSMCInference(t *testing.T) {
 		},
 	)
 }
+
+// TestSMCParticleEvaluationRejectsBadModel covers the two ways a particle model
+// can name something that is not there. Both would otherwise surface as a
+// silently unscored or unparameterised particle, which looks like a converging
+// run producing meaningless numbers.
+func TestSMCParticleEvaluationRejectsBadModel(t *testing.T) {
+	build := func(loglike string, forwarding map[string][]int) func() *SMCInnerSimConfig {
+		return func() *SMCInnerSimConfig {
+			return &SMCInnerSimConfig{
+				Partitions: []*simulator.PartitionConfig{{
+					Name:      "pred",
+					Iteration: &general.ParamValuesIteration{},
+					Params: simulator.NewParams(map[string][]float64{
+						"param_values": {0.0},
+					}),
+					InitStateValues:   []float64{0.0},
+					StateHistoryDepth: 1,
+					Seed:              0,
+				}},
+				Simulation: &simulator.SimulationConfig{
+					OutputCondition:      &simulator.NilOutputCondition{},
+					OutputFunction:       &simulator.NilOutputFunction{},
+					TerminationCondition: &simulator.NumberOfStepsTerminationCondition{MaxNumberOfSteps: 1},
+					TimestepFunction:     &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+					InitTimeValue:        0,
+				},
+				LoglikePartition: loglike,
+				ParamForwarding:  forwarding,
+			}
+		}
+	}
+
+	for _, testCase := range []struct {
+		name       string
+		loglike    string
+		forwarding map[string][]int
+	}{
+		{
+			name:       "unknown loglike partition",
+			loglike:    "absent",
+			forwarding: map[string][]int{"pred/param_values": {0}},
+		},
+		{
+			name:       "forwarding names an unknown partition",
+			loglike:    "pred",
+			forwarding: map[string][]int{"absent/param_values": {0}},
+		},
+		{
+			name:       "forwarding key is not partition/param",
+			loglike:    "pred",
+			forwarding: map[string][]int{"param_values": {0}},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Errorf("expected a panic for %s", testCase.name)
+				}
+			}()
+			NewSMCParticleEvaluationIteration(
+				build(testCase.loglike, testCase.forwarding), 2, 1)
+		})
+	}
+}
+
+// TestSMCParticleEvaluationIndependence checks each particle gets its own model
+// instance. Sharing one would couple the particles, since parameter forwarding
+// writes into params at evaluation time.
+func TestSMCParticleEvaluationIndependence(t *testing.T) {
+	build := func() *SMCInnerSimConfig {
+		return &SMCInnerSimConfig{
+			Partitions: []*simulator.PartitionConfig{{
+				Name:      "pred",
+				Iteration: &general.ParamValuesIteration{},
+				Params: simulator.NewParams(map[string][]float64{
+					"param_values": {0.0},
+				}),
+				InitStateValues:   []float64{0.0},
+				StateHistoryDepth: 1,
+				Seed:              0,
+			}},
+			Simulation: &simulator.SimulationConfig{
+				OutputCondition:      &simulator.NilOutputCondition{},
+				OutputFunction:       &simulator.NilOutputFunction{},
+				TerminationCondition: &simulator.NumberOfStepsTerminationCondition{MaxNumberOfSteps: 1},
+				TimestepFunction:     &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+				InitTimeValue:        0,
+			},
+			LoglikePartition: "pred",
+			ParamForwarding:  map[string][]int{"pred/param_values": {0}},
+		}
+	}
+	const particles = 3
+	evaluation := NewSMCParticleEvaluationIteration(build, particles, 1)
+	if len(evaluation.Simulations) != particles {
+		t.Fatalf("expected one simulation per particle, got %d", len(evaluation.Simulations))
+	}
+	for i := 0; i < particles; i++ {
+		for j := i + 1; j < particles; j++ {
+			if evaluation.Simulations[i] == evaluation.Simulations[j] {
+				t.Fatalf("particles %d and %d share a model instance", i, j)
+			}
+		}
+	}
+
+	// Each particle's own parameter reaches its own model: the partition echoes
+	// param_values, so the row it reports is the parameter it was given.
+	evaluation.Configure(0, &simulator.Settings{
+		Iterations: []simulator.IterationSettings{{Name: "eval", Seed: 3}},
+	})
+	params := simulator.NewParams(map[string][]float64{
+		"particle_params": {10, 20, 30},
+	})
+	out := evaluation.Iterate(&params, 0, nil,
+		&simulator.CumulativeTimestepsHistory{CurrentStepNumber: 1})
+	for particle, want := range []float64{10, 20, 30} {
+		if out[particle] != want {
+			t.Errorf("particle %d scored %v, want its own parameter %v",
+				particle, out[particle], want)
+		}
+	}
+}

--- a/pkg/macros/smc_test.go
+++ b/pkg/macros/smc_test.go
@@ -1,7 +1,6 @@
 package macros
 
 import (
-	"fmt"
 	"math"
 	"math/rand/v2"
 	"testing"
@@ -34,68 +33,51 @@ func TestRunSMCInference(t *testing.T) {
 			// Build SMC particle model: each particle proposes a mean value,
 			// and we compare against data using a normal likelihood with
 			// known variance.
+			// One particle's model, instantiated once per particle by the macro.
 			model := SMCParticleModel{
-				Build: func(N int, nParams int) *SMCInnerSimConfig {
-					partitions := make([]*simulator.PartitionConfig, 0)
-					loglikePartitions := make([]string, N)
-					paramForwarding := make(map[string][]int)
-
-					// Observed data partition
-					partitions = append(partitions, &simulator.PartitionConfig{
-						Name:      "observed_data",
-						Iteration: &general.FromStorageIteration{Data: data},
-						Params: simulator.NewParams(
-							make(map[string][]float64)),
-						InitStateValues:   data[0],
-						StateHistoryDepth: 2,
-						Seed:              0,
-					})
-
-					for p := range N {
-						predName := fmt.Sprintf("pred_%d", p)
-						llName := fmt.Sprintf("loglike_%d", p)
-
-						// Prediction partition: outputs the particle's mean param
-						partitions = append(partitions, &simulator.PartitionConfig{
-							Name:      predName,
-							Iteration: &general.ParamValuesIteration{},
-							Params: simulator.NewParams(map[string][]float64{
-								"param_values": {0.0},
-							}),
-							InitStateValues:   []float64{0.0},
-							StateHistoryDepth: 2,
-							Seed:              0,
-						})
-
-						// Log-likelihood partition
-						partitions = append(partitions, &simulator.PartitionConfig{
-							Name: llName,
-							Iteration: &inference.DataComparisonIteration{
-								Likelihood: &inference.NormalLikelihoodDistribution{},
-							},
-							Params: simulator.NewParams(map[string][]float64{
-								"mean":               {0.0},
-								"variance":           {trueVar},
-								"latest_data_values": data[0],
-								"cumulative":         {1},
-								"burn_in_steps":      {0},
-							}),
-							ParamsFromUpstream: map[string]simulator.NamedUpstreamConfig{
-								"mean":               {Upstream: predName},
-								"latest_data_values": {Upstream: "observed_data"},
-							},
-							InitStateValues:   []float64{0.0},
-							StateHistoryDepth: 2,
-							Seed:              0,
-						})
-
-						loglikePartitions[p] = llName
-						// Forward particle's mean param to pred partition
-						paramForwarding[predName+"/param_values"] = []int{p * nParams}
-					}
-
+				Build: func(nParams int) *SMCInnerSimConfig {
 					return &SMCInnerSimConfig{
-						Partitions: partitions,
+						Partitions: []*simulator.PartitionConfig{
+							{
+								Name:              "observed_data",
+								Iteration:         &general.FromStorageIteration{Data: data},
+								Params:            simulator.NewParams(make(map[string][]float64)),
+								InitStateValues:   data[0],
+								StateHistoryDepth: 2,
+								Seed:              0,
+							},
+							{
+								// Outputs this particle's proposed mean.
+								Name:      "pred",
+								Iteration: &general.ParamValuesIteration{},
+								Params: simulator.NewParams(map[string][]float64{
+									"param_values": {0.0},
+								}),
+								InitStateValues:   []float64{0.0},
+								StateHistoryDepth: 2,
+								Seed:              0,
+							},
+							{
+								Name: "loglike",
+								Iteration: &inference.DataComparisonIteration{
+									Likelihood: &inference.NormalLikelihoodDistribution{},
+								},
+								Params: simulator.NewParams(map[string][]float64{
+									"mean":               {0.0},
+									"variance":           {trueVar},
+									"latest_data_values": data[0],
+									"cumulative":         {1},
+									"burn_in_steps":      {0},
+								}),
+								ParamsFromUpstream: map[string]simulator.NamedUpstreamConfig{
+									"mean":               {Upstream: "pred"},
+									"latest_data_values": {Upstream: "observed_data"},
+								},
+								InitStateValues:   []float64{0.0},
+								StateHistoryDepth: 2,
+								Seed:              0,
+							},
+						},
 						Simulation: &simulator.SimulationConfig{
 							OutputCondition: &simulator.NilOutputCondition{},
 							OutputFunction:  &simulator.NilOutputFunction{},
@@ -107,8 +89,9 @@ func TestRunSMCInference(t *testing.T) {
 							},
 							InitTimeValue: times[0],
 						},
-						LoglikePartitions: loglikePartitions,
-						ParamForwarding:   paramForwarding,
+						LoglikePartition: "loglike",
+						// Index into this particle's own parameter vector.
+						ParamForwarding: map[string][]int{"pred/param_values": {0}},
 					}
 				},
 			}

--- a/pkg/simulator/reentrant.go
+++ b/pkg/simulator/reentrant.go
@@ -112,31 +112,81 @@ func (r *ReentrantSimulation) SetParam(partition int, key string, values []float
 	r.settings.Iterations[partition].Params.Set(key, values)
 }
 
-// Advance runs the sub-simulation for the given number of steps from the given
-// rows and returns the resulting rows, one per partition in partition order.
+// Settings exposes the underlying settings, for callers that need to reach
+// starting conditions this type does not model — params keyed by name, or an
+// iteration's own configuration. Mutating it changes what the next run does.
+func (r *ReentrantSimulation) Settings() *Settings { return r.settings }
+
+// Implementations exposes the underlying implementations, for callers that must
+// reach the iteration objects themselves (injecting outer context, for example).
+func (r *ReentrantSimulation) Implementations() *Implementations {
+	return r.implementations
+}
+
+// ReentrantRun describes one evaluation of a sub-simulation: where it starts,
+// how its randomness is fixed, and how long it goes on for.
+type ReentrantRun struct {
+	// Rows sets each partition's initial row, in partition order. A nil entry,
+	// or a short slice, leaves that partition's configured values alone.
+	Rows [][]float64
+	// Histories seeds whole state-history windows for the named partition
+	// indices, for models that read further back than one step. It takes
+	// precedence over Rows for those partitions.
+	Histories map[int]*StateHistory
+	// InitTimeValue overrides the sub-simulation's start time when non-nil.
+	InitTimeValue *float64
+	// Seed, when non-nil, reseeds every iteration before the run so the result
+	// depends only on this run's inputs. Nil leaves the iterations' random
+	// streams where the last run left them — the streaming behaviour that
+	// general.EmbeddedSimulationRunIteration has by default.
+	Seed *uint64
+	// Steps is how many steps to run. Zero defers to the sub-simulation's own
+	// termination condition instead.
+	Steps int
+	// AfterConfigure runs once the iterations have been (re)configured and
+	// before the run starts. Reseeding calls Configure, which the framework
+	// requires to re-initialise all mutable state — so anything injected into an
+	// iteration from outside (see general.StateMemoryIteration) has to be
+	// re-applied here, or a reseeded run would lose it.
+	AfterConfigure func()
+}
+
+// Run evaluates the sub-simulation and returns the resulting rows, one per
+// partition in partition order.
 //
-// Pure with respect to (rows, params, seed, steps): the iterations are reseeded
-// from seed before the run, so repeating a call repeats its result.
-//
-// steps is authoritative — the sub-simulation's own termination condition is not
-// consulted, because a re-entrant run's length is the caller's decision rather
-// than the configuration's. Rows are copied in and out, so the caller's slices
-// are never retained or mutated.
-func (r *ReentrantSimulation) Advance(rows [][]float64, seed uint64, steps int) [][]float64 {
+// With Seed set the run is pure with respect to its inputs: repeating a call
+// repeats its result, whatever ran in between. Rows are copied in and out, so
+// the caller's slices are never retained or mutated.
+func (r *ReentrantSimulation) Run(run ReentrantRun) [][]float64 {
 	for index := range r.settings.Iterations {
-		if index < len(rows) && rows[index] != nil {
+		if index < len(run.Rows) && run.Rows[index] != nil {
 			r.settings.Iterations[index].InitStateValues = append(
-				[]float64(nil), rows[index]...)
+				[]float64(nil), run.Rows[index]...)
 		}
 	}
-	ReseedIterations(r.settings, r.implementations, seed)
+	if run.InitTimeValue != nil {
+		r.settings.InitTimeValue = *run.InitTimeValue
+	}
+	if run.Seed != nil {
+		ReseedIterations(r.settings, r.implementations, *run.Seed)
+	}
+	if run.AfterConfigure != nil {
+		run.AfterConfigure()
+	}
 
 	coordinator := NewPartitionCoordinator(r.settings, r.implementations)
-	stepper := coordinator.NewStepper()
-	for i := 0; i < steps; i++ {
-		stepper.Step()
+	for index, history := range run.Histories {
+		coordinator.Shared.StateHistories[index] = history
 	}
-	stepper.Close()
+	if run.Steps > 0 {
+		stepper := coordinator.NewStepper()
+		for i := 0; i < run.Steps; i++ {
+			stepper.Step()
+		}
+		stepper.Close()
+	} else {
+		coordinator.Run()
+	}
 
 	out := make([][]float64, len(r.widths))
 	for index := range r.widths {
@@ -144,4 +194,11 @@ func (r *ReentrantSimulation) Advance(rows [][]float64, seed uint64, steps int) 
 			[]float64(nil), coordinator.Shared.StateHistories[index].Values.RawRowView(0)...)
 	}
 	return out
+}
+
+// Advance is the pure, fixed-length form of Run: evaluate the sub-simulation for
+// steps steps from rows, under seed. It is the shape a planner wants, where a
+// transition has to be a function of (state, action).
+func (r *ReentrantSimulation) Advance(rows [][]float64, seed uint64, steps int) [][]float64 {
+	return r.Run(ReentrantRun{Rows: rows, Seed: &seed, Steps: steps})
 }

--- a/pkg/simulator/reentrant.go
+++ b/pkg/simulator/reentrant.go
@@ -151,13 +151,10 @@ type ReentrantRun struct {
 	AfterConfigure func()
 }
 
-// Run evaluates the sub-simulation and returns the resulting rows, one per
-// partition in partition order.
-//
-// With Seed set the run is pure with respect to its inputs: repeating a call
-// repeats its result, whatever ran in between. Rows are copied in and out, so
-// the caller's slices are never retained or mutated.
-func (r *ReentrantSimulation) Run(run ReentrantRun) [][]float64 {
+// evaluate applies the run's starting conditions and drives the sub-simulation,
+// returning the coordinator so callers can read the final rows in whatever shape
+// they need.
+func (r *ReentrantSimulation) evaluate(run ReentrantRun) *PartitionCoordinator {
 	for index := range r.settings.Iterations {
 		if index < len(run.Rows) && run.Rows[index] != nil {
 			r.settings.Iterations[index].InitStateValues = append(
@@ -187,13 +184,40 @@ func (r *ReentrantSimulation) Run(run ReentrantRun) [][]float64 {
 	} else {
 		coordinator.Run()
 	}
+	return coordinator
+}
 
+// Run evaluates the sub-simulation and returns the resulting rows, one per
+// partition in partition order.
+//
+// With Seed set the run is pure with respect to its inputs: repeating a call
+// repeats its result, whatever ran in between. Rows are copied in and out, so
+// the caller's slices are never retained or mutated. Callers that only want the
+// rows concatenated should prefer RunInto, which reuses a buffer instead of
+// allocating one slice per partition.
+func (r *ReentrantSimulation) Run(run ReentrantRun) [][]float64 {
+	coordinator := r.evaluate(run)
 	out := make([][]float64, len(r.widths))
 	for index := range r.widths {
 		out[index] = append(
 			[]float64(nil), coordinator.Shared.StateHistories[index].Values.RawRowView(0)...)
 	}
 	return out
+}
+
+// RunInto is Run for callers that want every partition's final row concatenated
+// into one slice they own. dst is truncated and reused, so a caller holding one
+// buffer across runs pays no per-partition allocation — the shape an iteration
+// wants, since its own return value is a single row.
+//
+// The returned slice aliases dst. Treat it as valid only until the next call.
+func (r *ReentrantSimulation) RunInto(run ReentrantRun, dst []float64) []float64 {
+	coordinator := r.evaluate(run)
+	dst = dst[:0]
+	for index := range r.widths {
+		dst = append(dst, coordinator.Shared.StateHistories[index].Values.RawRowView(0)...)
+	}
+	return dst
 }
 
 // Advance is the pure, fixed-length form of Run: evaluate the sub-simulation for

--- a/pkg/simulator/reentrant.go
+++ b/pkg/simulator/reentrant.go
@@ -80,17 +80,6 @@ func (r *ReentrantSimulation) SetParam(partition int, key string, values []float
 	r.settings.Iterations[partition].Params.Set(key, values)
 }
 
-// Settings exposes the underlying settings, for callers that need to reach
-// starting conditions this type does not model — params keyed by name, or an
-// iteration's own configuration. Mutating it changes what the next run does.
-func (r *ReentrantSimulation) Settings() *Settings { return r.settings }
-
-// Implementations exposes the underlying implementations, for callers that must
-// reach the iteration objects themselves (injecting outer context, for example).
-func (r *ReentrantSimulation) Implementations() *Implementations {
-	return r.implementations
-}
-
 // ReentrantRun describes one evaluation of a sub-simulation: where it starts,
 // how its randomness is fixed, and how long it goes on for.
 type ReentrantRun struct {

--- a/pkg/simulator/reentrant.go
+++ b/pkg/simulator/reentrant.go
@@ -1,0 +1,147 @@
+package simulator
+
+// The re-entrant evaluation tier: running a simulation as a pure function of its
+// inputs, rather than as a stream that carries state forward.
+//
+// PartitionCoordinator advances a simulation. RunSeededEnsemble runs several.
+// RunWithHarnesses runs one under assertions. This file adds the fourth way to
+// drive a simulation: evaluate it from an arbitrary starting state, under a
+// chosen seed, and get the result back — with the guarantee that the same inputs
+// always produce the same output.
+//
+// # Why this is not already possible
+//
+// An iteration's mutable state, its RNG included, lives in the iteration object
+// and is established by Configure. Anything that builds a coordinator and steps
+// it therefore inherits whatever RNG state the iterations happen to be in, so
+// re-running a model "from the same place" silently continues the previous
+// stream instead of repeating it. general.EmbeddedSimulationRunIteration works
+// exactly this way: four calls with identical inputs give four different
+// answers, which is correct for advancing a nested simulation once per outer
+// step and wrong for anything that needs to evaluate the same model twice.
+//
+// # Why it works now
+//
+// The framework already requires that every iteration re-initialise all of its
+// mutable state in Configure — the rule RunWithHarnesses enforces by running a
+// simulation twice and comparing. That invariant is precisely what makes a pure
+// re-evaluation possible: re-Configuring from a derived seed restores the
+// iterations to a state that depends only on that seed. ReseedIterations is that
+// operation, and ReentrantSimulation wraps it up with the run itself.
+//
+// Callers that need this: planning over a model (an MCTS transition must be pure,
+// because the search materialises a successor once per edge and reuses it),
+// particle propagation, and any re-evaluation of a windowed model that should be
+// reproducible rather than dependent on how many times it has been called.
+
+// DeriveSeed mixes a base seed with a stream index, so the partitions of one
+// re-entrant run get distinct but jointly-determined seeds. Splitting this way
+// means two runs sharing a base seed reproduce each other exactly, while two
+// partitions within a run do not share a random stream.
+func DeriveSeed(base uint64, stream int) uint64 {
+	// Odd multiplier from the 64-bit golden ratio: cheap, and adequate for
+	// decorrelating per-partition streams that are already PCG-seeded.
+	return base ^ (uint64(stream+1) * 0x9e3779b97f4a7c15)
+}
+
+// ReseedIterations re-Configures every iteration with a seed derived from base,
+// restoring them to a state that depends only on base. After this call the next
+// run reproduces any earlier run made with the same base and starting state.
+//
+// This relies on the framework rule that Configure re-initialises all mutable
+// state. An iteration that stashes state outside Configure's reach breaks the
+// guarantee — which is the same defect RunWithHarnesses already fails on.
+func ReseedIterations(settings *Settings, implementations *Implementations, base uint64) {
+	for index := range settings.Iterations {
+		settings.Iterations[index].Seed = DeriveSeed(base, index)
+	}
+	for index, iteration := range implementations.Iterations {
+		iteration.Configure(index, settings)
+	}
+}
+
+// ReentrantSimulation evaluates a sub-simulation as a pure function of a
+// starting state, a seed, and a step count.
+//
+// It owns the settings and implementations it is given: Advance mutates their
+// initial values, params and seeds in place. Do not share one across goroutines,
+// and do not hand the same Implementations to a coordinator running concurrently.
+type ReentrantSimulation struct {
+	settings        *Settings
+	implementations *Implementations
+	widths          []int
+	nameToIndex     map[string]int
+}
+
+// NewReentrantSimulation wraps a configured sub-simulation for re-entrant use.
+//
+// The caller usually wants implementations.ExecutionStrategy set to
+// &InlineExecution{}: a re-entrant run is typically short and small, so the
+// per-step goroutine round-trip of the default strategy dominates its cost.
+func NewReentrantSimulation(
+	settings *Settings,
+	implementations *Implementations,
+) *ReentrantSimulation {
+	widths := make([]int, len(settings.Iterations))
+	nameToIndex := make(map[string]int, len(settings.Iterations))
+	for index, iteration := range settings.Iterations {
+		widths[index] = iteration.StateWidth
+		nameToIndex[iteration.Name] = index
+	}
+	return &ReentrantSimulation{
+		settings:        settings,
+		implementations: implementations,
+		widths:          widths,
+		nameToIndex:     nameToIndex,
+	}
+}
+
+// PartitionIndex returns the index of a named partition, and whether it exists.
+func (r *ReentrantSimulation) PartitionIndex(name string) (int, bool) {
+	index, ok := r.nameToIndex[name]
+	return index, ok
+}
+
+// StateWidths returns each partition's state width, in partition order.
+func (r *ReentrantSimulation) StateWidths() []int { return r.widths }
+
+// SetParam sets a params key on a partition by index, which is how an input that
+// is not part of the state — a control, an action, a parameter draw — enters a
+// re-entrant run.
+func (r *ReentrantSimulation) SetParam(partition int, key string, values []float64) {
+	r.settings.Iterations[partition].Params.Set(key, values)
+}
+
+// Advance runs the sub-simulation for the given number of steps from the given
+// rows and returns the resulting rows, one per partition in partition order.
+//
+// Pure with respect to (rows, params, seed, steps): the iterations are reseeded
+// from seed before the run, so repeating a call repeats its result.
+//
+// steps is authoritative — the sub-simulation's own termination condition is not
+// consulted, because a re-entrant run's length is the caller's decision rather
+// than the configuration's. Rows are copied in and out, so the caller's slices
+// are never retained or mutated.
+func (r *ReentrantSimulation) Advance(rows [][]float64, seed uint64, steps int) [][]float64 {
+	for index := range r.settings.Iterations {
+		if index < len(rows) && rows[index] != nil {
+			r.settings.Iterations[index].InitStateValues = append(
+				[]float64(nil), rows[index]...)
+		}
+	}
+	ReseedIterations(r.settings, r.implementations, seed)
+
+	coordinator := NewPartitionCoordinator(r.settings, r.implementations)
+	stepper := coordinator.NewStepper()
+	for i := 0; i < steps; i++ {
+		stepper.Step()
+	}
+	stepper.Close()
+
+	out := make([][]float64, len(r.widths))
+	for index := range r.widths {
+		out[index] = append(
+			[]float64(nil), coordinator.Shared.StateHistories[index].Values.RawRowView(0)...)
+	}
+	return out
+}

--- a/pkg/simulator/reentrant.go
+++ b/pkg/simulator/reentrant.go
@@ -1,39 +1,5 @@
 package simulator
 
-// The re-entrant evaluation tier: running a simulation as a pure function of its
-// inputs, rather than as a stream that carries state forward.
-//
-// PartitionCoordinator advances a simulation. RunSeededEnsemble runs several.
-// RunWithHarnesses runs one under assertions. This file adds the fourth way to
-// drive a simulation: evaluate it from an arbitrary starting state, under a
-// chosen seed, and get the result back — with the guarantee that the same inputs
-// always produce the same output.
-//
-// # Why this is not already possible
-//
-// An iteration's mutable state, its RNG included, lives in the iteration object
-// and is established by Configure. Anything that builds a coordinator and steps
-// it therefore inherits whatever RNG state the iterations happen to be in, so
-// re-running a model "from the same place" silently continues the previous
-// stream instead of repeating it. general.EmbeddedSimulationRunIteration works
-// exactly this way: four calls with identical inputs give four different
-// answers, which is correct for advancing a nested simulation once per outer
-// step and wrong for anything that needs to evaluate the same model twice.
-//
-// # Why it works now
-//
-// The framework already requires that every iteration re-initialise all of its
-// mutable state in Configure — the rule RunWithHarnesses enforces by running a
-// simulation twice and comparing. That invariant is precisely what makes a pure
-// re-evaluation possible: re-Configuring from a derived seed restores the
-// iterations to a state that depends only on that seed. ReseedIterations is that
-// operation, and ReentrantSimulation wraps it up with the run itself.
-//
-// Callers that need this: planning over a model (an MCTS transition must be pure,
-// because the search materialises a successor once per edge and reuses it),
-// particle propagation, and any re-evaluation of a windowed model that should be
-// reproducible rather than dependent on how many times it has been called.
-
 // DeriveSeed mixes a base seed with a stream index, so the partitions of one
 // re-entrant run get distinct but jointly-determined seeds. Splitting this way
 // means two runs sharing a base seed reproduce each other exactly, while two

--- a/pkg/simulator/reentrant.go
+++ b/pkg/simulator/reentrant.go
@@ -1,5 +1,7 @@
 package simulator
 
+import "gonum.org/v1/gonum/mat"
+
 // DeriveSeed mixes a base seed with a stream index, so the partitions of one
 // re-entrant run get distinct but jointly-determined seeds. Splitting this way
 // means two runs sharing a base seed reproduce each other exactly, while two
@@ -169,6 +171,47 @@ func (r *ReentrantSimulation) Run(run ReentrantRun) [][]float64 {
 			[]float64(nil), coordinator.Shared.StateHistories[index].Values.RawRowView(0)...)
 	}
 	return out
+}
+
+// RunWindows is Run for callers that need each partition's whole state-history
+// window back rather than just its latest row — models whose iterations read
+// further back than one step, where the window IS part of the state.
+//
+// Each returned slice is one partition's window flattened row-major with the
+// latest row first, so it round-trips through NewStateHistoryFromWindow.
+func (r *ReentrantSimulation) RunWindows(run ReentrantRun) [][]float64 {
+	coordinator := r.evaluate(run)
+	out := make([][]float64, len(r.widths))
+	for index := range r.widths {
+		history := coordinator.Shared.StateHistories[index]
+		window := make([]float64, 0, history.StateHistoryDepth*history.StateWidth)
+		for row := 0; row < history.StateHistoryDepth; row++ {
+			window = append(window, history.Values.RawRowView(row)...)
+		}
+		out[index] = window
+	}
+	return out
+}
+
+// NewStateHistoryFromWindow builds a StateHistory from a flattened window,
+// row-major with the latest row first — the shape ReentrantSimulation.RunWindows
+// returns, so a caller can carry a model's whole window through its own state
+// encoding and hand it back to start the next run.
+func NewStateHistoryFromWindow(window []float64, width, depth int) *StateHistory {
+	values := mat.NewDense(depth, width, nil)
+	for row := 0; row < depth; row++ {
+		offset := row * width
+		if offset+width > len(window) {
+			break
+		}
+		values.SetRow(row, window[offset:offset+width])
+	}
+	return &StateHistory{
+		Values:            values,
+		NextValues:        make([]float64, width),
+		StateWidth:        width,
+		StateHistoryDepth: depth,
+	}
 }
 
 // RunInto is Run for callers that want every partition's final row concatenated

--- a/pkg/simulator/reentrant_test.go
+++ b/pkg/simulator/reentrant_test.go
@@ -139,3 +139,133 @@ func TestReentrantSimulationPartitionLookup(t *testing.T) {
 		t.Errorf("StateWidths = %v", widths)
 	}
 }
+
+// deepCounterIteration increments a counter, so its history window holds a
+// predictable descending sequence.
+type deepCounterIteration struct{}
+
+func (d *deepCounterIteration) Configure(int, *simulator.Settings) {}
+
+func (d *deepCounterIteration) Iterate(
+	params *simulator.Params,
+	partitionIndex int,
+	stateHistories []*simulator.StateHistory,
+	timestepsHistory *simulator.CumulativeTimestepsHistory,
+) []float64 {
+	return []float64{stateHistories[partitionIndex].Values.RawRowView(0)[0] + 1}
+}
+
+func newDeepSimulation(t *testing.T, depth int) *simulator.ReentrantSimulation {
+	t.Helper()
+	gen := simulator.NewConfigGenerator()
+	gen.SetSimulation(&simulator.SimulationConfig{
+		OutputCondition:      &simulator.NilOutputCondition{},
+		OutputFunction:       &simulator.NilOutputFunction{},
+		TerminationCondition: &simulator.NumberOfStepsTerminationCondition{MaxNumberOfSteps: 4},
+		TimestepFunction:     &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+		InitTimeValue:        0,
+	})
+	gen.SetPartition(&simulator.PartitionConfig{
+		Name:              "counter",
+		Iteration:         &deepCounterIteration{},
+		InitStateValues:   []float64{0},
+		StateHistoryDepth: depth,
+		Seed:              1,
+	})
+	settings, impl := gen.GenerateConfigs()
+	impl.ExecutionStrategy = &simulator.InlineExecution{}
+	return simulator.NewReentrantSimulation(settings, impl)
+}
+
+// TestReentrantSimulationWindowRoundTrip checks the pairing that lets a caller
+// carry a model's whole history through its own state encoding: RunWindows out,
+// NewStateHistoryFromWindow back in. Without it an iteration reading N steps back
+// restarts from the initial value on every run.
+func TestReentrantSimulationWindowRoundTrip(t *testing.T) {
+	const depth = 4
+	simulation := newDeepSimulation(t, depth)
+
+	// One step from a window holding [3 2 1 0] must shift to [4 3 2 1].
+	seed := uint64(11)
+	windows := simulation.RunWindows(simulator.ReentrantRun{
+		Histories: map[int]*simulator.StateHistory{
+			0: simulator.NewStateHistoryFromWindow([]float64{3, 2, 1, 0}, 1, depth),
+		},
+		Seed:  &seed,
+		Steps: 1,
+	})
+	if len(windows) != 1 || len(windows[0]) != depth {
+		t.Fatalf("expected one %d-long window, got %v", depth, windows)
+	}
+	for row, want := range []float64{4, 3, 2, 1} {
+		if windows[0][row] != want {
+			t.Fatalf("window %v: row %d is %v, want %v (the window is not shifting)",
+				windows[0], row, windows[0][row], want)
+		}
+	}
+
+	// Feeding the result straight back must keep advancing, which is what makes
+	// the round trip usable as a state encoding.
+	next := simulation.RunWindows(simulator.ReentrantRun{
+		Histories: map[int]*simulator.StateHistory{
+			0: simulator.NewStateHistoryFromWindow(windows[0], 1, depth),
+		},
+		Seed:  &seed,
+		Steps: 1,
+	})
+	if next[0][0] != 5 {
+		t.Fatalf("second run gave %v, want the sequence to continue at 5", next[0])
+	}
+}
+
+// TestNewStateHistoryFromWindowTolersShortInput checks a truncated window is
+// filled as far as it goes rather than panicking, so a caller cannot crash the
+// engine with a malformed encoding.
+func TestNewStateHistoryFromWindowToleratesShortInput(t *testing.T) {
+	history := simulator.NewStateHistoryFromWindow([]float64{7, 8}, 1, 4)
+	if history.StateHistoryDepth != 4 || history.StateWidth != 1 {
+		t.Fatalf("shape not preserved: depth %d width %d",
+			history.StateHistoryDepth, history.StateWidth)
+	}
+	if history.Values.At(0, 0) != 7 || history.Values.At(1, 0) != 8 {
+		t.Errorf("supplied rows not copied: %v %v",
+			history.Values.At(0, 0), history.Values.At(1, 0))
+	}
+	if history.Values.At(3, 0) != 0 {
+		t.Errorf("missing rows should stay zero, got %v", history.Values.At(3, 0))
+	}
+}
+
+// TestReentrantSimulationRunIntoReusesBuffer pins the allocation-free path: the
+// concatenation goes into the caller's slice, and its contents match Run's.
+func TestReentrantSimulationRunIntoReusesBuffer(t *testing.T) {
+	simulation := newTestReentrantSimulation(t)
+	buffer := make([]float64, 0, 8)
+	out := simulation.Advance([][]float64{{2}}, 5, 1)
+
+	got := simulation.RunInto(
+		simulator.ReentrantRun{Rows: [][]float64{{2}}, Seed: ptrUint64(5), Steps: 1}, buffer)
+	if len(got) != 1 || got[0] != out[0][0] {
+		t.Fatalf("RunInto gave %v, want the same as Run's %v", got, out)
+	}
+	if cap(got) != cap(buffer) {
+		t.Errorf("RunInto allocated a new slice (cap %d, gave it %d)", cap(got), cap(buffer))
+	}
+}
+
+// TestReentrantSimulationRunsToTerminationWithoutSteps covers Steps=0, where the
+// sub-simulation's own termination condition decides the length.
+func TestReentrantSimulationRunsToTerminationWithoutSteps(t *testing.T) {
+	simulation := newDeepSimulation(t, 1)
+	seed := uint64(3)
+	rows := simulation.Run(simulator.ReentrantRun{
+		Rows: [][]float64{{0}}, Seed: &seed, Steps: 0,
+	})
+	// The configured condition is four steps, so the counter must reach four.
+	if rows[0][0] != 4 {
+		t.Errorf("counter reached %v, want 4 from the configured termination condition",
+			rows[0][0])
+	}
+}
+
+func ptrUint64(v uint64) *uint64 { return &v }

--- a/pkg/simulator/reentrant_test.go
+++ b/pkg/simulator/reentrant_test.go
@@ -1,0 +1,141 @@
+package simulator_test
+
+import (
+	"math/rand/v2"
+	"testing"
+
+	"github.com/umbralcalc/stochadex/pkg/simulator"
+)
+
+// randomWalkIteration is a minimal stochastic iteration whose RNG is built in
+// Configure from the partition seed — the shape every framework iteration has,
+// and the reason re-evaluating a model needs reseeding to be reproducible.
+type randomWalkIteration struct{ rng *rand.Rand }
+
+func (w *randomWalkIteration) Configure(partitionIndex int, settings *simulator.Settings) {
+	w.rng = rand.New(rand.NewPCG(settings.Iterations[partitionIndex].Seed, 0xabcd))
+}
+
+func (w *randomWalkIteration) Iterate(
+	params *simulator.Params,
+	partitionIndex int,
+	stateHistories []*simulator.StateHistory,
+	timestepsHistory *simulator.CumulativeTimestepsHistory,
+) []float64 {
+	row := stateHistories[partitionIndex].Values.RawRowView(0)
+	return []float64{row[0] + w.rng.NormFloat64() + params.GetIndex("drift", 0)}
+}
+
+func newTestReentrantSimulation(t *testing.T) *simulator.ReentrantSimulation {
+	t.Helper()
+	gen := simulator.NewConfigGenerator()
+	gen.SetSimulation(&simulator.SimulationConfig{
+		OutputCondition:      &simulator.NilOutputCondition{},
+		OutputFunction:       &simulator.NilOutputFunction{},
+		TerminationCondition: &simulator.NumberOfStepsTerminationCondition{MaxNumberOfSteps: 1},
+		TimestepFunction:     &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+		InitTimeValue:        0,
+	})
+	gen.SetPartition(&simulator.PartitionConfig{
+		Name:              "walk",
+		Iteration:         &randomWalkIteration{},
+		Params:            simulator.NewParams(map[string][]float64{"drift": {0}}),
+		InitStateValues:   []float64{0},
+		StateHistoryDepth: 1,
+		Seed:              1,
+	})
+	settings, impl := gen.GenerateConfigs()
+	impl.ExecutionStrategy = &simulator.InlineExecution{}
+	return simulator.NewReentrantSimulation(settings, impl)
+}
+
+// TestReentrantSimulationIsPure is the property the type exists to provide, and
+// the one a plain coordinator cannot give: evaluating the same model from the
+// same state under the same seed must repeat, no matter what ran in between.
+func TestReentrantSimulationIsPure(t *testing.T) {
+	simulation := newTestReentrantSimulation(t)
+	from := [][]float64{{5.0}}
+
+	first := simulation.Advance(from, 42, 1)[0][0]
+	// Interleave other evaluations, which would advance a shared RNG stream.
+	simulation.Advance(from, 43, 1)
+	simulation.Advance([][]float64{{99.0}}, 42, 3)
+	again := simulation.Advance(from, 42, 1)[0][0]
+
+	if first != again {
+		t.Fatalf("not reproducible across interleaved runs: %v then %v", first, again)
+	}
+	if other := simulation.Advance(from, 43, 1)[0][0]; other == first {
+		t.Fatalf("different seeds gave the same result (%v); the seed is not reaching "+
+			"the iterations", other)
+	}
+}
+
+func TestReentrantSimulationDoesNotRetainOrMutateInput(t *testing.T) {
+	simulation := newTestReentrantSimulation(t)
+	from := [][]float64{{5.0}}
+
+	out := simulation.Advance(from, 7, 1)
+	if from[0][0] != 5.0 {
+		t.Fatalf("Advance mutated the rows it was given: %v", from)
+	}
+	// Mutating the returned rows must not affect a later identical call.
+	out[0][0] = 12345
+	if repeat := simulation.Advance(from, 7, 1)[0][0]; repeat == 12345 {
+		t.Fatal("Advance returned a slice aliased to its own internal state")
+	}
+}
+
+// TestReentrantSimulationStepsAreAuthoritative pins that the run length comes
+// from the caller, not the sub-simulation's own termination condition (which is
+// configured here for a single step).
+func TestReentrantSimulationStepsAreAuthoritative(t *testing.T) {
+	simulation := newTestReentrantSimulation(t)
+	one := simulation.Advance([][]float64{{0}}, 5, 1)[0][0]
+	many := simulation.Advance([][]float64{{0}}, 5, 20)[0][0]
+	if one == many {
+		t.Fatalf("1 step and 20 steps gave the same result (%v); steps is being ignored", one)
+	}
+	// With a positive drift the 20-step run must have travelled further.
+	simulation.SetParam(0, "drift", []float64{10})
+	drifted := simulation.Advance([][]float64{{0}}, 5, 20)[0][0]
+	if drifted < 100 {
+		t.Fatalf("20 steps of drift 10 should be far from the origin, got %v", drifted)
+	}
+}
+
+func TestReentrantSimulationSetParamReachesTheIteration(t *testing.T) {
+	simulation := newTestReentrantSimulation(t)
+	base := simulation.Advance([][]float64{{0}}, 3, 1)[0][0]
+	simulation.SetParam(0, "drift", []float64{100})
+	shifted := simulation.Advance([][]float64{{0}}, 3, 1)[0][0]
+	if shifted-base < 99 || shifted-base > 101 {
+		t.Fatalf("drift param did not reach the iteration: %v then %v", base, shifted)
+	}
+}
+
+func TestDeriveSeedSeparatesStreams(t *testing.T) {
+	if simulator.DeriveSeed(7, 0) == simulator.DeriveSeed(7, 1) {
+		t.Error("two partitions of the same run must not share a seed")
+	}
+	if simulator.DeriveSeed(7, 0) != simulator.DeriveSeed(7, 0) {
+		t.Error("DeriveSeed must be deterministic")
+	}
+	if simulator.DeriveSeed(7, 0) == simulator.DeriveSeed(8, 0) {
+		t.Error("different base seeds must give different partition seeds")
+	}
+}
+
+func TestReentrantSimulationPartitionLookup(t *testing.T) {
+	simulation := newTestReentrantSimulation(t)
+	index, ok := simulation.PartitionIndex("walk")
+	if !ok || index != 0 {
+		t.Fatalf("PartitionIndex(walk) = %d, %v", index, ok)
+	}
+	if _, ok := simulation.PartitionIndex("absent"); ok {
+		t.Error("PartitionIndex reported an unknown partition as present")
+	}
+	if widths := simulation.StateWidths(); len(widths) != 1 || widths[0] != 1 {
+		t.Errorf("StateWidths = %v", widths)
+	}
+}


### PR DESCRIPTION
Follow-on from #67. That PR let a config *name* an `agents.Environment` a downstream module wrote in Go. This one lets a config plan over **its own forward model**, with no rules authored anywhere — and, along the way, extracts the framework primitive that four different places had each been working around.

## The primitive: `simulator.ReentrantSimulation`

`PartitionCoordinator` advances a simulation, `RunSeededEnsemble` runs several, `RunWithHarnesses` runs one under assertions. This is the fourth way to drive one: **evaluate it from an arbitrary starting state, under a chosen seed, purely**.

That was not previously possible. An iteration's mutable state — RNG included — lives in the iteration object and is established by `Configure`, so anything that builds a coordinator inherits whatever RNG state the iterations are already in. `EmbeddedSimulationRunIteration` is a *stream* in exactly this sense; four calls with identical inputs give four different answers:

```
[-0.103, 1.827, -0.991, -0.723]
```

Correct for advancing a nested simulation once per outer step, wrong for anything needing to evaluate the same model twice. Four places had each worked around it separately: windowed likelihood, mean-function fit, evolution strategy, and SMC (which avoided it by replicating the model as N per-particle partitions).

**What makes it work is a rule the framework already had**: every iteration must re-initialise all mutable state in `Configure`, which `RunWithHarnesses` enforces by running a simulation twice and comparing. The invariant that makes iterations *testable* is the one that makes them *re-evaluable*. Nothing was exploiting it.

## Rewirings

- `EmbeddedSimulationRunIteration` no longer builds a coordinator; its job is now purely plumbing outer context into starting conditions. Opt-in reseeding via `SetReseedBase` (**off by default** — enabling it moves existing inference numbers).
- `ReentrantRun.AfterConfigure` closes a hazard the reseed option opened: reseeding goes through `Configure`, so anything injected via `UpdateMemory` would be wiped. It survives today only because `FromHistoryIteration.Configure` happens to be empty.
- **BREAKING — SMC states its model once instead of replicating it per particle.** Migration notes in the CHANGELOG. Particles synchronise once per round rather than at every inner step; the convergence test runs ~30% faster.

## Two real bugs found

**SMC gave every particle the same noise realisation.** Per-particle partitions inherited their template's seed verbatim, so with a stochastic model all N particles produced identical trajectories and identical log-likelihoods. Invisible with a deterministic model — which is why the tests missed it — and damaging for simulation-based inference, where the particle cloud is meant to carry the model's Monte Carlo variation. Posterior spread was understated because only the proposed parameters varied. Fixed directly, then made structural: seeds are now derived by the evaluation iteration, not by the config.

**MCTS dropped depth-capped and stalled selections.** Follow-on from the terminal-selection fix in #67; `SelectLeaf`'s four stop reasons are now explicit via `MCTSLeafOutcome`.

## Planning: `agents.SimulationEnvironment` and the `mcts_planning` macro

The dynamics are already partitions, so an action is a params injection, a transition is one step of the model, and the reward is **another partition** named by `reward_partition` — normally an `{type: expression}` one, which keeps rewards in the expressions DSL instead of introducing a second language.

It reuses the existing self-play topology rather than adding one: `SimulationEnvironment` implements `Environment[[]float64, int]`, so it drops into `NewMCTSSelfPlayPartitions` with an identity codec.

Validated on battery arbitrage over a cyclic price, where buying looks like a pure loss at the moment it must happen. The environment is deterministic, so the optimum is found exactly by brute force over all action sequences — and the config recovers it: **160 against 0 for doing nothing**, with no Go.

## Chance nodes

`MCTSTree` commits to one successor per action edge. Right for deterministic game rules, silently wrong for a stochastic model: it pins the noise, so the search can exploit the draw it is going to receive.

`MCTSChanceTree` interposes a chance node between an action and its outcomes, with progressive widening (`ceil(k·visits^α)`). Environments opt in via `StochasticEnvironment`; deterministic game environments deliberately do not.

Measured over six planning scenarios, each plan replayed across eight others — the over-promise from planning in one's own scenario:

| simulations | pinned noise | chance nodes |
|---|---|---|
| 100 | 44.8 | −6.4 |
| 200 | 79.3 | −5.6 |
| 400 | 91.5 | 21.4 |
| 1600 | 91.5 | −8.1 |

**Note the pinned column's direction: its bias grows with the search budget**, because more search means more exploitation of the single realisation it can see. Spending more simulations makes a pinned plan's number less trustworthy, not more.

Honest trade-off: chance-node plans earn slightly less at equal budget; what you buy is that they predict what they earn.

## Repo boundary

`CLAUDE.md`'s Invariant A note is updated, because this moves the line and it shouldn't be implicit. The two MCTS macros now sit on opposite sides deliberately: `mcts_self_play` searches decision **rules** (downstream, named through the registry); `mcts_planning` searches a **model** — search-as-forward-simulation, in scope by the same argument that admits `posterior_estimation`.

## Performance

Checked by A/B against the pre-refactor implementation, since the rewiring added a row-copy layer:

| 8 inner partitions | allocs/run | bytes/run |
|---|---|---|
| before refactor | 161 | 9769 B |
| after refactor | 170 | 10116 B |
| **now** (`RunInto` buffer) | **157** | **9237 B** |

Wall-clock within noise throughout. A permanent benchmark guards it.

## Not done

None of this has been run against a real calibrated model — the battery problem is a toy. A downstream trial is the next step, not more engineering here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)