### PR TITLE
Release v0.12.0: stamp changelog

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The stochadex simulation engine, packaged as an installable Claude Code plugin.",
-    "version": "0.11.0"
+    "version": "0.12.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stochadex",
   "description": "Author, run, and analyse a stochastic simulation as a single YAML config for the stochadex engine — no Go, no compilation, no toolchain. Bundles the stochadex-model skill with four validated, converging worked recipes.",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "author": {
     "name": "umbralcalc",
     "email": "umbralcalc@gmail.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ an exact version rather than assume stability across minors.
 
 ## [Unreleased]
 
+## [0.12.0] — 2026-07-26
+
 ### Changed
 
 - **BREAKING: SMC states its model once instead of replicating it per particle.** The particle
@@ -1107,7 +1109,8 @@ treat the intermediates as internal, never shipped API.
   stochastic-process formalism (diffusions, Poisson noise, windowed history for noise
   dependencies) before any Go engine existed. The pivot to Go begins Feb 2023.
 
-[Unreleased]: https://github.com/umbralcalc/stochadex/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/umbralcalc/stochadex/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/umbralcalc/stochadex/compare/v0.11.0...v0.12.0
 [0.7.0]: https://github.com/umbralcalc/stochadex/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/umbralcalc/stochadex/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/umbralcalc/stochadex/compare/v0.5.3...v0.6.0


### PR DESCRIPTION
Stamps the `[Unreleased]` section as **v0.12.0** and bumps the plugin manifests, which `TestPluginManifestsMatchRelease` requires to track the newest released entry.

A **minor** bump despite breaking changes, per the versioning policy: `v0.x` may break in a minor, and callers pin exact versions.

## What's in it

- `simulator.ReentrantSimulation` — evaluating a simulation as a pure function of a starting state and seed
- `agents.SimulationEnvironment` + the `mcts_planning` macro — planning over a forward model, entirely as config
- `agents.MCTSChanceTree` — chance nodes, so a stochastic plan's value averages over sampled successors
- **BREAKING:** SMC states its model once instead of replicating it per particle
- Fixes: SMC gave every particle the same noise realisation; MCTS dropped depth-capped and stalled selections

## Downstream verification

All twelve downstream repos were built and tested against this before merge. Three needed the SMC migration (anglersim, business-survival, energy-balancer); the other nine were unaffected. Dependency bumps follow as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)