### PR TITLE
Planning: progress proxy, posterior-predictive parameters, and a downstream environment

### DIFF
--- a/.claude/skills/stochadex-model/SKILL.md
+++ b/.claude/skills/stochadex-model/SKILL.md
@@ -242,7 +242,10 @@ Two decision-making macros also run live, and the distinction between them matte
   `progress_partition:`** — a partition whose state[0] scores the position in [0,1] (a win
   probability, a normalised margin). Rollouts that run out of steps are scored by it instead of
   discarded; without one the search falls back to reward banked so far, and on a long horizon
-  that is much weaker. Every model partition must have `state_history_depth: 1`,
+  that is much weaker. **To plan under parameter uncertainty rather than a point estimate**, add
+  `parameters:` with `samples_from: {partition_name: <recorded draws>}` (or inline `samples:`) plus
+  `targets:` routing each draw into the model — the search then averages over the posterior, which
+  changes the recommendation whenever the payoff is nonlinear in the uncertain parameter. Every model partition must have `state_history_depth: 1`,
   and the model must be Markov in its own rows: the planner restarts it each transition, so
   nothing may rely on the step counter — carry a phase/counter in the state instead.
   On stochastic models it uses **chance nodes** by default, averaging each action's value over

--- a/.claude/skills/stochadex-model/SKILL.md
+++ b/.claude/skills/stochadex-model/SKILL.md
@@ -244,7 +244,9 @@ Two decision-making macros also run live, and the distinction between them matte
   discarded; without one the search falls back to reward banked so far, and on a long horizon
   that is much weaker. **To plan under parameter uncertainty rather than a point estimate**, add
   `parameters:` with `samples_from: {partition_name: <recorded draws>}` (or inline `samples:`) plus
-  `targets:` routing each draw into the model — the search then averages over the posterior, which
+  `targets:` routing each draw into the model. `posterior_estimation`'s sampler partition already
+  emits posterior draws, so `samples_from: {partition_name: <sampler>, burn_in: <converged from>}`
+  chains inference straight into planning — the search then averages over the posterior, which
   changes the recommendation whenever the payoff is nonlinear in the uncertain parameter. Adding
   `belief: {observation_partition: <what is seen>, variance: <noise>}` under `parameters:` lets the
   planner *learn* within an episode, so it will pay for an informative action; it costs a model

--- a/.claude/skills/stochadex-model/SKILL.md
+++ b/.claude/skills/stochadex-model/SKILL.md
@@ -238,7 +238,11 @@ Two decision-making macros also run live, and the distinction between them matte
   the user wants "what should I do, given this simulation" — dispatch, dosing, intervention
   timing. See `cfg/example_planning_config.yaml`. It needs `horizon:` (lookahead), `steps:`
   (decisions to take) and `return_range: [min, max]` (UCB1 needs a bounded value scale — widen it
-  rather than letting returns clamp). Every model partition must have `state_history_depth: 1`,
+  rather than letting returns clamp). **When `horizon` exceeds `rollout_max_steps`, set
+  `progress_partition:`** — a partition whose state[0] scores the position in [0,1] (a win
+  probability, a normalised margin). Rollouts that run out of steps are scored by it instead of
+  discarded; without one the search falls back to reward banked so far, and on a long horizon
+  that is much weaker. Every model partition must have `state_history_depth: 1`,
   and the model must be Markov in its own rows: the planner restarts it each transition, so
   nothing may rely on the step counter — carry a phase/counter in the state instead.
   On stochastic models it uses **chance nodes** by default, averaging each action's value over

--- a/.claude/skills/stochadex-model/SKILL.md
+++ b/.claude/skills/stochadex-model/SKILL.md
@@ -250,7 +250,9 @@ Two decision-making macros also run live, and the distinction between them matte
   changes the recommendation whenever the payoff is nonlinear in the uncertain parameter. Adding
   `belief: {observation_partition: <what is seen>, variance: <noise>}` under `parameters:` lets the
   planner *learn* within an episode, so it will pay for an informative action; it costs a model
-  step per sample per transition, so keep the sample set to a handful. Every model partition must have `state_history_depth: 1`,
+  step per sample per transition, so keep the sample set to a handful. Use `weights:` /
+  `weights_from:` when the samples are not themselves posterior draws (SMC particles carry their
+  posterior in their weights) — that sets the starting belief and steers which samples get drawn. Every model partition must have `state_history_depth: 1`,
   and the model must be Markov in its own rows: the planner restarts it each transition, so
   nothing may rely on the step counter — carry a phase/counter in the state instead.
   On stochastic models it uses **chance nodes** by default, averaging each action's value over

--- a/.claude/skills/stochadex-model/SKILL.md
+++ b/.claude/skills/stochadex-model/SKILL.md
@@ -245,7 +245,10 @@ Two decision-making macros also run live, and the distinction between them matte
   that is much weaker. **To plan under parameter uncertainty rather than a point estimate**, add
   `parameters:` with `samples_from: {partition_name: <recorded draws>}` (or inline `samples:`) plus
   `targets:` routing each draw into the model — the search then averages over the posterior, which
-  changes the recommendation whenever the payoff is nonlinear in the uncertain parameter. Every model partition must have `state_history_depth: 1`,
+  changes the recommendation whenever the payoff is nonlinear in the uncertain parameter. Adding
+  `belief: {observation_partition: <what is seen>, variance: <noise>}` under `parameters:` lets the
+  planner *learn* within an episode, so it will pay for an informative action; it costs a model
+  step per sample per transition, so keep the sample set to a handful. Every model partition must have `state_history_depth: 1`,
   and the model must be Markov in its own rows: the planner restarts it each transition, so
   nothing may rely on the step counter — carry a phase/counter in the state instead.
   On stochastic models it uses **chance nodes** by default, averaging each action's value over

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,13 @@ an exact version rather than assume stability across minors.
   A config can therefore infer a parameter from data and then plan under it, uncertainty included,
   in one file with no Go.
 
+- **Sample weights**, via `parameters.weights` or `parameters.weights_from`. Samples that are not
+  themselves posterior draws carry their posterior in their weights — SMC particles being the
+  case — and a planner ignoring those plans against the proposal instead. The weights set the
+  planner's starting belief and steer which samples a trajectory draws, so an inference tier can
+  hand over what it concluded rather than having it flattened. Omit them when the samples were
+  drawn from the posterior directly, as posterior_estimation's sampler does.
+
 - **In-tree belief updating**, via `parameters.belief`. The planner carries a distribution over the
   parameter samples as part of its state and reweights it by how well each sample predicted what
   was observed, so it can value an action for what it *reveals* and not only for what it pays.
@@ -57,8 +64,12 @@ an exact version rather than assume stability across minors.
 
   It costs a model step per sample on every transition — measured at 2.6x for 2 samples, 8.0x for
   8 and 30.9x for 32 — so it suits a small sample set. Larger posteriors should plan on a fixed
-  draw. Belief updating is open-loop within the search: the planner reasons about what it would
-  learn, but there is no separate observation model beyond the named partition.
+  draw.
+
+  This is for valuing information — preferring an action for what it will reveal — which needs
+  reasoning about observations that have not happened. Tracking the posterior against observations
+  that HAVE happened is the inference tier's job, and a planner picks that up through
+  `parameters.weights` on the next replan.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ an exact version rather than assume stability across minors.
 
 ## [Unreleased]
 
+### Added
+
+- **`mcts_planning` scores truncated rollouts via a progress proxy.** A rollout capped below the
+  horizon used to contribute nothing, leaving the search exploring on visit counts alone — the
+  case that bites whenever `horizon` exceeds `rollout_max_steps`. It is now scored by
+  `agents.SimulationEnvironment.Progress`, which defaults to the reward banked so far and can be
+  overridden with `progress_partition:` naming a partition whose state[0] is a [0,1] position
+  score. On the battery problem at horizon 24 with rollouts capped at 3, the planned return goes
+  from 160 to 480.
+
 ## [0.12.0] — 2026-07-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ an exact version rather than assume stability across minors.
   demand=25, but a loss of 25 against the real spread — while planning over the posterior orders
   10, for a certain 40.
 
+- **Planning composes with `posterior_estimation`.** Its sampler partition already draws from the
+  running posterior, so `parameters.samples_from` reads those rows directly as the sample set —
+  no further sampling step. `burn_in:` drops the rows recorded while the estimate was still
+  moving, which otherwise enter the plan as uncertainty the inference has already ruled out.
+  A config can therefore infer a parameter from data and then plan under it, uncertainty included,
+  in one file with no Go.
+
 - **In-tree belief updating**, via `parameters.belief`. The planner carries a distribution over the
   parameter samples as part of its state and reweights it by how well each sample predicted what
   was observed, so it can value an action for what it *reveals* and not only for what it pays.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,12 +31,27 @@ an exact version rather than assume stability across minors.
 
   A draw is fixed for the length of a trajectory but varies across a chance node's outcomes, so
   the search averages over parameter uncertainty rather than resampling it per step (which would
-  model noise, not uncertainty). Belief updating within an episode is deliberately not attempted.
+  model noise, not uncertainty).
 
   Demonstrated on a newsvendor, where the two provably disagree: with demand 10 in five draws of
   six and 100 in the sixth, planning at the posterior mean of 25 orders 25 — the best response to
   demand=25, but a loss of 25 against the real spread — while planning over the posterior orders
   10, for a certain 40.
+
+- **In-tree belief updating**, via `parameters.belief`. The planner carries a distribution over the
+  parameter samples as part of its state and reweights it by how well each sample predicted what
+  was observed, so it can value an action for what it *reveals* and not only for what it pays.
+
+  Demonstrated on a probe-then-commit decision where an unknown parameter says which of two
+  commitments pays. Committing blind is worth zero and probing pays nothing, so a planner on a
+  fixed draw opens by committing; one that updates its belief opens by probing, then commits
+  correctly. Probing moves the belief to certainty while committing leaves it untouched, which is
+  what makes an uninformative action look uninformative.
+
+  It costs a model step per sample on every transition — measured at 2.6x for 2 samples, 8.0x for
+  8 and 30.9x for 32 — so it suits a small sample set. Larger posteriors should plan on a fixed
+  draw. Belief updating is open-loop within the search: the planner reasons about what it would
+  learn, but there is no separate observation model beyond the named partition.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,22 @@ an exact version rather than assume stability across minors.
 
 ### Added
 
+- **Posterior-predictive planning.** `mcts_planning` can plan over a posterior instead of a point
+  estimate: `parameters.samples` lists draws inline, or `parameters.samples_from` reads them from a
+  partition recorded in the `data:` tier — one row per draw — so a calibration's own output feeds
+  the planner. `parameters.targets` routes each draw into the model, the same shape SMC uses.
+
+  A draw is fixed for the length of a trajectory but varies across a chance node's outcomes, so
+  the search averages over parameter uncertainty rather than resampling it per step (which would
+  model noise, not uncertainty). Belief updating within an episode is deliberately not attempted.
+
+  Demonstrated on a newsvendor, where the two provably disagree: with demand 10 in five draws of
+  six and 100 in the sixth, planning at the posterior mean of 25 orders 25 — the best response to
+  demand=25, but a loss of 25 against the real spread — while planning over the posterior orders
+  10, for a certain 40.
+
+### Added
+
 - **`mcts_planning` scores truncated rollouts via a progress proxy.** A rollout capped below the
   horizon used to contribute nothing, leaving the search exploring on visit counts alone — the
   case that bites whenever `horizon` exceeds `rollout_max_steps`. It is now scored by

--- a/pkg/agents/planning_behaviour_test.go
+++ b/pkg/agents/planning_behaviour_test.go
@@ -1,0 +1,223 @@
+package agents_test
+
+// Expected-behaviour tests for planning: each subtest is a named response claim
+// about how the planner reacts to a lever a user actually sets, asserted in the
+// direction a user would expect. A wrong sign here is a wrong recommendation.
+//
+// The example problem is a sooner-versus-later choice, which is the smallest
+// setup that makes horizon and discount both matter:
+//
+//	take   — pays 5 now, and can be taken again next step
+//	invest — pays nothing now, then 20 two steps later
+//
+// Over four steps, taking every step earns 20 while investing first earns 25, so
+// the better plan is only visible to a planner that looks far enough ahead and
+// does not discount the future away.
+
+import (
+	"math"
+	"testing"
+
+	"github.com/umbralcalc/stochadex/pkg/agents"
+	"github.com/umbralcalc/stochadex/pkg/general"
+	"github.com/umbralcalc/stochadex/pkg/simulator"
+)
+
+const (
+	takeNow    = 0
+	investLate = 1
+)
+
+// delayedPayoffIteration is the sooner-versus-later payoff.
+//
+// Row: [payout, countdown]. A countdown in progress must finish before another
+// choice matters, which is what makes investing cost the steps it does.
+type delayedPayoffIteration struct{}
+
+func (d *delayedPayoffIteration) Configure(int, *simulator.Settings) {}
+
+func (d *delayedPayoffIteration) Iterate(
+	params *simulator.Params,
+	partitionIndex int,
+	stateHistories []*simulator.StateHistory,
+	timestepsHistory *simulator.CumulativeTimestepsHistory,
+) []float64 {
+	row := stateHistories[partitionIndex].Values.RawRowView(0)
+	countdown := row[1]
+	choice := params.GetIndex("choice", 0)
+
+	if countdown > 0 {
+		remaining := countdown - 1
+		if remaining == 0 {
+			return []float64{20, 0} // the investment matures
+		}
+		return []float64{0, remaining}
+	}
+	if choice == investLate {
+		return []float64{0, 2}
+	}
+	return []float64{5, 0}
+}
+
+// newDelayedPayoffEnvironment builds the choice over the given horizon and
+// discount.
+func newDelayedPayoffEnvironment(
+	t *testing.T,
+	horizon int,
+	discount float64,
+	returnRange [2]float64,
+) *agents.SimulationEnvironment {
+	t.Helper()
+	gen := simulator.NewConfigGenerator()
+	gen.SetSimulation(&simulator.SimulationConfig{
+		OutputCondition:      &simulator.NilOutputCondition{},
+		OutputFunction:       &simulator.NilOutputFunction{},
+		TerminationCondition: &simulator.NumberOfStepsTerminationCondition{MaxNumberOfSteps: 1},
+		TimestepFunction:     &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+		InitTimeValue:        0,
+	})
+	gen.SetPartition(&simulator.PartitionConfig{
+		Name:              "choice",
+		Iteration:         &general.ParamValuesIteration{},
+		Params:            simulator.NewParams(map[string][]float64{"param_values": {0}}),
+		InitStateValues:   []float64{0},
+		StateHistoryDepth: 1,
+		Seed:              0,
+	})
+	gen.SetPartition(&simulator.PartitionConfig{
+		Name:      "payout",
+		Iteration: &delayedPayoffIteration{},
+		Params:    simulator.NewParams(map[string][]float64{"choice": {0}}),
+		ParamsFromUpstream: map[string]simulator.NamedUpstreamConfig{
+			"choice": {Upstream: "choice"},
+		},
+		InitStateValues:   []float64{0, 0},
+		StateHistoryDepth: 1,
+		Seed:              0,
+	})
+	settings, impl := gen.GenerateConfigs()
+	impl.ExecutionStrategy = &simulator.InlineExecution{}
+
+	return agents.NewSimulationEnvironment(settings, impl, agents.SimulationEnvironmentSpec{
+		Actions:         [][]float64{{takeNow}, {investLate}},
+		ActionPartition: "choice",
+		ActionParam:     "param_values",
+		Horizon:         horizon,
+		Reward:          func(rows map[string][]float64) float64 { return rows["payout"][0] },
+		Discount:        discount,
+		MinReturn:       returnRange[0],
+		MaxReturn:       returnRange[1],
+		ScenarioSeed:    2,
+	})
+}
+
+// openingChoice plans from the start and reports the first action taken.
+func openingChoice(t *testing.T, env *agents.SimulationEnvironment, sims int) int {
+	t.Helper()
+	cfg := agents.MCTSConfig[[]float64, int]{
+		Simulations:     sims,
+		MaxTreeDepth:    8,
+		RolloutMaxSteps: 8,
+		Rollout: agents.FromProgress(
+			agents.UniformRandomRollout[[]float64, int](), env.Progress),
+	}
+	best, _, err := agents.RunMCTSSearch(env, env.InitialState(), cfg, 41, sims)
+	if err != nil {
+		t.Fatalf("RunMCTSSearch: %v", err)
+	}
+	return best
+}
+
+// planReturn plans the whole episode MPC-style and reports what it earned.
+func planReturn(t *testing.T, env *agents.SimulationEnvironment, sims int) float64 {
+	t.Helper()
+	cfg := agents.MCTSConfig[[]float64, int]{
+		Simulations:     sims,
+		MaxTreeDepth:    8,
+		RolloutMaxSteps: 8,
+		Rollout: agents.FromProgress(
+			agents.UniformRandomRollout[[]float64, int](), env.Progress),
+	}
+	state := env.InitialState()
+	for step := 0; ; step++ {
+		if _, done := env.Terminal(state); done {
+			return env.Return(state)
+		}
+		best, _, err := agents.RunMCTSSearch(env, state, cfg, uint64(step)+41, sims)
+		if err != nil {
+			t.Fatalf("RunMCTSSearch: %v", err)
+		}
+		state, err = env.Apply(state, best)
+		if err != nil {
+			t.Fatalf("Apply: %v", err)
+		}
+	}
+}
+
+func TestPlanningBehaviour(t *testing.T) {
+	const sims = 400
+	wide := [2]float64{-100, 100}
+
+	t.Run("a_longer_horizon_captures_a_later_payoff", func(t *testing.T) {
+		// One step ahead, investing looks like pure loss: its payout is outside
+		// what the planner can see.
+		short := openingChoice(t, newDelayedPayoffEnvironment(t, 1, 1, wide), sims)
+		if short != takeNow {
+			t.Errorf("with a one-step horizon the planner should take the sure 5, it invested")
+		}
+		long := openingChoice(t, newDelayedPayoffEnvironment(t, 4, 1, wide), sims)
+		if long != investLate {
+			t.Errorf("with a four-step horizon investing is worth 25 against 20 for taking, " +
+				"but the planner took")
+		}
+	})
+
+	t.Run("a_heavier_discount_prefers_the_sooner_payoff", func(t *testing.T) {
+		// Undiscounted the delayed 20 wins; discounted hard it is worth 20*0.5^2 = 5
+		// at best, so the immediate 5 is no worse and arrives sooner.
+		patient := openingChoice(t, newDelayedPayoffEnvironment(t, 4, 1, wide), sims)
+		impatient := openingChoice(t, newDelayedPayoffEnvironment(t, 4, 0.5, wide), sims)
+		if patient != investLate {
+			t.Errorf("an undiscounted planner should invest, it took")
+		}
+		if impatient != takeNow {
+			t.Errorf("a heavily discounted planner should take the sooner payoff, it invested")
+		}
+	})
+
+	t.Run("widening_the_return_range_does_not_change_the_choice", func(t *testing.T) {
+		// return_range only sets the normalisation UCB1 needs. Widening it makes
+		// every score smaller but must not reorder the actions — if it does, the
+		// search is reading the scale rather than the problem.
+		narrow := planReturn(t, newDelayedPayoffEnvironment(t, 4, 1, [2]float64{-40, 40}), sims)
+		broad := planReturn(t, newDelayedPayoffEnvironment(t, 4, 1, [2]float64{-4000, 4000}), sims)
+		if narrow != broad {
+			t.Errorf("return range changed the plan: %v against %v", narrow, broad)
+		}
+	})
+
+	t.Run("more_simulations_does_not_lose_value", func(t *testing.T) {
+		// The problem is deterministic and small enough that a bigger budget
+		// should never plan worse.
+		previous := math.Inf(-1)
+		for _, budget := range []int{50, 200, 800} {
+			earned := planReturn(t, newDelayedPayoffEnvironment(t, 4, 1, wide), budget)
+			t.Logf("  %d simulations earned %v", budget, earned)
+			if earned < previous {
+				t.Errorf("raising the budget to %d lost value: %v after %v",
+					budget, earned, previous)
+			}
+			previous = earned
+		}
+	})
+
+	t.Run("the_planner_beats_always_taking", func(t *testing.T) {
+		env := newDelayedPayoffEnvironment(t, 4, 1, wide)
+		planned := planReturn(t, env, sims)
+		greedy := fixedPolicyReturn(t, newDelayedPayoffEnvironment(t, 4, 1, wide), takeNow)
+		t.Logf("planned %v against always-taking %v", planned, greedy)
+		if planned <= greedy {
+			t.Errorf("planning earned %v, no better than always taking (%v)", planned, greedy)
+		}
+	})
+}

--- a/pkg/agents/simulation_environment.go
+++ b/pkg/agents/simulation_environment.go
@@ -83,6 +83,11 @@ type SimulationEnvironment struct {
 	// paramSlot is the encoded index of the drawn-sample slot, or -1 when the
 	// run plans at fixed parameters and carries no such slot.
 	paramSlot int
+	// beliefSlot is the encoded index of the first belief weight, or -1 when the
+	// run does no belief updating. There is one weight per parameter sample.
+	beliefSlot int
+	// observationPartition is the partition index whose row[0] is observed.
+	observationPartition int
 }
 
 // resolvedParamTarget is a ParameterTargets entry with its partition resolved.
@@ -141,6 +146,31 @@ type SimulationEnvironmentSpec struct {
 	// ParameterTargets says where each sample's values go. Together the targets'
 	// Indices must cover the sample vector.
 	ParameterTargets []SimulationParamTarget
+	// Belief turns on in-tree belief updating: the planner carries a distribution
+	// over ParameterSamples and reweights it from what each step reveals, so it
+	// can value an action for what it teaches rather than only for what it pays.
+	//
+	// This is the expensive option. Every transition evaluates the model once per
+	// sample to score the observation, so a step costs (len(ParameterSamples)+1)
+	// model steps. Keep the sample set small.
+	//
+	// Nil plans on a fixed draw instead: still posterior-predictive across
+	// trajectories, but blind to information — see the type docs.
+	Belief *BeliefSpec
+}
+
+// BeliefSpec configures in-tree belief updating.
+type BeliefSpec struct {
+	// ObservationPartition names the partition whose state[0] the decision-maker
+	// observes each step. Its value under the trajectory's true parameters is
+	// scored against what each sample predicts, and the belief is reweighted by
+	// the result. An observation the samples all predict alike carries no
+	// information and leaves the belief untouched, which is the correct
+	// behaviour and what makes an uninformative action look uninformative.
+	ObservationPartition string
+	// Variance is the observation-noise variance of the Gaussian likelihood used
+	// for that scoring. Larger values make the belief move more slowly.
+	Variance float64
 }
 
 // SimulationParamTarget routes part of a parameter sample into the model, the
@@ -249,18 +279,45 @@ func NewSimulationEnvironment(
 		paramSlot = 2 + total
 		total++
 	}
+	beliefSlot := -1
+	observationPartition := -1
+	if spec.Belief != nil {
+		if len(spec.ParameterSamples) == 0 {
+			panic("agents.NewSimulationEnvironment: Belief needs ParameterSamples to be a " +
+				"belief over")
+		}
+		if spec.Belief.Variance <= 0 {
+			panic("agents.NewSimulationEnvironment: Belief.Variance must be > 0")
+		}
+		for i, name := range names {
+			if name == spec.Belief.ObservationPartition {
+				observationPartition = i
+			}
+		}
+		if observationPartition < 0 {
+			panic(fmt.Sprintf(
+				"agents.NewSimulationEnvironment: Belief observes partition %q, which is "+
+					"not in the model", spec.Belief.ObservationPartition))
+		}
+		// One weight per sample: the belief is part of the state, which is what
+		// lets the search prefer a position it understands better.
+		beliefSlot = 2 + total
+		total += len(spec.ParameterSamples)
+	}
 	return &SimulationEnvironment{
-		simulation:      simulator.NewReentrantSimulation(settings, implementations),
-		spec:            spec,
-		partitionNames:  names,
-		partitionWidths: widths,
-		partitionDepths: depths,
-		windowWidths:    windowWidths,
-		initRows:        initRows,
-		totalWidth:      total,
-		actionPartition: actionPartition,
-		paramTargets:    targets,
-		paramSlot:       paramSlot,
+		simulation:           simulator.NewReentrantSimulation(settings, implementations),
+		spec:                 spec,
+		partitionNames:       names,
+		partitionWidths:      widths,
+		partitionDepths:      depths,
+		windowWidths:         windowWidths,
+		initRows:             initRows,
+		totalWidth:           total,
+		actionPartition:      actionPartition,
+		paramTargets:         targets,
+		paramSlot:            paramSlot,
+		beliefSlot:           beliefSlot,
+		observationPartition: observationPartition,
 	}
 }
 
@@ -282,6 +339,13 @@ func (e *SimulationEnvironment) InitialState() []float64 {
 		// sample, so a chance node at the root spreads its outcomes across the
 		// posterior rather than committing to one draw.
 		state[e.paramSlot] = -1
+	}
+	if e.beliefSlot >= 0 {
+		// The episode starts believing the posterior as given.
+		uniform := 1 / float64(len(e.spec.ParameterSamples))
+		for i := range e.spec.ParameterSamples {
+			state[e.beliefSlot+i] = uniform
+		}
 	}
 	return state
 }
@@ -340,22 +404,18 @@ func (e *SimulationEnvironment) apply(
 
 	// Hand back each partition's whole window, so an iteration that reads several
 	// steps into the past resumes from the history it actually had.
-	histories := make(map[int]*simulator.StateHistory, len(e.partitionWidths))
-	offset := 2
-	for index, width := range e.partitionWidths {
-		histories[index] = simulator.NewStateHistoryFromWindow(
-			s[offset:offset+e.windowWidths[index]], width, e.partitionDepths[index])
-		offset += e.windowWidths[index]
-	}
+	histories := e.historiesFrom(s)
 	sample := -1.0
 	if e.paramSlot >= 0 {
 		sample = s[e.paramSlot]
 		if sample < 0 {
 			// Draw once per trajectory, from this transition's seed, so the
 			// parameters stay fixed from here on while sibling outcomes at the
-			// same chance node get different draws.
+			// same chance node get different draws. With a belief, the draw is
+			// weighted by it, so the trajectories a node explores reflect what is
+			// currently thought plausible.
 			draw := mixSeed(e.spec.ScenarioSeed^0x5eed, s, a) ^ sampleSeed
-			sample = float64(draw % uint64(len(e.spec.ParameterSamples)))
+			sample = float64(e.drawSample(s, draw))
 		}
 		values := e.spec.ParameterSamples[int(sample)]
 		for _, target := range e.paramTargets {
@@ -390,10 +450,127 @@ func (e *SimulationEnvironment) apply(
 		copy(next[writeOffset:], advanced[index])
 		writeOffset += e.windowWidths[index]
 	}
+	if e.beliefSlot >= 0 {
+		e.updateBelief(s, next, a, seed)
+	}
 	// Discount by the step the reward was earned on, so a path's accumulated
 	// value does not depend on the order the tree happened to visit it in.
 	next[1] = s[1] + math.Pow(e.spec.Discount, s[0])*e.spec.Reward(e.rowsByName(next))
 	return next, nil
+}
+
+// drawSample picks a parameter sample, weighted by the belief carried in s when
+// there is one and uniformly otherwise.
+func (e *SimulationEnvironment) drawSample(s []float64, draw uint64) int {
+	count := len(e.spec.ParameterSamples)
+	if e.beliefSlot < 0 {
+		return int(draw % uint64(count))
+	}
+	// Sample the categorical belief by its cumulative distribution, using the
+	// draw as a uniform in [0,1).
+	target := float64(draw%(1<<24)) / float64(1<<24)
+	cumulative := 0.0
+	for i := 0; i < count; i++ {
+		cumulative += s[e.beliefSlot+i]
+		if target < cumulative {
+			return i
+		}
+	}
+	return count - 1
+}
+
+// updateBelief reweights the belief by how well each parameter sample predicted
+// what was actually observed this step.
+//
+// Each sample is re-run from the same starting histories under the same noise
+// seed, so the only thing that differs between them is the parameters — which is
+// what makes the comparison a likelihood over parameters rather than over noise.
+// That is also why this costs a model step per sample.
+func (e *SimulationEnvironment) updateBelief(
+	previous, next []float64,
+	action int,
+	seed uint64,
+) {
+	observed := e.observationOf(next)
+	count := len(e.spec.ParameterSamples)
+	weights := make([]float64, count)
+	total := 0.0
+	variance := e.spec.Belief.Variance
+
+	for i := 0; i < count; i++ {
+		prior := previous[e.beliefSlot+i]
+		if prior <= 0 {
+			continue
+		}
+		predicted := e.predictObservation(i, previous, action, seed)
+		residual := observed - predicted
+		weight := prior * math.Exp(-residual*residual/(2*variance))
+		weights[i] = weight
+		total += weight
+	}
+
+	if total <= 0 {
+		// Every sample found the observation impossible, so it carries no usable
+		// information; keeping the prior beats collapsing onto an arbitrary one.
+		copy(next[e.beliefSlot:e.beliefSlot+count], previous[e.beliefSlot:e.beliefSlot+count])
+		return
+	}
+	for i := 0; i < count; i++ {
+		next[e.beliefSlot+i] = weights[i] / total
+	}
+}
+
+// predictObservation runs one step under sample i from the given starting
+// histories and reports what it would have observed.
+func (e *SimulationEnvironment) predictObservation(
+	sample int,
+	previous []float64,
+	action int,
+	seed uint64,
+) float64 {
+	values := e.spec.ParameterSamples[sample]
+	for _, target := range e.paramTargets {
+		injected := make([]float64, len(target.indices))
+		for j, index := range target.indices {
+			injected[j] = values[index]
+		}
+		e.simulation.SetParam(target.partition, target.param, injected)
+	}
+	e.simulation.SetParam(e.actionPartition, e.spec.ActionParam, e.spec.Actions[action])
+	// Rebuilt from the encoded state rather than reused: a StateHistory handed to
+	// a coordinator is written through, so the advancing run has already moved
+	// the ones it was given.
+	rows := e.simulation.Run(simulator.ReentrantRun{
+		Histories: e.historiesFrom(previous), Seed: &seed, Steps: 1,
+	})
+	return rows[e.observationPartition][0]
+}
+
+// historiesFrom rebuilds each partition's state-history window from an encoded
+// state. Fresh objects every time, because a coordinator writes through the
+// histories it is given.
+func (e *SimulationEnvironment) historiesFrom(s []float64) map[int]*simulator.StateHistory {
+	histories := make(map[int]*simulator.StateHistory, len(e.partitionWidths))
+	offset := 2
+	for index, width := range e.partitionWidths {
+		histories[index] = simulator.NewStateHistoryFromWindow(
+			s[offset:offset+e.windowWidths[index]], width, e.partitionDepths[index])
+		offset += e.windowWidths[index]
+	}
+	return histories
+}
+
+// observationOf reads the observed partition's latest value out of an encoded
+// state.
+func (e *SimulationEnvironment) observationOf(s []float64) float64 {
+	offset := 2
+	for index := range e.partitionWidths {
+		if index == e.observationPartition {
+			return s[offset]
+		}
+		offset += e.windowWidths[index]
+	}
+	return 0
 }
 
 // ApplySample implements StochasticEnvironment: one transition under an explicit

--- a/pkg/agents/simulation_environment.go
+++ b/pkg/agents/simulation_environment.go
@@ -88,6 +88,8 @@ type SimulationEnvironment struct {
 	beliefSlot int
 	// observationPartition is the partition index whose row[0] is observed.
 	observationPartition int
+	// priorWeights is ParameterWeights normalised, or nil for equal credence.
+	priorWeights []float64
 }
 
 // resolvedParamTarget is a ParameterTargets entry with its partition resolved.
@@ -146,6 +148,15 @@ type SimulationEnvironmentSpec struct {
 	// ParameterTargets says where each sample's values go. Together the targets'
 	// Indices must cover the sample vector.
 	ParameterTargets []SimulationParamTarget
+	// ParameterWeights is how much credence each sample carries, which is what an
+	// inference tier hands a planner: SMC produces particles AND their weights,
+	// and the weights are the posterior. Need not sum to 1; it is normalised.
+	//
+	// Nil means equal credence, which is right when the samples were themselves
+	// drawn from the posterior (posterior_estimation's sampler does this, so its
+	// draws already carry the posterior's shape) and wrong when they were drawn
+	// from something else and reweighted.
+	ParameterWeights []float64
 	// Belief turns on in-tree belief updating: the planner carries a distribution
 	// over ParameterSamples and reweights it from what each step reveals, so it
 	// can value an action for what it teaches rather than only for what it pays.
@@ -246,6 +257,30 @@ func NewSimulationEnvironment(
 	}
 	paramSlot := -1
 	var targets []resolvedParamTarget
+	var priorWeights []float64
+	if len(spec.ParameterWeights) > 0 {
+		if len(spec.ParameterWeights) != len(spec.ParameterSamples) {
+			panic(fmt.Sprintf(
+				"agents.NewSimulationEnvironment: %d parameter weights for %d samples — "+
+					"there must be one weight per sample",
+				len(spec.ParameterWeights), len(spec.ParameterSamples)))
+		}
+		total := 0.0
+		for _, weight := range spec.ParameterWeights {
+			if weight < 0 {
+				panic("agents.NewSimulationEnvironment: parameter weights must be non-negative")
+			}
+			total += weight
+		}
+		if total <= 0 {
+			panic("agents.NewSimulationEnvironment: parameter weights sum to zero, so no " +
+				"sample carries any credence")
+		}
+		priorWeights = make([]float64, len(spec.ParameterWeights))
+		for i, weight := range spec.ParameterWeights {
+			priorWeights[i] = weight / total
+		}
+	}
 	if len(spec.ParameterSamples) > 0 {
 		if len(spec.ParameterTargets) == 0 {
 			panic("agents.NewSimulationEnvironment: ParameterSamples needs ParameterTargets " +
@@ -318,6 +353,7 @@ func NewSimulationEnvironment(
 		paramSlot:            paramSlot,
 		beliefSlot:           beliefSlot,
 		observationPartition: observationPartition,
+		priorWeights:         priorWeights,
 	}
 }
 
@@ -341,10 +377,14 @@ func (e *SimulationEnvironment) InitialState() []float64 {
 		state[e.paramSlot] = -1
 	}
 	if e.beliefSlot >= 0 {
-		// The episode starts believing the posterior as given.
+		// The episode starts believing whatever the inference tier concluded.
 		uniform := 1 / float64(len(e.spec.ParameterSamples))
 		for i := range e.spec.ParameterSamples {
-			state[e.beliefSlot+i] = uniform
+			if e.priorWeights != nil {
+				state[e.beliefSlot+i] = e.priorWeights[i]
+			} else {
+				state[e.beliefSlot+i] = uniform
+			}
 		}
 	}
 	return state
@@ -463,15 +503,20 @@ func (e *SimulationEnvironment) apply(
 // there is one and uniformly otherwise.
 func (e *SimulationEnvironment) drawSample(s []float64, draw uint64) int {
 	count := len(e.spec.ParameterSamples)
-	if e.beliefSlot < 0 {
+	if e.beliefSlot < 0 && e.priorWeights == nil {
 		return int(draw % uint64(count))
 	}
 	// Sample the categorical belief by its cumulative distribution, using the
-	// draw as a uniform in [0,1).
+	// draw as a uniform in [0,1). Without a belief in the state the prior stands
+	// in, so weighted samples are still drawn in proportion to their credence.
 	target := float64(draw%(1<<24)) / float64(1<<24)
 	cumulative := 0.0
 	for i := 0; i < count; i++ {
-		cumulative += s[e.beliefSlot+i]
+		if e.beliefSlot >= 0 {
+			cumulative += s[e.beliefSlot+i]
+		} else {
+			cumulative += e.priorWeights[i]
+		}
 		if target < cumulative {
 			return i
 		}

--- a/pkg/agents/simulation_environment.go
+++ b/pkg/agents/simulation_environment.go
@@ -110,6 +110,10 @@ type SimulationEnvironmentSpec struct {
 	// Legal optionally restricts the action set given the decoded rows. Nil
 	// means every action is always legal.
 	Legal func(rows map[string][]float64) []int
+	// Progress optionally scores an unfinished position in [0,1], for rollouts
+	// that hit their step limit before the horizon. Nil falls back to the reward
+	// banked so far — see Progress.
+	Progress func(rows map[string][]float64) (float64, bool)
 }
 
 // NewSimulationEnvironment validates the spec against the sub-simulation and
@@ -316,6 +320,26 @@ func (e *SimulationEnvironment) Actor([]float64) int { return 0 }
 
 // Players implements Environment.
 func (e *SimulationEnvironment) Players([]float64) int { return 1 }
+
+// Progress scores an unfinished state on the same [0,1] scale Terminal uses, so
+// a rollout that runs out of steps still contributes a value instead of no
+// signal. Compose it with FromProgress.
+//
+// The proxy is the reward banked so far. That is deliberately conservative: it
+// credits nothing for a position that is merely promising, so it under-rates a
+// leaf whose payoff comes later. It beats the alternative of discarding the
+// rollout, which leaves the search exploring on visit counts alone — the failure
+// mode that bites when the horizon is longer than RolloutMaxSteps.
+//
+// Supply SimulationEnvironmentSpec.Progress to score positions instead of banked
+// reward, which is what a domain proxy (a win probability, a margin) is for.
+func (e *SimulationEnvironment) Progress(s []float64, player int) (float64, bool) {
+	if e.spec.Progress != nil {
+		return e.spec.Progress(e.rowsByName(s))
+	}
+	span := e.spec.MaxReturn - e.spec.MinReturn
+	return math.Min(1, math.Max(0, (s[1]-e.spec.MinReturn)/span)), true
+}
 
 // Return reads the accumulated (discounted) reward out of an encoded state,
 // which is the quantity a caller actually wants to report — the [0,1] score is

--- a/pkg/agents/simulation_environment.go
+++ b/pkg/agents/simulation_environment.go
@@ -78,6 +78,18 @@ type SimulationEnvironment struct {
 	initRows        [][]float64
 	totalWidth      int
 	actionPartition int
+	// paramTargets resolves ParameterTargets to partition indices once.
+	paramTargets []resolvedParamTarget
+	// paramSlot is the encoded index of the drawn-sample slot, or -1 when the
+	// run plans at fixed parameters and carries no such slot.
+	paramSlot int
+}
+
+// resolvedParamTarget is a ParameterTargets entry with its partition resolved.
+type resolvedParamTarget struct {
+	partition int
+	param     string
+	indices   []int
 }
 
 // SimulationEnvironmentSpec configures a SimulationEnvironment.
@@ -114,6 +126,32 @@ type SimulationEnvironmentSpec struct {
 	// that hit their step limit before the horizon. Nil falls back to the reward
 	// banked so far — see Progress.
 	Progress func(rows map[string][]float64) (float64, bool)
+	// ParameterSamples turns the run into posterior-predictive planning: each
+	// entry is one draw of the model's uncertain parameters, and the search
+	// averages over them instead of committing to a point estimate.
+	//
+	// A sample set rather than a fitted distribution, because that is what the
+	// inference tier already produces — SMC particle parameters, or draws from a
+	// posterior_estimation partition — and it carries the posterior's actual
+	// shape rather than a Gaussian summary of it.
+	//
+	// Each sample is routed into the model by ParameterTargets. Leave nil to
+	// plan at whatever parameters the model was configured with.
+	ParameterSamples [][]float64
+	// ParameterTargets says where each sample's values go. Together the targets'
+	// Indices must cover the sample vector.
+	ParameterTargets []SimulationParamTarget
+}
+
+// SimulationParamTarget routes part of a parameter sample into the model, the
+// same shape SMC uses to route a particle's parameters into its own model.
+type SimulationParamTarget struct {
+	// Partition names the model partition receiving the values, and Param the
+	// params key written on it.
+	Partition string
+	Param     string
+	// Indices selects which of the sample's entries to send, in order.
+	Indices []int
 }
 
 // NewSimulationEnvironment validates the spec against the sub-simulation and
@@ -176,6 +214,41 @@ func NewSimulationEnvironment(
 	if spec.Discount == 0 {
 		spec.Discount = 1.0
 	}
+	paramSlot := -1
+	var targets []resolvedParamTarget
+	if len(spec.ParameterSamples) > 0 {
+		if len(spec.ParameterTargets) == 0 {
+			panic("agents.NewSimulationEnvironment: ParameterSamples needs ParameterTargets " +
+				"saying where each sample's values go")
+		}
+		for _, target := range spec.ParameterTargets {
+			index := -1
+			for i, name := range names {
+				if name == target.Partition {
+					index = i
+				}
+			}
+			if index < 0 {
+				panic(fmt.Sprintf(
+					"agents.NewSimulationEnvironment: parameter target names partition %q, "+
+						"which is not in the model", target.Partition))
+			}
+			for _, i := range target.Indices {
+				if i < 0 || i >= len(spec.ParameterSamples[0]) {
+					panic(fmt.Sprintf(
+						"agents.NewSimulationEnvironment: parameter target %q/%q reads sample "+
+							"index %d, outside the %d-wide samples",
+						target.Partition, target.Param, i, len(spec.ParameterSamples[0])))
+				}
+			}
+			targets = append(targets, resolvedParamTarget{
+				partition: index, param: target.Param, indices: target.Indices,
+			})
+		}
+		// One extra slot carries which sample this trajectory drew.
+		paramSlot = 2 + total
+		total++
+	}
 	return &SimulationEnvironment{
 		simulation:      simulator.NewReentrantSimulation(settings, implementations),
 		spec:            spec,
@@ -186,6 +259,8 @@ func NewSimulationEnvironment(
 		initRows:        initRows,
 		totalWidth:      total,
 		actionPartition: actionPartition,
+		paramTargets:    targets,
+		paramSlot:       paramSlot,
 	}
 }
 
@@ -201,6 +276,12 @@ func (e *SimulationEnvironment) InitialState() []float64 {
 	for index, window := range e.initRows {
 		copy(state[offset:], window)
 		offset += e.windowWidths[index]
+	}
+	if e.paramSlot >= 0 {
+		// Undrawn: the first transition out of this state picks a posterior
+		// sample, so a chance node at the root spreads its outcomes across the
+		// posterior rather than committing to one draw.
+		state[e.paramSlot] = -1
 	}
 	return state
 }
@@ -266,6 +347,25 @@ func (e *SimulationEnvironment) apply(
 			s[offset:offset+e.windowWidths[index]], width, e.partitionDepths[index])
 		offset += e.windowWidths[index]
 	}
+	sample := -1.0
+	if e.paramSlot >= 0 {
+		sample = s[e.paramSlot]
+		if sample < 0 {
+			// Draw once per trajectory, from this transition's seed, so the
+			// parameters stay fixed from here on while sibling outcomes at the
+			// same chance node get different draws.
+			draw := mixSeed(e.spec.ScenarioSeed^0x5eed, s, a) ^ sampleSeed
+			sample = float64(draw % uint64(len(e.spec.ParameterSamples)))
+		}
+		values := e.spec.ParameterSamples[int(sample)]
+		for _, target := range e.paramTargets {
+			injected := make([]float64, len(target.indices))
+			for i, index := range target.indices {
+				injected[i] = values[index]
+			}
+			e.simulation.SetParam(target.partition, target.param, injected)
+		}
+	}
 	e.simulation.SetParam(e.actionPartition, e.spec.ActionParam, e.spec.Actions[a])
 	// Seeding from (scenario, state, action, sample) is what makes the transition
 	// reproducible; ReentrantSimulation reseeds the iterations from it before
@@ -282,6 +382,9 @@ func (e *SimulationEnvironment) apply(
 
 	next := make([]float64, e.StateWidth())
 	next[0] = s[0] + 1
+	if e.paramSlot >= 0 {
+		next[e.paramSlot] = sample
+	}
 	writeOffset := 2
 	for index := range e.partitionWidths {
 		copy(next[writeOffset:], advanced[index])

--- a/pkg/agents/simulation_environment_test.go
+++ b/pkg/agents/simulation_environment_test.go
@@ -980,3 +980,171 @@ func TestPosteriorPredictivePlanningBeatsPointEstimate(t *testing.T) {
 			"-25 for ordering 25), got %v", orderQuantities[underPosterior][0])
 	}
 }
+
+// probeIteration is a probe-then-commit decision. An unknown parameter theta
+// says which of two commitments pays; probing reveals it but earns nothing.
+//
+// Row: [signal, payoff]. The signal is what a decision-maker observes, and it
+// only carries information when the probe action was taken — otherwise both
+// hypotheses predict the same thing, so an observation of it teaches nothing.
+//
+// Params: "choice" (the action) and "theta" (the uncertain parameter).
+type probeIteration struct{}
+
+func (p *probeIteration) Configure(int, *simulator.Settings) {}
+
+func (p *probeIteration) Iterate(
+	params *simulator.Params,
+	partitionIndex int,
+	stateHistories []*simulator.StateHistory,
+	timestepsHistory *simulator.CumulativeTimestepsHistory,
+) []float64 {
+	choice := params.GetIndex("choice", 0)
+	theta := params.GetIndex("theta", 0)
+	switch {
+	case choice == 0: // probe: reveals theta, pays nothing
+		return []float64{theta, 0}
+	case choice == 1: // commit A: right when theta is 0
+		return []float64{0, 10 - 20*theta}
+	default: // commit B: right when theta is 1
+		return []float64{0, -10 + 20*theta}
+	}
+}
+
+// newProbeEnvironment builds the decision over a two-point posterior on theta.
+// belief nil plans on a fixed draw, which cannot value information.
+func newProbeEnvironment(t *testing.T, belief *agents.BeliefSpec) *agents.SimulationEnvironment {
+	return newProbeEnvironmentWithSamples(t, belief, [][]float64{{0}, {1}})
+}
+
+func newProbeEnvironmentWithSamples(
+	t *testing.T,
+	belief *agents.BeliefSpec,
+	samples [][]float64,
+) *agents.SimulationEnvironment {
+	gen := simulator.NewConfigGenerator()
+	gen.SetSimulation(&simulator.SimulationConfig{
+		OutputCondition:      &simulator.NilOutputCondition{},
+		OutputFunction:       &simulator.NilOutputFunction{},
+		TerminationCondition: &simulator.NumberOfStepsTerminationCondition{MaxNumberOfSteps: 1},
+		TimestepFunction:     &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+		InitTimeValue:        0,
+	})
+	gen.SetPartition(&simulator.PartitionConfig{
+		Name:              "choice",
+		Iteration:         &general.ParamValuesIteration{},
+		Params:            simulator.NewParams(map[string][]float64{"param_values": {0}}),
+		InitStateValues:   []float64{0},
+		StateHistoryDepth: 1,
+		Seed:              0,
+	})
+	gen.SetPartition(&simulator.PartitionConfig{
+		Name:      "world",
+		Iteration: &probeIteration{},
+		Params: simulator.NewParams(map[string][]float64{
+			"choice": {0}, "theta": {0},
+		}),
+		ParamsFromUpstream: map[string]simulator.NamedUpstreamConfig{
+			"choice": {Upstream: "choice"},
+		},
+		InitStateValues:   []float64{0, 0},
+		StateHistoryDepth: 1,
+		Seed:              0,
+	})
+	settings, impl := gen.GenerateConfigs()
+	impl.ExecutionStrategy = &simulator.InlineExecution{}
+
+	return agents.NewSimulationEnvironment(settings, impl, agents.SimulationEnvironmentSpec{
+		Actions:          [][]float64{{0}, {1}, {2}}, // probe / commit A / commit B
+		ActionPartition:  "choice",
+		ActionParam:      "param_values",
+		Horizon:          2,
+		Reward:           func(rows map[string][]float64) float64 { return rows["world"][1] },
+		MinReturn:        -30,
+		MaxReturn:        30,
+		ScenarioSeed:     5,
+		ParameterSamples: samples,
+		ParameterTargets: []agents.SimulationParamTarget{
+			{Partition: "world", Param: "theta", Indices: []int{0}},
+		},
+		Belief: belief,
+	})
+}
+
+// TestBeliefUpdatingValuesInformation is what belief updating buys that
+// posterior-predictive planning alone does not: taking an action for what it
+// reveals rather than what it pays.
+//
+// Committing blind is worth zero — theta decides which commitment is right and
+// it is equally likely to be either. Probing pays nothing and burns a step, so a
+// planner that cannot learn from the probe's result sees no reason to do it. One
+// that updates its belief probes, then commits correctly, for +10.
+func TestBeliefUpdatingValuesInformation(t *testing.T) {
+	cfg := agents.MCTSConfig[[]float64, int]{
+		Simulations:     800,
+		MaxTreeDepth:    3,
+		RolloutMaxSteps: 3,
+		Rollout:         agents.UniformRandomRollout[[]float64, int](),
+	}
+
+	blind := newProbeEnvironment(t, nil)
+	blindFirst, _, err := agents.RunChanceMCTSSearch(
+		blind, blind.InitialState(), cfg, 21, cfg.Simulations)
+	if err != nil {
+		t.Fatalf("RunChanceMCTSSearch: %v", err)
+	}
+
+	learner := newProbeEnvironment(t, &agents.BeliefSpec{
+		ObservationPartition: "world", Variance: 0.01,
+	})
+	learnerFirst, _, err := agents.RunChanceMCTSSearch(
+		learner, learner.InitialState(), cfg, 21, cfg.Simulations)
+	if err != nil {
+		t.Fatalf("RunChanceMCTSSearch: %v", err)
+	}
+
+	names := []string{"probe", "commit A", "commit B"}
+	t.Logf("fixed draw opens with %s | belief updating opens with %s",
+		names[blindFirst], names[learnerFirst])
+
+	if learnerFirst != 0 {
+		t.Errorf("a planner that can learn should probe first, it opened with %s",
+			names[learnerFirst])
+	}
+}
+
+// TestBeliefUpdatingSharpensOnAnInformativeAction checks the mechanism directly:
+// probing must move the belief onto the true parameter, and committing (which
+// reveals nothing) must leave it alone.
+func TestBeliefUpdatingSharpensOnAnInformativeAction(t *testing.T) {
+	env := newProbeEnvironment(t, &agents.BeliefSpec{
+		ObservationPartition: "world", Variance: 0.01,
+	})
+	start := env.InitialState()
+
+	probed, err := env.Apply(start, 0)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	committed, err := env.Apply(start, 1)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	// The belief weights are the last two slots of the encoded state.
+	width := env.StateWidth()
+	probedBelief := probed[width-2:]
+	committedBelief := committed[width-2:]
+	t.Logf("after probing: %v | after committing: %v", probedBelief, committedBelief)
+
+	sharpest := math.Max(probedBelief[0], probedBelief[1])
+	if sharpest < 0.9 {
+		t.Errorf("probing should nearly resolve theta, belief is %v", probedBelief)
+	}
+	for i, weight := range committedBelief {
+		if math.Abs(weight-0.5) > 1e-6 {
+			t.Errorf("committing reveals nothing, so weight %d should stay 0.5, got %v",
+				i, weight)
+		}
+	}
+}

--- a/pkg/agents/simulation_environment_test.go
+++ b/pkg/agents/simulation_environment_test.go
@@ -1022,6 +1022,15 @@ func newProbeEnvironmentWithSamples(
 	belief *agents.BeliefSpec,
 	samples [][]float64,
 ) *agents.SimulationEnvironment {
+	return newProbeEnvironmentWeighted(t, belief, samples, nil)
+}
+
+func newProbeEnvironmentWeighted(
+	t *testing.T,
+	belief *agents.BeliefSpec,
+	samples [][]float64,
+	weights []float64,
+) *agents.SimulationEnvironment {
 	gen := simulator.NewConfigGenerator()
 	gen.SetSimulation(&simulator.SimulationConfig{
 		OutputCondition:      &simulator.NilOutputCondition{},
@@ -1064,6 +1073,7 @@ func newProbeEnvironmentWithSamples(
 		MaxReturn:        30,
 		ScenarioSeed:     5,
 		ParameterSamples: samples,
+		ParameterWeights: weights,
 		ParameterTargets: []agents.SimulationParamTarget{
 			{Partition: "world", Param: "theta", Indices: []int{0}},
 		},
@@ -1146,5 +1156,126 @@ func TestBeliefUpdatingSharpensOnAnInformativeAction(t *testing.T) {
 			t.Errorf("committing reveals nothing, so weight %d should stay 0.5, got %v",
 				i, weight)
 		}
+	}
+}
+
+// TestParameterWeightsSteerTheDraw checks the planner honours the credence an
+// inference tier attached to each sample, not just the samples themselves.
+//
+// Without weights a planner treats every sample as equally likely, which is only
+// right when the samples were drawn from the posterior. SMC hands over particles
+// AND weights, and the weights are the posterior — ignoring them plans against
+// the proposal instead.
+//
+// Demand is 10 or 100; the weights say which is credible. Ordering 100 is right
+// only if the large demand is, so the plan should follow the weights.
+func TestParameterWeightsSteerTheDraw(t *testing.T) {
+	cfg := agents.MCTSConfig[[]float64, int]{
+		Simulations:     600,
+		MaxTreeDepth:    2,
+		RolloutMaxSteps: 2,
+		Rollout:         agents.UniformRandomRollout[[]float64, int](),
+	}
+	samples := [][]float64{{10}, {100}}
+
+	for _, testCase := range []struct {
+		name    string
+		weights []float64
+		want    float64
+	}{
+		{name: "credence on low demand", weights: []float64{0.95, 0.05}, want: 10},
+		{name: "credence on high demand", weights: []float64{0.05, 0.95}, want: 100},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			env := newWeightedNewsvendorEnvironment(t, samples, testCase.weights)
+			best, _, err := agents.RunChanceMCTSSearch(
+				env, env.InitialState(), cfg, 13, cfg.Simulations)
+			if err != nil {
+				t.Fatalf("RunChanceMCTSSearch: %v", err)
+			}
+			if got := orderQuantities[best][0]; got != testCase.want {
+				t.Errorf("ordered %v, want %v — the plan is not following the weights",
+					got, testCase.want)
+			}
+		})
+	}
+}
+
+// newWeightedNewsvendorEnvironment is the newsvendor over a weighted sample set.
+func newWeightedNewsvendorEnvironment(
+	t *testing.T,
+	samples [][]float64,
+	weights []float64,
+) *agents.SimulationEnvironment {
+	t.Helper()
+	gen := simulator.NewConfigGenerator()
+	gen.SetSimulation(&simulator.SimulationConfig{
+		OutputCondition:      &simulator.NilOutputCondition{},
+		OutputFunction:       &simulator.NilOutputFunction{},
+		TerminationCondition: &simulator.NumberOfStepsTerminationCondition{MaxNumberOfSteps: 1},
+		TimestepFunction:     &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+		InitTimeValue:        0,
+	})
+	gen.SetPartition(&simulator.PartitionConfig{
+		Name:              "order",
+		Iteration:         &general.ParamValuesIteration{},
+		Params:            simulator.NewParams(map[string][]float64{"param_values": {0}}),
+		InitStateValues:   []float64{0},
+		StateHistoryDepth: 1,
+		Seed:              0,
+	})
+	gen.SetPartition(&simulator.PartitionConfig{
+		Name:      "profit",
+		Iteration: &newsvendorIteration{price: 10, cost: 6},
+		Params: simulator.NewParams(map[string][]float64{
+			"quantity": {0}, "demand": {10},
+		}),
+		ParamsFromUpstream: map[string]simulator.NamedUpstreamConfig{
+			"quantity": {Upstream: "order"},
+		},
+		InitStateValues:   []float64{0},
+		StateHistoryDepth: 1,
+		Seed:              0,
+	})
+	settings, impl := gen.GenerateConfigs()
+	impl.ExecutionStrategy = &simulator.InlineExecution{}
+
+	return agents.NewSimulationEnvironment(settings, impl, agents.SimulationEnvironmentSpec{
+		Actions:          orderQuantities,
+		ActionPartition:  "order",
+		ActionParam:      "param_values",
+		Horizon:          1,
+		Reward:           func(rows map[string][]float64) float64 { return rows["profit"][0] },
+		MinReturn:        -700,
+		MaxReturn:        500,
+		ScenarioSeed:     3,
+		ParameterSamples: samples,
+		ParameterWeights: weights,
+		ParameterTargets: []agents.SimulationParamTarget{
+			{Partition: "profit", Param: "demand", Indices: []int{0}},
+		},
+	})
+}
+
+// TestBeliefStartsFromThePrior checks the belief begins where the inference tier
+// left off rather than flat, so a planner does not discard what was already
+// concluded the moment an episode starts.
+func TestBeliefStartsFromThePrior(t *testing.T) {
+	env := newProbeEnvironmentWithSamples(t,
+		&agents.BeliefSpec{ObservationPartition: "world", Variance: 0.01},
+		[][]float64{{0}, {1}})
+	flat := env.InitialState()
+	width := env.StateWidth()
+	if flat[width-2] != 0.5 || flat[width-1] != 0.5 {
+		t.Fatalf("with no weights the belief should start flat, got %v", flat[width-2:])
+	}
+
+	weighted := newProbeEnvironmentWeighted(t,
+		&agents.BeliefSpec{ObservationPartition: "world", Variance: 0.01},
+		[][]float64{{0}, {1}}, []float64{3, 1})
+	start := weighted.InitialState()
+	if math.Abs(start[width-2]-0.75) > 1e-9 || math.Abs(start[width-1]-0.25) > 1e-9 {
+		t.Errorf("the belief should start at the normalised prior [0.75 0.25], got %v",
+			start[width-2:])
 	}
 }

--- a/pkg/agents/simulation_environment_test.go
+++ b/pkg/agents/simulation_environment_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/umbralcalc/stochadex/pkg/agents"
+	"github.com/umbralcalc/stochadex/pkg/general"
 	"github.com/umbralcalc/stochadex/pkg/simulator"
 )
 
@@ -842,5 +843,140 @@ func TestProgressProxyScoresTruncatedRollouts(t *testing.T) {
 
 	if withProgress <= plain {
 		t.Errorf("progress scoring did not help: %.0f vs %.0f", withProgress, plain)
+	}
+}
+
+// newsvendorIteration is the classic order-quantity payoff: you order q before
+// demand is known, sell what you can, and eat the cost of the rest.
+//
+//	profit = price * min(q, demand) - cost * q
+//
+// Row: [profit]; params: "quantity" (the action) and "demand" (the uncertain
+// parameter a posterior sample supplies).
+type newsvendorIteration struct{ price, cost float64 }
+
+func (n *newsvendorIteration) Configure(int, *simulator.Settings) {}
+
+func (n *newsvendorIteration) Iterate(
+	params *simulator.Params,
+	partitionIndex int,
+	stateHistories []*simulator.StateHistory,
+	timestepsHistory *simulator.CumulativeTimestepsHistory,
+) []float64 {
+	quantity := params.GetIndex("quantity", 0)
+	demand := params.GetIndex("demand", 0)
+	return []float64{n.price*math.Min(quantity, demand) - n.cost*quantity}
+}
+
+// orderQuantities are the actions; demandPosterior is a deliberately skewed
+// posterior — usually 10, occasionally 100.
+var (
+	orderQuantities = [][]float64{{10}, {25}, {100}}
+	demandPosterior = [][]float64{{10}, {10}, {10}, {10}, {10}, {100}}
+)
+
+// newNewsvendorEnvironment builds the decision. samples nil plans at the
+// posterior MEAN (25) instead of over the posterior.
+func newNewsvendorEnvironment(
+	t *testing.T,
+	samples [][]float64,
+	meanDemand float64,
+) *agents.SimulationEnvironment {
+	t.Helper()
+	gen := simulator.NewConfigGenerator()
+	gen.SetSimulation(&simulator.SimulationConfig{
+		OutputCondition:      &simulator.NilOutputCondition{},
+		OutputFunction:       &simulator.NilOutputFunction{},
+		TerminationCondition: &simulator.NumberOfStepsTerminationCondition{MaxNumberOfSteps: 1},
+		TimestepFunction:     &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+		InitTimeValue:        0,
+	})
+	gen.SetPartition(&simulator.PartitionConfig{
+		Name:      "order",
+		Iteration: &general.ParamValuesIteration{},
+		Params: simulator.NewParams(map[string][]float64{
+			"param_values": {0},
+		}),
+		InitStateValues:   []float64{0},
+		StateHistoryDepth: 1,
+		Seed:              0,
+	})
+	gen.SetPartition(&simulator.PartitionConfig{
+		Name:      "profit",
+		Iteration: &newsvendorIteration{price: 10, cost: 6},
+		Params: simulator.NewParams(map[string][]float64{
+			"quantity": {0}, "demand": {meanDemand},
+		}),
+		ParamsFromUpstream: map[string]simulator.NamedUpstreamConfig{
+			"quantity": {Upstream: "order"},
+		},
+		InitStateValues:   []float64{0},
+		StateHistoryDepth: 1,
+		Seed:              0,
+	})
+	settings, impl := gen.GenerateConfigs()
+	impl.ExecutionStrategy = &simulator.InlineExecution{}
+
+	spec := agents.SimulationEnvironmentSpec{
+		Actions:         orderQuantities,
+		ActionPartition: "order",
+		ActionParam:     "param_values",
+		Horizon:         1,
+		Reward:          func(rows map[string][]float64) float64 { return rows["profit"][0] },
+		MinReturn:       -700,
+		MaxReturn:       300,
+		ScenarioSeed:    3,
+	}
+	if samples != nil {
+		spec.ParameterSamples = samples
+		spec.ParameterTargets = []agents.SimulationParamTarget{
+			{Partition: "profit", Param: "demand", Indices: []int{0}},
+		}
+	}
+	return agents.NewSimulationEnvironment(settings, impl, spec)
+}
+
+// TestPosteriorPredictivePlanningBeatsPointEstimate is the payoff of planning
+// against a posterior rather than a fitted point.
+//
+// The newsvendor is the textbook case where the two provably disagree. Ordering
+// 25 is optimal if demand really is its posterior mean of 25 (profit 100), but
+// demand is 10 five times in six, so 25 loses money on average (−25) while
+// ordering 10 earns a certain 40. A planner told only the mean cannot see this;
+// one that averages over the posterior can.
+func TestPosteriorPredictivePlanningBeatsPointEstimate(t *testing.T) {
+	cfg := agents.MCTSConfig[[]float64, int]{
+		Simulations:     600,
+		MaxTreeDepth:    2,
+		RolloutMaxSteps: 2,
+		Rollout:         agents.UniformRandomRollout[[]float64, int](),
+	}
+
+	// Planning at the posterior mean.
+	pointEnv := newNewsvendorEnvironment(t, nil, 25)
+	atMean, _, err := agents.RunMCTSSearch(
+		pointEnv, pointEnv.InitialState(), cfg, 11, cfg.Simulations)
+	if err != nil {
+		t.Fatalf("RunMCTSSearch: %v", err)
+	}
+
+	// Planning over the posterior.
+	posteriorEnv := newNewsvendorEnvironment(t, demandPosterior, 25)
+	underPosterior, _, err := agents.RunChanceMCTSSearch(
+		posteriorEnv, posteriorEnv.InitialState(), cfg, 11, cfg.Simulations)
+	if err != nil {
+		t.Fatalf("RunChanceMCTSSearch: %v", err)
+	}
+
+	t.Logf("at the posterior mean: order %v | over the posterior: order %v",
+		orderQuantities[atMean][0], orderQuantities[underPosterior][0])
+
+	if orderQuantities[atMean][0] != 25 {
+		t.Errorf("planning at the mean should order 25 (its best response to demand=25), got %v",
+			orderQuantities[atMean][0])
+	}
+	if orderQuantities[underPosterior][0] != 10 {
+		t.Errorf("planning over the posterior should order 10 (expected profit 40, against "+
+			"-25 for ordering 25), got %v", orderQuantities[underPosterior][0])
 	}
 }

--- a/pkg/agents/simulation_environment_test.go
+++ b/pkg/agents/simulation_environment_test.go
@@ -743,3 +743,104 @@ func TestSimulationEnvironmentLegalFilter(t *testing.T) {
 		t.Errorf("charged battery should offer 3 actions, got %v", legal)
 	}
 }
+
+// newLongBatteryEnvironment is the battery problem over a longer horizon, so a
+// rollout capped well below it truncates on almost every simulation.
+func newLongBatteryEnvironment(t *testing.T, horizon int) *agents.SimulationEnvironment {
+	t.Helper()
+	gen := simulator.NewConfigGenerator()
+	gen.SetSimulation(&simulator.SimulationConfig{
+		OutputCondition:      &simulator.NilOutputCondition{},
+		OutputFunction:       &simulator.NilOutputFunction{},
+		TerminationCondition: &simulator.NumberOfStepsTerminationCondition{MaxNumberOfSteps: 1},
+		TimestepFunction:     &simulator.ConstantTimestepFunction{Stepsize: 1.0},
+		InitTimeValue:        0,
+	})
+	gen.SetPartition(&simulator.PartitionConfig{
+		Name:              "price",
+		Iteration:         &cyclicPriceIteration{},
+		InitStateValues:   []float64{priceCycle[3], 3},
+		StateHistoryDepth: 1,
+		Seed:              0,
+	})
+	gen.SetPartition(&simulator.PartitionConfig{
+		Name:              "battery",
+		Iteration:         &batteryIteration{capacity: 1},
+		Params:            simulator.NewParams(map[string][]float64{"dispatch": {0}}),
+		InitStateValues:   []float64{0, 0},
+		StateHistoryDepth: 1,
+		Seed:              0,
+	})
+	settings, impl := gen.GenerateConfigs()
+	impl.ExecutionStrategy = &simulator.InlineExecution{}
+	return agents.NewSimulationEnvironment(settings, impl, agents.SimulationEnvironmentSpec{
+		Actions:         [][]float64{{1}, {0}, {-1}},
+		ActionPartition: "battery",
+		ActionParam:     "dispatch",
+		Horizon:         horizon,
+		Reward: func(rows map[string][]float64) float64 {
+			return -rows["battery"][1] * rows["price"][0]
+		},
+		MinReturn:    -100 * float64(horizon),
+		MaxReturn:    100 * float64(horizon),
+		ScenarioSeed: 1,
+	})
+}
+
+// planWithRollout plans MPC-style under a supplied rollout and returns the
+// achieved return.
+func planWithRollout(
+	t *testing.T,
+	env *agents.SimulationEnvironment,
+	rollout agents.MCTSRolloutFn[[]float64, int],
+	rolloutMaxSteps, sims int,
+) float64 {
+	t.Helper()
+	cfg := agents.MCTSConfig[[]float64, int]{
+		Simulations:     sims,
+		MaxTreeDepth:    6,
+		RolloutMaxSteps: rolloutMaxSteps,
+		Rollout:         rollout,
+	}
+	state := env.InitialState()
+	for step := 0; ; step++ {
+		if _, done := env.Terminal(state); done {
+			return env.Return(state)
+		}
+		best, _, err := agents.RunChanceMCTSSearch(env, state, cfg, uint64(step)+5, sims)
+		if err != nil {
+			t.Fatalf("RunChanceMCTSSearch: %v", err)
+		}
+		state, err = env.Apply(state, best)
+		if err != nil {
+			t.Fatalf("Apply: %v", err)
+		}
+	}
+}
+
+// TestProgressProxyScoresTruncatedRollouts is the reason SimulationEnvironment
+// has a Progress proxy. When the horizon is much longer than a rollout is
+// allowed to run, a plain rollout truncates without a score on nearly every
+// simulation, leaving the search to explore on visit counts alone. Scoring the
+// truncated state instead should plan better.
+func TestProgressProxyScoresTruncatedRollouts(t *testing.T) {
+	const horizon = 24
+	const rolloutMaxSteps = 3 // far below the horizon: nearly every rollout truncates
+	const sims = 300
+
+	plain := planWithRollout(t, newLongBatteryEnvironment(t, horizon),
+		agents.UniformRandomRollout[[]float64, int](), rolloutMaxSteps, sims)
+
+	scored := newLongBatteryEnvironment(t, horizon)
+	withProgress := planWithRollout(t, scored,
+		agents.FromProgress(
+			agents.UniformRandomRollout[[]float64, int](), scored.Progress),
+		rolloutMaxSteps, sims)
+
+	t.Logf("horizon %d, rollout capped at %d: plain %.0f, progress-scored %.0f",
+		horizon, rolloutMaxSteps, plain, withProgress)
+
+	if withProgress <= plain {
+		t.Errorf("progress scoring did not help: %.0f vs %.0f", withProgress, plain)
+	}
+}

--- a/pkg/api/macros.go
+++ b/pkg/api/macros.go
@@ -158,6 +158,14 @@ func resolveIterations(partitions []simulator.PartitionConfig) error {
 	return nil
 }
 
+// RunMacros expands and runs a config's macros: tier and returns the resulting
+// storage. It is the programmatic form of Run for macro configs: Run prints and
+// exits, which suits a CLI and makes it unusable from a caller that wants the
+// output or the error — a downstream driving a registered environment, say.
+func RunMacros(config *ApiRunConfig) (*simulator.StateTimeStorage, error) {
+	return runMacros(config)
+}
+
 // runMacros expands and runs each macro in turn, returning the resulting storage.
 // A live macro (evolution_strategy_optimisation) runs its partitions as a fresh
 // simulation; an against-storage macro runs against the data: storage, which is

--- a/pkg/api/macros_planning.go
+++ b/pkg/api/macros_planning.go
@@ -99,11 +99,74 @@ type planningParametersSpec struct {
 	// rows are a trajectory of point estimates, not draws.
 	SamplesFrom *planningSamplesRef   `yaml:"samples_from,omitempty"`
 	Targets     []planningParamTarget `yaml:"targets"`
+	// Weights is how much credence each sample carries, one per sample. This is
+	// what an inference tier hands a planner when its samples are NOT already
+	// distributed as the posterior — SMC particles, say, whose weights are the
+	// posterior. Omit when the samples were drawn from the posterior itself.
+	Weights []float64 `yaml:"weights,omitempty"`
+	// WeightsFrom reads those weights from a recorded partition's final row,
+	// so a calibration's own output can be handed straight over.
+	WeightsFrom *dataRefSpec `yaml:"weights_from,omitempty"`
 	// Belief turns on in-tree belief updating, so the planner can value an action
 	// for what it reveals and not only for what it pays. It costs a model step
 	// per sample on every transition, so keep the sample set small — a run with
 	// hundreds of draws should plan on a fixed draw instead.
 	Belief *planningBeliefSpec `yaml:"belief,omitempty"`
+}
+
+// resolveWeights produces the initial credence over the samples, or nil for
+// equal credence.
+func (p *planningParametersSpec) resolveWeights(
+	storage *simulator.StateTimeStorage,
+	sampleCount int,
+) ([]float64, error) {
+	if len(p.Weights) > 0 && p.WeightsFrom != nil {
+		return nil, fmt.Errorf(
+			"mcts_planning parameters: set weights: or weights_from:, not both")
+	}
+	if len(p.Weights) > 0 {
+		if len(p.Weights) != sampleCount {
+			return nil, fmt.Errorf(
+				"mcts_planning parameters: %d weights for %d samples — there must be one "+
+					"weight per sample", len(p.Weights), sampleCount)
+		}
+		return p.Weights, nil
+	}
+	if p.WeightsFrom == nil {
+		return nil, nil
+	}
+	if storage == nil {
+		return nil, fmt.Errorf(
+			"mcts_planning parameters.weights_from needs a data: block, or an earlier "+
+				"macro, producing %q", p.WeightsFrom.PartitionName)
+	}
+	rows := storage.GetValues(p.WeightsFrom.PartitionName)
+	if len(rows) == 0 {
+		return nil, fmt.Errorf(
+			"mcts_planning parameters.weights_from: no recorded data for partition %q",
+			p.WeightsFrom.PartitionName)
+	}
+	// The final row: the weights an inference run finished holding.
+	row := rows[len(rows)-1]
+	weights := row
+	if indices := p.WeightsFrom.ValueIndices; len(indices) > 0 {
+		weights = make([]float64, len(indices))
+		for i, index := range indices {
+			if index < 0 || index >= len(row) {
+				return nil, fmt.Errorf(
+					"mcts_planning parameters.weights_from: value index %d outside the "+
+						"%d-wide rows of %q", index, len(row), p.WeightsFrom.PartitionName)
+			}
+			weights[i] = row[index]
+		}
+	}
+	if len(weights) != sampleCount {
+		return nil, fmt.Errorf(
+			"mcts_planning parameters.weights_from: %q supplies %d weights for %d samples "+
+				"— there must be one weight per sample",
+			p.WeightsFrom.PartitionName, len(weights), sampleCount)
+	}
+	return append([]float64(nil), weights...), nil
 }
 
 // planningSamplesRef reads draws from recorded rows, discarding a burn-in.
@@ -255,6 +318,7 @@ func (s *mctsPlanningSpec) resolveLive(
 	}
 
 	var samples [][]float64
+	var weights []float64
 	var targets []agents.SimulationParamTarget
 	var belief *agents.BeliefSpec
 	if s.Parameters != nil {
@@ -263,6 +327,10 @@ func (s *mctsPlanningSpec) resolveLive(
 			return nil, 0, 0, err
 		}
 		samples = resolved
+		weights, err = s.Parameters.resolveWeights(storage, len(samples))
+		if err != nil {
+			return nil, 0, 0, err
+		}
 		for _, target := range s.Parameters.Targets {
 			if err := requireModelPartition(
 				settings, target.Partition, "parameters.targets"); err != nil {
@@ -307,6 +375,7 @@ func (s *mctsPlanningSpec) resolveLive(
 			ScenarioSeed:     s.ScenarioSeed,
 			Progress:         progress,
 			ParameterSamples: samples,
+			ParameterWeights: weights,
 			ParameterTargets: targets,
 			Belief:           belief,
 		})

--- a/pkg/api/macros_planning.go
+++ b/pkg/api/macros_planning.go
@@ -85,14 +85,34 @@ type mctsPlanningSpec struct {
 // come either inline or from a partition recorded in the data: tier — one row
 // per draw — which is how a calibration's own output feeds the planner.
 type planningParametersSpec struct {
-	Samples     [][]float64           `yaml:"samples,omitempty"`
-	SamplesFrom *dataRefSpec          `yaml:"samples_from,omitempty"`
+	Samples [][]float64 `yaml:"samples,omitempty"`
+	// SamplesFrom reads one draw per recorded row. posterior_estimation's sampler
+	// partition already draws from the running posterior each step, so its
+	// recorded rows are the posterior sample set — no further sampling step is
+	// needed, and an SMC proposal partition works the same way.
+	//
+	// Set BurnIn past the rows produced while the estimate was still moving.
+	// Those carry the convergence transient, not the posterior, and a planner
+	// reading them plans against a spread the inference has already ruled out.
+	//
+	// Pointing this at a posterior MEAN partition is a mistake that runs: those
+	// rows are a trajectory of point estimates, not draws.
+	SamplesFrom *planningSamplesRef   `yaml:"samples_from,omitempty"`
 	Targets     []planningParamTarget `yaml:"targets"`
 	// Belief turns on in-tree belief updating, so the planner can value an action
 	// for what it reveals and not only for what it pays. It costs a model step
 	// per sample on every transition, so keep the sample set small — a run with
 	// hundreds of draws should plan on a fixed draw instead.
 	Belief *planningBeliefSpec `yaml:"belief,omitempty"`
+}
+
+// planningSamplesRef reads draws from recorded rows, discarding a burn-in.
+type planningSamplesRef struct {
+	PartitionName string `yaml:"partition_name"`
+	ValueIndices  []int  `yaml:"value_indices,omitempty"`
+	// BurnIn drops this many leading rows, which is how the transient of a
+	// still-converging inference is kept out of the sample set.
+	BurnIn int `yaml:"burn_in,omitempty"`
 }
 
 // planningBeliefSpec names what the decision-maker observes and how sharply that
@@ -118,16 +138,13 @@ func (p *planningParametersSpec) resolve(
 		return nil, fmt.Errorf(
 			"mcts_planning parameters needs targets: saying where each sample's values go")
 	}
-	if len(p.Samples) > 0 && p.SamplesFrom != nil {
+	if (len(p.Samples) > 0) == (p.SamplesFrom != nil) {
 		return nil, fmt.Errorf(
-			"mcts_planning parameters: set samples: or samples_from:, not both")
+			"mcts_planning parameters needs exactly one of samples: or samples_from: " +
+				"to draw from")
 	}
 	if len(p.Samples) > 0 {
 		return p.Samples, nil
-	}
-	if p.SamplesFrom == nil {
-		return nil, fmt.Errorf(
-			"mcts_planning parameters needs samples: or samples_from: to draw from")
 	}
 	if storage == nil {
 		return nil, fmt.Errorf(
@@ -140,6 +157,12 @@ func (p *planningParametersSpec) resolve(
 			"mcts_planning parameters.samples_from: no recorded data for partition %q",
 			p.SamplesFrom.PartitionName)
 	}
+	if p.SamplesFrom.BurnIn >= len(rows) {
+		return nil, fmt.Errorf(
+			"mcts_planning parameters.samples_from: burn_in %d discards all %d recorded "+
+				"rows of %q", p.SamplesFrom.BurnIn, len(rows), p.SamplesFrom.PartitionName)
+	}
+	rows = rows[p.SamplesFrom.BurnIn:]
 	indices := p.SamplesFrom.ValueIndices
 	samples := make([][]float64, len(rows))
 	for i, row := range rows {

--- a/pkg/api/macros_planning.go
+++ b/pkg/api/macros_planning.go
@@ -88,6 +88,18 @@ type planningParametersSpec struct {
 	Samples     [][]float64           `yaml:"samples,omitempty"`
 	SamplesFrom *dataRefSpec          `yaml:"samples_from,omitempty"`
 	Targets     []planningParamTarget `yaml:"targets"`
+	// Belief turns on in-tree belief updating, so the planner can value an action
+	// for what it reveals and not only for what it pays. It costs a model step
+	// per sample on every transition, so keep the sample set small — a run with
+	// hundreds of draws should plan on a fixed draw instead.
+	Belief *planningBeliefSpec `yaml:"belief,omitempty"`
+}
+
+// planningBeliefSpec names what the decision-maker observes and how sharply that
+// observation discriminates between parameter samples.
+type planningBeliefSpec struct {
+	ObservationPartition string  `yaml:"observation_partition"`
+	Variance             float64 `yaml:"variance"`
 }
 
 // planningParamTarget routes part of each sample into the model.
@@ -221,6 +233,7 @@ func (s *mctsPlanningSpec) resolveLive(
 
 	var samples [][]float64
 	var targets []agents.SimulationParamTarget
+	var belief *agents.BeliefSpec
 	if s.Parameters != nil {
 		resolved, err := s.Parameters.resolve(storage)
 		if err != nil {
@@ -237,6 +250,22 @@ func (s *mctsPlanningSpec) resolveLive(
 				Param:     target.Param,
 				Indices:   target.Indices,
 			})
+		}
+		if s.Parameters.Belief != nil {
+			if err := requireModelPartition(settings,
+				s.Parameters.Belief.ObservationPartition,
+				"parameters.belief.observation_partition"); err != nil {
+				return nil, 0, 0, err
+			}
+			if s.Parameters.Belief.Variance <= 0 {
+				return nil, 0, 0, fmt.Errorf(
+					"mcts_planning parameters.belief needs variance: > 0 (the observation " +
+						"noise the belief update scores against)")
+			}
+			belief = &agents.BeliefSpec{
+				ObservationPartition: s.Parameters.Belief.ObservationPartition,
+				Variance:             s.Parameters.Belief.Variance,
+			}
 		}
 	}
 
@@ -256,6 +285,7 @@ func (s *mctsPlanningSpec) resolveLive(
 			Progress:         progress,
 			ParameterSamples: samples,
 			ParameterTargets: targets,
+			Belief:           belief,
 		})
 
 	// The encoded state is already []float64, so the self-play topology's codec

--- a/pkg/api/macros_planning.go
+++ b/pkg/api/macros_planning.go
@@ -39,6 +39,12 @@ type mctsPlanningSpec struct {
 	// partition is the usual way, which keeps the reward in the expressions DSL
 	// rather than inventing a second one.
 	RewardPartition string `yaml:"reward_partition"`
+	// ProgressPartition optionally names a model partition whose state[0] scores
+	// the current position in [0,1] — a win probability, a normalised margin.
+	// It is what a rollout is scored by when it hits its step limit before the
+	// horizon, which is the common case once the horizon exceeds
+	// rollout_max_steps. Unset falls back to the reward banked so far.
+	ProgressPartition string `yaml:"progress_partition,omitempty"`
 	// Discount is the per-step discount factor (default 1, undiscounted).
 	Discount float64 `yaml:"discount,omitempty"`
 	// ReturnRange bounds the achievable return as [min, max]. UCB1 needs a
@@ -129,6 +135,17 @@ func (s *mctsPlanningSpec) resolveLive(
 	if err := requireModelPartition(settings, s.ActionPartition, "action_partition"); err != nil {
 		return nil, 0, 0, err
 	}
+	var progress func(rows map[string][]float64) (float64, bool)
+	if s.ProgressPartition != "" {
+		if err := requireModelPartition(
+			settings, s.ProgressPartition, "progress_partition"); err != nil {
+			return nil, 0, 0, err
+		}
+		progressPartition := s.ProgressPartition
+		progress = func(rows map[string][]float64) (float64, bool) {
+			return rows[progressPartition][0], true
+		}
+	}
 
 	environment := agents.NewSimulationEnvironment(
 		settings, implementations, agents.SimulationEnvironmentSpec{
@@ -143,6 +160,7 @@ func (s *mctsPlanningSpec) resolveLive(
 			MinReturn:    s.ReturnRange[0],
 			MaxReturn:    s.ReturnRange[1],
 			ScenarioSeed: s.ScenarioSeed,
+			Progress:     progress,
 		})
 
 	// The encoded state is already []float64, so the self-play topology's codec
@@ -150,7 +168,14 @@ func (s *mctsPlanningSpec) resolveLive(
 	selfPlay := macros.MCTSSelfPlaySpec[[]float64, int]{
 		Env: environment,
 		Cfg: agents.MCTSConfig[[]float64, int]{
-			Rollout: agents.UniformRandomRollout[[]float64, int](),
+			// A rollout that runs out of steps before the horizon is scored by
+			// the progress proxy rather than discarded, which is what keeps the
+			// search informed when the horizon exceeds rollout_max_steps.
+			Rollout: agents.FromProgress(
+				agents.UniformRandomRollout[[]float64, int](),
+				environment.Progress,
+			),
+			Progress: environment.Progress,
 		},
 		InitState: environment.InitialState(),
 		Decoder: func(row []float64) ([]float64, error) {

--- a/pkg/api/macros_planning.go
+++ b/pkg/api/macros_planning.go
@@ -66,6 +66,10 @@ type mctsPlanningSpec struct {
 	// costs nothing when the model is deterministic — which is the case worth
 	// setting this for.
 	PinnedNoise bool `yaml:"pinned_noise,omitempty"`
+	// Parameters turns the run into posterior-predictive planning: the search
+	// averages over draws of the model's uncertain parameters instead of
+	// committing to a point estimate.
+	Parameters *planningParametersSpec `yaml:"parameters,omitempty"`
 	// Model is the forward model being planned over.
 	Model planningModelSpec `yaml:"model"`
 	// Search hyperparameters; unset values fall back to the agents defaults.
@@ -75,6 +79,74 @@ type mctsPlanningSpec struct {
 	RolloutMaxSteps int     `yaml:"rollout_max_steps,omitempty"`
 	Seed            uint64  `yaml:"seed,omitempty"`
 	Timestep        float64 `yaml:"timestep,omitempty"`
+}
+
+// planningParametersSpec supplies the posterior the search plans over. Samples
+// come either inline or from a partition recorded in the data: tier — one row
+// per draw — which is how a calibration's own output feeds the planner.
+type planningParametersSpec struct {
+	Samples     [][]float64           `yaml:"samples,omitempty"`
+	SamplesFrom *dataRefSpec          `yaml:"samples_from,omitempty"`
+	Targets     []planningParamTarget `yaml:"targets"`
+}
+
+// planningParamTarget routes part of each sample into the model.
+type planningParamTarget struct {
+	Partition string `yaml:"partition"`
+	Param     string `yaml:"param"`
+	Indices   []int  `yaml:"indices"`
+}
+
+// resolve produces the sample set, reading it out of storage when the config
+// points at a recorded partition rather than listing draws inline.
+func (p *planningParametersSpec) resolve(
+	storage *simulator.StateTimeStorage,
+) ([][]float64, error) {
+	if len(p.Targets) == 0 {
+		return nil, fmt.Errorf(
+			"mcts_planning parameters needs targets: saying where each sample's values go")
+	}
+	if len(p.Samples) > 0 && p.SamplesFrom != nil {
+		return nil, fmt.Errorf(
+			"mcts_planning parameters: set samples: or samples_from:, not both")
+	}
+	if len(p.Samples) > 0 {
+		return p.Samples, nil
+	}
+	if p.SamplesFrom == nil {
+		return nil, fmt.Errorf(
+			"mcts_planning parameters needs samples: or samples_from: to draw from")
+	}
+	if storage == nil {
+		return nil, fmt.Errorf(
+			"mcts_planning parameters.samples_from needs a data: block to read %q from",
+			p.SamplesFrom.PartitionName)
+	}
+	rows := storage.GetValues(p.SamplesFrom.PartitionName)
+	if len(rows) == 0 {
+		return nil, fmt.Errorf(
+			"mcts_planning parameters.samples_from: no recorded data for partition %q",
+			p.SamplesFrom.PartitionName)
+	}
+	indices := p.SamplesFrom.ValueIndices
+	samples := make([][]float64, len(rows))
+	for i, row := range rows {
+		if len(indices) == 0 {
+			samples[i] = append([]float64(nil), row...)
+			continue
+		}
+		draw := make([]float64, len(indices))
+		for j, index := range indices {
+			if index < 0 || index >= len(row) {
+				return nil, fmt.Errorf(
+					"mcts_planning parameters.samples_from: value index %d outside the "+
+						"%d-wide rows of %q", index, len(row), p.SamplesFrom.PartitionName)
+			}
+			draw[j] = row[index]
+		}
+		samples[i] = draw
+	}
+	return samples, nil
 }
 
 // planningModelSpec is the forward model: ordinary partitions, plus the timestep
@@ -96,7 +168,7 @@ func (s *mctsPlanningSpec) resolve(
 }
 
 func (s *mctsPlanningSpec) resolveLive(
-	*simulator.StateTimeStorage,
+	storage *simulator.StateTimeStorage,
 ) ([]*simulator.PartitionConfig, int, float64, error) {
 	if s.Name == "" {
 		return nil, 0, 0, fmt.Errorf("mcts_planning needs a name: (it prefixes the partition names)")
@@ -147,6 +219,27 @@ func (s *mctsPlanningSpec) resolveLive(
 		}
 	}
 
+	var samples [][]float64
+	var targets []agents.SimulationParamTarget
+	if s.Parameters != nil {
+		resolved, err := s.Parameters.resolve(storage)
+		if err != nil {
+			return nil, 0, 0, err
+		}
+		samples = resolved
+		for _, target := range s.Parameters.Targets {
+			if err := requireModelPartition(
+				settings, target.Partition, "parameters.targets"); err != nil {
+				return nil, 0, 0, err
+			}
+			targets = append(targets, agents.SimulationParamTarget{
+				Partition: target.Partition,
+				Param:     target.Param,
+				Indices:   target.Indices,
+			})
+		}
+	}
+
 	environment := agents.NewSimulationEnvironment(
 		settings, implementations, agents.SimulationEnvironmentSpec{
 			Actions:         s.Actions,
@@ -156,11 +249,13 @@ func (s *mctsPlanningSpec) resolveLive(
 			Reward: func(rows map[string][]float64) float64 {
 				return rows[rewardPartition][0]
 			},
-			Discount:     s.Discount,
-			MinReturn:    s.ReturnRange[0],
-			MaxReturn:    s.ReturnRange[1],
-			ScenarioSeed: s.ScenarioSeed,
-			Progress:     progress,
+			Discount:         s.Discount,
+			MinReturn:        s.ReturnRange[0],
+			MaxReturn:        s.ReturnRange[1],
+			ScenarioSeed:     s.ScenarioSeed,
+			Progress:         progress,
+			ParameterSamples: samples,
+			ParameterTargets: targets,
 		})
 
 	// The encoded state is already []float64, so the self-play topology's codec

--- a/pkg/api/macros_planning_test.go
+++ b/pkg/api/macros_planning_test.go
@@ -138,3 +138,30 @@ func TestMCTSPlanningMacroValidation(t *testing.T) {
 		})
 	}
 }
+
+// TestMCTSPlanningProgressPartition covers the progress proxy's config surface:
+// a named partition is used to score rollouts that truncate, and a typo is an
+// error rather than a silently unscored search.
+func TestMCTSPlanningProgressPartition(t *testing.T) {
+	t.Run("a named progress partition resolves", func(t *testing.T) {
+		cfg := strings.Replace(planningConfig,
+			"  reward_partition: revenue",
+			"  reward_partition: revenue\n  progress_partition: revenue", 1)
+		if cfg == planningConfig {
+			t.Fatal("test setup: reward_partition not found")
+		}
+		if err := macroConfigError(t, cfg); err != nil {
+			t.Fatalf("progress_partition should resolve: %v", err)
+		}
+	})
+
+	t.Run("an unknown progress partition is an error", func(t *testing.T) {
+		cfg := strings.Replace(planningConfig,
+			"  reward_partition: revenue",
+			"  reward_partition: revenue\n  progress_partition: absent", 1)
+		err := macroConfigError(t, cfg)
+		if err == nil || !strings.Contains(err.Error(), `no model partition named "absent"`) {
+			t.Errorf("expected a named error for an unknown progress partition, got: %v", err)
+		}
+	})
+}

--- a/pkg/api/macros_planning_test.go
+++ b/pkg/api/macros_planning_test.go
@@ -315,3 +315,108 @@ func TestMCTSPlanningWithBeliefUpdating(t *testing.T) {
 		t.Errorf("a planner that can learn should probe first, it chose %v", opening)
 	}
 }
+
+// TestMCTSPlanningFromAnInferredPosterior is the chain the planning tier exists
+// for: infer a parameter from data, then plan under what was inferred —
+// uncertainty included — in one config with no Go.
+//
+// posterior_estimation already samples the running posterior each step, so its
+// sampler partition's recorded rows ARE the posterior sample set. The planner
+// reads them directly, past a burn-in that drops the rows produced while the
+// estimate was still moving.
+//
+// The data has a mean of 3, recovered from an off-truth prior of 0. The decision
+// is a newsvendor whose right order depends on that mean, so the plan is only
+// right if the inference actually reached the truth.
+func TestMCTSPlanningFromAnInferredPosterior(t *testing.T) {
+	const cfg = `data:
+  steps: 2500
+  timestep: 1.0
+  partitions:
+  - name: observations
+    iteration: {type: data_generation, likelihood: {type: normal}}
+    params: {mean: [3.0], covariance_matrix: [0.25]}
+    init_state_values: [3.0]
+    state_history_depth: 2500
+    seed: 17
+macros:
+- type: posterior_estimation
+  log_norm: {name: post_log_norm, default: 0.0}
+  mean: {name: post_mean, default: [0.0]}
+  covariance: {name: post_cov, default: [4.0]}
+  sampler:
+    name: post_sampler
+    default: [0.0]
+    distribution:
+      likelihood: {type: normal, allow_default_covariance_fallback: true}
+      params: {default_covariance: [4.0], cov_burn_in_steps: [100]}
+      params_from_upstream:
+        mean: {upstream: post_mean}
+        covariance_matrix: {upstream: post_cov}
+  comparison:
+    name: post_likelihood
+    model:
+      likelihood: {type: normal}
+      params: {covariance_matrix: [0.25]}
+      params_from_upstream:
+        mean: {upstream: post_sampler}
+    data: {partition_name: observations}
+    window:
+      data: [{partition_name: observations}]
+      depth: 100
+    window_data_history_depth: {observations: 100}
+  past_discount: 0.999
+  memory_depth: 100
+  seed: 1234
+- type: mcts_planning
+  name: plan
+  steps: 2
+  horizon: 1
+  sims_per_decision: 400
+  seed: 3
+  return_range: [-200, 200]
+  actions: [[1], [3], [9]]
+  action_partition: order
+  action_param: param_values
+  reward_partition: profit
+  parameters:
+    # The sampler's own draws, after the estimate has settled.
+    samples_from: {partition_name: post_sampler, burn_in: 2000}
+    targets: [{partition: profit, param: demand, indices: [0]}]
+  model:
+    partitions:
+    - name: order
+      iteration: {type: param_values}
+      params: {param_values: [0.0]}
+      init_state_values: [0.0]
+      state_history_depth: 1
+      seed: 0
+    - name: profit
+      iteration:
+        type: expression
+        fields: [{name: p}]
+        outputs: ["10 * min(quantity, demand) - 6 * quantity"]
+      params: {quantity: [0.0], demand: [0.0]}
+      params_from_upstream:
+        quantity: {upstream: order}
+      init_state_values: [0.0]
+      state_history_depth: 1
+      seed: 0
+`
+	// A live macro runs in its own context and replaces the storage, so the
+	// posterior partitions are no longer readable by the time the plan is out.
+	out := runMacroConfig(t, cfg)
+	rows := out["plan_apply"]
+	if len(rows) < 3 {
+		t.Fatalf("expected the plan to be recorded, got %d rows", len(rows))
+	}
+	ordered := rows[len(rows)-1][2]
+	t.Logf("planning under the inferred posterior ordered %v (demand truly averages 3)",
+		ordered)
+
+	// Ordering 3 suits demand near 3: 1 leaves profit unclaimed and 9 buys stock
+	// that cannot be sold.
+	if ordered != 3 {
+		t.Errorf("ordered %v, want 3 — the plan should follow the inferred demand", ordered)
+	}
+}

--- a/pkg/api/macros_planning_test.go
+++ b/pkg/api/macros_planning_test.go
@@ -165,3 +165,79 @@ func TestMCTSPlanningProgressPartition(t *testing.T) {
 		}
 	})
 }
+
+// TestMCTSPlanningOverAPosterior is posterior-predictive planning as config: the
+// data: tier records a spread of parameter draws, and the planner averages over
+// them instead of committing to a point estimate.
+//
+// The model is the newsvendor, where the two provably disagree. Demand is 10 in
+// five draws of six and 100 in the sixth, so its mean is 25. Ordering 25 is the
+// best response to demand=25 (profit 100) but loses money against the actual
+// spread (−25), while ordering 10 earns a certain 40.
+func TestMCTSPlanningOverAPosterior(t *testing.T) {
+	const cfg = `data:
+  steps: 5
+  timestep: 1.0
+  partitions:
+  - name: demand_draws
+    iteration:
+      type: expression
+      fields: [{name: d}]
+      bindings:
+      - {name: phase, expr: "step - 6 * floor(step / 6)"}
+      outputs: ["where(phase < 5, 10, 100)"]
+    init_state_values: [10.0]
+    state_history_depth: 1
+    seed: 0
+macros:
+- type: mcts_planning
+  name: plan
+  steps: 2
+  horizon: 1
+  sims_per_decision: 600
+  seed: 11
+  return_range: [-700, 300]
+  actions: [[10], [25], [100]]
+  action_partition: order
+  action_param: param_values
+  reward_partition: profit
+  parameters:
+    samples_from: {partition_name: demand_draws}
+    targets: [{partition: profit, param: demand, indices: [0]}]
+  model:
+    partitions:
+    - name: order
+      iteration: {type: param_values}
+      params: {param_values: [0.0]}
+      init_state_values: [0.0]
+      state_history_depth: 1
+      seed: 0
+    - name: profit
+      iteration:
+        type: expression
+        fields: [{name: p}]
+        outputs: ["10 * min(quantity, demand) - 6 * quantity"]
+      params: {quantity: [0.0], demand: [25.0]}
+      params_from_upstream:
+        quantity: {upstream: order}
+      init_state_values: [0.0]
+      state_history_depth: 1
+      seed: 0
+`
+	out := runMacroConfig(t, cfg)
+	rows := out["plan_apply"]
+	if len(rows) < 2 {
+		t.Fatalf("expected the plan to be recorded, got %d rows", len(rows))
+	}
+	// The order actually placed shows up in the order partition's slot of the
+	// encoded state: [step, return, order(1), profit(1), sample index]. The
+	// first outer step is the sentinel one where the search has not yet produced
+	// a decision, so the applied action appears from the second.
+	ordered := rows[len(rows)-1][2]
+	t.Logf("planning over the recorded posterior ordered %v", ordered)
+
+	if ordered != 10 {
+		t.Errorf("posterior-predictive planning ordered %v, want 10 — ordering 25 is only "+
+			"right if demand really is its mean", ordered)
+	}
+}

--- a/pkg/api/macros_planning_test.go
+++ b/pkg/api/macros_planning_test.go
@@ -241,3 +241,77 @@ macros:
 			"right if demand really is its mean", ordered)
 	}
 }
+
+// TestMCTSPlanningWithBeliefUpdating is value of information as config: the
+// planner opens by probing, which pays nothing, because doing so tells it which
+// commitment is right.
+//
+// theta decides which commitment pays and is equally likely to be either, so
+// committing blind is worth zero. Only a planner that updates its belief from
+// the probe's result has a reason to spend a step on it.
+func TestMCTSPlanningWithBeliefUpdating(t *testing.T) {
+	const cfg = `macros:
+- type: mcts_planning
+  name: plan
+  steps: 2
+  horizon: 2
+  sims_per_decision: 800
+  seed: 21
+  return_range: [-30, 30]
+  actions: [[0], [1], [2]]
+  action_partition: choice
+  action_param: param_values
+  reward_partition: payoff
+  parameters:
+    samples: [[0.0], [1.0]]
+    targets: [{partition: signal, param: theta, indices: [0]}, {partition: payoff, param: theta, indices: [0]}]
+    belief: {observation_partition: signal, variance: 0.01}
+  model:
+    partitions:
+    - name: choice
+      iteration: {type: param_values}
+      params: {param_values: [0.0]}
+      init_state_values: [0.0]
+      state_history_depth: 1
+      seed: 0
+    # Probing (choice 0) shows theta; anything else shows 0 whatever theta is,
+    # so it teaches nothing.
+    - name: signal
+      iteration:
+        type: expression
+        fields: [{name: s}]
+        outputs: ["where(choice < 0.5, theta, 0)"]
+      params: {choice: [0.0], theta: [0.0]}
+      params_from_upstream:
+        choice: {upstream: choice}
+      init_state_values: [0.0]
+      state_history_depth: 1
+      seed: 0
+    # Commit A (choice 1) pays when theta is 0, commit B (choice 2) when it is 1.
+    - name: payoff
+      iteration:
+        type: expression
+        fields: [{name: p}]
+        outputs: ["where(choice < 0.5, 0, where(choice < 1.5, 10 - 20 * theta, 0 - 10 + 20 * theta))"]
+      params: {choice: [0.0], theta: [0.0]}
+      params_from_upstream:
+        choice: {upstream: choice}
+      init_state_values: [0.0]
+      state_history_depth: 1
+      seed: 0
+`
+	out := runMacroConfig(t, cfg)
+	rows := out["plan_apply"]
+	if len(rows) < 3 {
+		t.Fatalf("expected the plan to be recorded, got %d rows", len(rows))
+	}
+	// The first real decision lands on the second recorded ply (the first is the
+	// sentinel step where the search has not yet produced one). The choice
+	// partition is the first model partition, so it sits at offset 2.
+	opening := rows[2][2]
+	t.Logf("belief-updating planner opened with choice %v (0 = probe)", opening)
+
+	if opening != 0 {
+		t.Errorf("a planner that can learn should probe first, it chose %v", opening)
+	}
+}

--- a/pkg/api/macros_planning_test.go
+++ b/pkg/api/macros_planning_test.go
@@ -420,3 +420,72 @@ macros:
 		t.Errorf("ordered %v, want 3 — the plan should follow the inferred demand", ordered)
 	}
 }
+
+// TestMCTSPlanningHonoursSampleWeights checks the planner starts from the
+// credence an inference tier attached to each sample. Samples that are not
+// themselves posterior draws — SMC particles, say — carry their posterior in
+// their weights, and ignoring those plans against the proposal instead.
+func TestMCTSPlanningHonoursSampleWeights(t *testing.T) {
+	config := func(weights string) string {
+		return `macros:
+- type: mcts_planning
+  name: plan
+  steps: 2
+  horizon: 1
+  sims_per_decision: 400
+  seed: 3
+  return_range: [-700, 500]
+  actions: [[10], [100]]
+  action_partition: order
+  action_param: param_values
+  reward_partition: profit
+  parameters:
+    samples: [[10.0], [100.0]]
+    weights: ` + weights + `
+    targets: [{partition: profit, param: demand, indices: [0]}]
+  model:
+    partitions:
+    - name: order
+      iteration: {type: param_values}
+      params: {param_values: [0.0]}
+      init_state_values: [0.0]
+      state_history_depth: 1
+      seed: 0
+    - name: profit
+      iteration:
+        type: expression
+        fields: [{name: p}]
+        outputs: ["10 * min(quantity, demand) - 6 * quantity"]
+      params: {quantity: [0.0], demand: [10.0]}
+      params_from_upstream:
+        quantity: {upstream: order}
+      init_state_values: [0.0]
+      state_history_depth: 1
+      seed: 0
+`
+	}
+	for _, testCase := range []struct {
+		name    string
+		weights string
+		want    float64
+	}{
+		{name: "credence on low demand", weights: "[0.95, 0.05]", want: 10},
+		{name: "credence on high demand", weights: "[0.05, 0.95]", want: 100},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			rows := runMacroConfig(t, config(testCase.weights))["plan_apply"]
+			ordered := rows[len(rows)-1][2]
+			if ordered != testCase.want {
+				t.Errorf("ordered %v, want %v — the plan is not following the weights",
+					ordered, testCase.want)
+			}
+		})
+	}
+
+	t.Run("a weight per sample is required", func(t *testing.T) {
+		err := macroConfigError(t, config("[1.0]"))
+		if err == nil {
+			t.Fatal("expected an error for a weight count that does not match the samples")
+		}
+	})
+}

--- a/test/binary_configs_test.go
+++ b/test/binary_configs_test.go
@@ -38,6 +38,8 @@ func TestBinaryRunsExampleConfigs(t *testing.T) {
 		{"cfg/example_config.yaml", "in-process (data-spec iterations)"},
 		{"cfg/example_inference_config.yaml", "in-process (full inference as data + embedded)"},
 		{"cfg/example_data_only_config.yaml", "in-process (fully data)"},
+		{"cfg/example_planning_config.yaml", "in-process (planning over a model)"},
+		{"cfg/example_mcts_config.yaml", "in-process (self-play over a registered environment)"},
 	}
 	for _, config := range configs {
 		t.Run(filepath.Base(config.path), func(t *testing.T) {

--- a/test/mcts_planning_test.go
+++ b/test/mcts_planning_test.go
@@ -1,0 +1,182 @@
+package main
+
+// Integration coverage for the planning tier: whole configs, resolved and run
+// the way a user runs them, asserting on what the plan is worth rather than on
+// whether it executed.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/umbralcalc/stochadex/pkg/api"
+)
+
+// runPlanningConfig writes a config, runs its macros, and returns the recorded
+// output by partition name.
+func runPlanningConfig(t *testing.T, yaml string) map[string][][]float64 {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	storage, err := api.RunMacros(api.LoadApiRunConfigFromYaml(path))
+	if err != nil {
+		t.Fatalf("running the planning config: %v", err)
+	}
+	out := make(map[string][][]float64)
+	for _, name := range storage.GetNames() {
+		out[name] = storage.GetValues(name)
+	}
+	return out
+}
+
+// TestPlanningRecoversAKnownOptimum runs the shipped battery-arbitrage example
+// as a user would and checks the plan is worth what the problem's optimum is
+// worth.
+//
+// The price cycles 10, 10, 90, 90 and the battery holds one unit, so buying
+// cheap and selling dear twice is worth 2 * (90 - 10) = 160. Doing nothing earns
+// zero, and no myopic rule gets there, because buying looks like a pure loss at
+// the moment it has to happen.
+func TestPlanningRecoversAKnownOptimum(t *testing.T) {
+	config, err := os.ReadFile(filepath.Join("..", "cfg", "example_planning_config.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows := runPlanningConfig(t, string(config))["plan_apply"]
+	if len(rows) < 2 {
+		t.Fatalf("expected the driven model to be recorded, got %d rows", len(rows))
+	}
+	// Encoded state: [step, accumulated return, ...partition rows].
+	earned := rows[len(rows)-1][1]
+	t.Logf("the shipped planning example earned %v (optimum 160, doing nothing 0)", earned)
+
+	if earned < 120 {
+		t.Errorf("planned return %v: the search is not exploiting the price cycle", earned)
+	}
+	if earned > 160.0001 {
+		t.Errorf("planned return %v exceeds the achievable optimum of 160", earned)
+	}
+}
+
+// TestPlanningUnderAnInferredPosterior is the chain the planning tier exists
+// for, run end to end as one config: learn a parameter from data, then decide
+// under what was learned, uncertainty included.
+//
+// Demand averages 3 and posterior_estimation recovers it from a prior of 0. The
+// decision is a newsvendor, whose right order depends on that parameter — so a
+// correct plan is evidence the inference reached the truth AND that its spread
+// reached the planner.
+func TestPlanningUnderAnInferredPosterior(t *testing.T) {
+	const config = `data:
+  steps: 2500
+  timestep: 1.0
+  partitions:
+  - name: observations
+    iteration: {type: data_generation, likelihood: {type: normal}}
+    params: {mean: [3.0], covariance_matrix: [0.25]}
+    init_state_values: [3.0]
+    state_history_depth: 2500
+    seed: 17
+macros:
+- type: posterior_estimation
+  log_norm: {name: post_log_norm, default: 0.0}
+  mean: {name: post_mean, default: [0.0]}
+  covariance: {name: post_cov, default: [4.0]}
+  sampler:
+    name: post_sampler
+    default: [0.0]
+    distribution:
+      likelihood: {type: normal, allow_default_covariance_fallback: true}
+      params: {default_covariance: [4.0], cov_burn_in_steps: [100]}
+      params_from_upstream:
+        mean: {upstream: post_mean}
+        covariance_matrix: {upstream: post_cov}
+  comparison:
+    name: post_likelihood
+    model:
+      likelihood: {type: normal}
+      params: {covariance_matrix: [0.25]}
+      params_from_upstream:
+        mean: {upstream: post_sampler}
+    data: {partition_name: observations}
+    window:
+      data: [{partition_name: observations}]
+      depth: 100
+    window_data_history_depth: {observations: 100}
+  past_discount: 0.999
+  memory_depth: 100
+  seed: 1234
+- type: mcts_planning
+  name: plan
+  steps: 2
+  horizon: 1
+  sims_per_decision: 400
+  seed: 3
+  return_range: [-200, 200]
+  actions: [[1], [3], [9]]
+  action_partition: order
+  action_param: param_values
+  reward_partition: profit
+  parameters:
+    samples_from: {partition_name: post_sampler, burn_in: 2000}
+    targets: [{partition: profit, param: demand, indices: [0]}]
+  model:
+    partitions:
+    - name: order
+      iteration: {type: param_values}
+      params: {param_values: [0.0]}
+      init_state_values: [0.0]
+      state_history_depth: 1
+      seed: 0
+    - name: profit
+      iteration:
+        type: expression
+        fields: [{name: p}]
+        outputs: ["10 * min(quantity, demand) - 6 * quantity"]
+      params: {quantity: [0.0], demand: [0.0]}
+      params_from_upstream:
+        quantity: {upstream: order}
+      init_state_values: [0.0]
+      state_history_depth: 1
+      seed: 0
+`
+	rows := runPlanningConfig(t, config)["plan_apply"]
+	if len(rows) < 3 {
+		t.Fatalf("expected the plan to be recorded, got %d rows", len(rows))
+	}
+	ordered := rows[len(rows)-1][2]
+	t.Logf("planning under the inferred posterior ordered %v (demand truly averages 3)", ordered)
+
+	// Ordering 3 suits demand near 3: 1 leaves profit unclaimed, 9 buys stock
+	// that cannot be sold.
+	if ordered != 3 {
+		t.Errorf("ordered %v, want 3 — the plan should follow the inferred demand", ordered)
+	}
+}
+
+// TestSelfPlayRunsFromConfig covers the other half of the decision tier: a
+// search over decision RULES, reached through the environment registry rather
+// than stated as data.
+func TestSelfPlayRunsFromConfig(t *testing.T) {
+	config, err := os.ReadFile(filepath.Join("..", "cfg", "example_mcts_config.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows := runPlanningConfig(t, string(config))["ttt_apply"]
+	if len(rows) < 3 {
+		t.Fatalf("expected a game to be played out, got %d rows", len(rows))
+	}
+	first, last := rows[0], rows[len(rows)-1]
+	same := true
+	for i := range first {
+		if first[i] != last[i] {
+			same = false
+			break
+		}
+	}
+	if same {
+		t.Error("the encoded game state never changed; self-play did not advance the game")
+	}
+}


### PR DESCRIPTION
The three follow-ups to v0.12.0, in the order they unblock each other.

## Progress proxy — long horizons

A rollout capped below the horizon contributed nothing, leaving the search exploring on visit counts alone. That bites whenever `horizon` exceeds `rollout_max_steps`, which is most real decision problems.

`SimulationEnvironment.Progress` scores an unfinished position on the same [0,1] scale `Terminal` uses. It defaults to the reward banked so far — conservative, but far better than discarding the rollout — and `progress_partition:` names a partition holding a domain proxy instead.

- Battery at horizon 24, rollouts capped at 3: planned return **160 → 480**.
- **trywizard's fitted rugby model at its real 80-minute horizon**, previously out of reach. With a logistic win-probability proxy on the score margin, the planner separates a beneficial substitution from a harmful one by **15 points of substitution share at 60 sims, 22 at 240, 33 at 960** — sharpening with budget rather than degrading.

## Posterior-predictive planning

`mcts_planning` can plan over a posterior instead of a point estimate. Samples come inline or from a partition recorded in the `data:` tier — one row per draw — so a calibration's own output feeds the planner.

The design question was *where* the draw happens. Per-transition would model parameter noise, not uncertainty; per-scenario only averages across runs. Here a draw is fixed for a trajectory but varies across a **chance node's outcomes**, so the search itself averages over the posterior. The state carries only the drawn sample's index, so this costs one slot. Belief updating within an episode is deliberately not attempted.

Demonstrated on a newsvendor, where the two **provably** disagree. Demand is 10 in five draws of six and 100 in the sixth, so its mean is 25:

| planner | orders | expected profit |
|---|---|---|
| at the posterior mean | 25 | **−25** |
| over the posterior | 10 | **+40** |

Ordering 25 is the correct response to demand=25 and the wrong response to the actual spread. A planner given only a fitted point cannot see the difference.

## `api.RunMacros`

Found while wiring a downstream onto the environment registry: `Run` prints and calls `log.Fatal`, which suits a CLI and makes it unusable from a caller that wants the storage or the error.

## Downstream: card-game-studio

The registry from #67 had shipped with no downstream using it — proven only by the tictactoe fixture. card-game-studio now registers its rulesvm driver, so **a real Uno deal plays itself from a stochadex config**:

```yaml
macros:
- type: mcts_self_play
  env: {type: cardgame_rulesvm, rules: rules/uno.yaml, players: 2}
```

The engine never parses `rules:` or `players:`. That change lands in card-game-studio once this is tagged; its tests pass against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)