### PR TITLE
Release v0.13.0: stamp changelog

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The stochadex simulation engine, packaged as an installable Claude Code plugin.",
-    "version": "0.12.0"
+    "version": "0.13.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stochadex",
   "description": "Author, run, and analyse a stochastic simulation as a single YAML config for the stochadex engine — no Go, no compilation, no toolchain. Bundles the stochadex-model skill with four validated, converging worked recipes.",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "author": {
     "name": "umbralcalc",
     "email": "umbralcalc@gmail.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,19 @@ an exact version rather than assume stability across minors.
 
 ## [Unreleased]
 
+## [0.13.0] — 2026-07-27
+
 ### Added
+
+- **`mcts_planning` scores truncated rollouts via a progress proxy.** A rollout capped below the
+  horizon used to contribute nothing, leaving the search exploring on visit counts alone — the
+  case that bites whenever `horizon` exceeds `rollout_max_steps`. It is now scored by
+  `agents.SimulationEnvironment.Progress`, which defaults to the reward banked so far and can be
+  overridden with `progress_partition:` naming a partition whose state[0] is a [0,1] position
+  score. On the battery problem at horizon 24 with rollouts capped at 3, the planned return goes
+  from 160 to 480. Validated on a fitted rugby model at its real 80-minute horizon, previously out
+  of reach: the planner's separation between a beneficial and a harmful substitution grows with
+  the search budget (15 points of substitution share at 60 simulations, 22 at 240, 33 at 960).
 
 - **Posterior-predictive planning.** `mcts_planning` can plan over a posterior instead of a point
   estimate: `parameters.samples` lists draws inline, or `parameters.samples_from` reads them from a
@@ -71,15 +83,13 @@ an exact version rather than assume stability across minors.
   that HAVE happened is the inference tier's job, and a planner picks that up through
   `parameters.weights` on the next replan.
 
-### Added
+- **`api.RunMacros`** runs a config's `macros:` tier and returns the storage or an error. `Run`
+  prints and exits, which suits a CLI and makes it unusable from a caller that wants the result —
+  a downstream driving a registered environment, say.
 
-- **`mcts_planning` scores truncated rollouts via a progress proxy.** A rollout capped below the
-  horizon used to contribute nothing, leaving the search exploring on visit counts alone — the
-  case that bites whenever `horizon` exceeds `rollout_max_steps`. It is now scored by
-  `agents.SimulationEnvironment.Progress`, which defaults to the reward banked so far and can be
-  overridden with `progress_partition:` naming a partition whose state[0] is a [0,1] position
-  score. On the battery problem at horizon 24 with rollouts capped at 3, the planned return goes
-  from 160 to 480.
+- **card-game-studio drives the environment registry.** The hook shipped in 0.12.0 had no
+  downstream using it; a rulesvm ruleset is now reachable as `env: {type: cardgame_rulesvm, rules:
+  rules/uno.yaml, players: 2}`, with the engine never parsing that rules format.
 
 ## [0.12.0] — 2026-07-26
 
@@ -1168,7 +1178,8 @@ treat the intermediates as internal, never shipped API.
   stochastic-process formalism (diffusions, Poisson noise, windowed history for noise
   dependencies) before any Go engine existed. The pivot to Go begins Feb 2023.
 
-[Unreleased]: https://github.com/umbralcalc/stochadex/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/umbralcalc/stochadex/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/umbralcalc/stochadex/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/umbralcalc/stochadex/compare/v0.11.0...v0.12.0
 [0.7.0]: https://github.com/umbralcalc/stochadex/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/umbralcalc/stochadex/compare/v0.6.0...v0.6.1


### PR DESCRIPTION
Stamps `[Unreleased]` as **v0.13.0** and bumps the plugin manifests, which `TestPluginManifestsMatchRelease` requires to track the newest released entry.

A **minor** bump, and this one is purely additive — no exported API was removed or changed since v0.12.0, so downstreams upgrade without edits.

While stamping, the two `### Added` blocks that accumulated across separate commits are folded into one, ordered as the capability actually builds up, and two entries that were only in commit messages are recorded: `api.RunMacros` and card-game-studio driving the environment registry.

## What's in it

- **Progress proxy** — rollouts capped below the horizon are scored instead of discarded. Battery at horizon 24 with rollouts capped at 3: planned return 160 → 480. Validated on a fitted rugby model at its real 80-minute horizon, where the planner's separation between a beneficial and a harmful substitution *grows* with the search budget (15 → 22 → 33 points).
- **Posterior-predictive planning** — plan over a posterior rather than a point estimate. On a newsvendor the two provably disagree: planning at the mean orders for a loss of 25, planning over the posterior orders for a certain 40.
- **Composition with `posterior_estimation`** — its sampler partition already draws from the running posterior, so one config can infer a parameter and then plan under it, uncertainty included.
- **Sample weights** — an inference tier hands over what it concluded rather than having it flattened to uniform.
- **In-tree belief updating** — the planner can value an action for what it *reveals*. Costs a model step per sample per transition (2.6× at 2 samples, 30.9× at 32), so it suits small sample sets.
- **`api.RunMacros`** and the **card-game-studio registration**, which retires the "no downstream uses the registry" caveat from 0.12.0.

## Verification

Engine suite green. `test/` green apart from the Postgres integration test, which needs a live DB.

Downstream dependency bumps follow separately — card-game-studio has its registration waiting on this tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)