### PR TITLE
Warn on oversized window data history depth; fix nil params in comparison models

### DIFF
--- a/.claude/skills/stochadex-model/SKILL.md
+++ b/.claude/skills/stochadex-model/SKILL.md
@@ -290,9 +290,11 @@ macro *names* only, so change the numbers and the objective/model, but keep the 
   omit:** the `comparison.model` has to read the sampler via `params_from_upstream`
   (`mean: {upstream: <sampler_name>}`) — the posterior is a loglike-weighted average of the
   *sampled* params, so if the loglike doesn't depend on the sample the mean just drifts. (The macro
-  now panics if you forget, naming the fix.) **Levers:** proposal covariance wide enough to explore
-  prior→truth (diag ≈9); `past_discount` near 1 (0.999) so evidence accumulates instead of being
-  forgotten; enough `steps` to concentrate.
+  now panics if you forget, naming the fix.) **The second thing:** `window_data_history_depth` must
+  *equal* `comparison.window.depth` — too large only warns, and the window then scores the
+  zero-filled tail of the replay buffer instead of your data, freezing the posterior at its prior.
+  **Levers:** proposal covariance wide enough to explore prior→truth (diag ≈9); `past_discount`
+  near 1 (0.999) so evidence accumulates instead of being forgotten; enough `steps` to concentrate.
 - **`recipes/smc_inference.yaml`** — particle-filter inference; write the model once under
   `model.partitions` and it is run once per particle (each with its own random streams), routing
   each particle's parameters in via `param_forwarding`. Recovers the observed stream's mean.

--- a/.claude/skills/stochadex-model/recipes/posterior_estimation.yaml
+++ b/.claude/skills/stochadex-model/recipes/posterior_estimation.yaml
@@ -17,6 +17,11 @@
 #     forgotten each step (0.5 forgets too fast to ever converge).
 #   - enough `steps` for the weighted mean to concentrate (the high-variance 2nd
 #     coordinate — data covariance 9 — leaves a little honest sampling residual).
+#   - `window_data_history_depth` must EQUAL `comparison.window.depth`. Too small
+#     panics; too large (e.g. the run length) does not — the window then replays
+#     the zero-filled tail of the replay buffer, so the loglike scores zeros
+#     instead of the data and the posterior freezes at its prior. The engine only
+#     warns, so read the log if nothing is converging.
 data:
   steps: 2000
   timestep: 1.0

--- a/cfg/example_posterior_macro_config.yaml
+++ b/cfg/example_posterior_macro_config.yaml
@@ -17,6 +17,11 @@
 #     forgotten each step (0.5 forgets too fast to ever converge).
 #   - enough `steps` for the weighted mean to concentrate (the high-variance 2nd
 #     coordinate — data covariance 9 — leaves a little honest sampling residual).
+#   - `window_data_history_depth` must EQUAL `comparison.window.depth`. Too small
+#     panics; too large (e.g. the run length) does not — the window then replays
+#     the zero-filled tail of the replay buffer, so the loglike scores zeros
+#     instead of the data and the posterior freezes at its prior. The engine only
+#     warns, so read the log if nothing is converging.
 data:
   steps: 2000
   timestep: 1.0

--- a/pkg/analysis/partitions.go
+++ b/pkg/analysis/partitions.go
@@ -36,9 +36,7 @@ func NewStateTimeStorageFromPartitions(
 // generated values from the specified partitions.
 //
 // For each existing partition name, windowSizeByPartition[name] sets
-// StateHistoryDepth for the FromStorageIteration replay (default 1). Windowed
-// likelihood helpers need depth ≥ window length; use
-// macros.ValidateWindowDataHistoryDepth with the same map before running.
+// StateHistoryDepth for the FromStorageIteration replay (default 1).
 func AddPartitionsToStateTimeStorage(
 	storage *simulator.StateTimeStorage,
 	partitions []*simulator.PartitionConfig,

--- a/pkg/api/macros_inference_test.go
+++ b/pkg/api/macros_inference_test.go
@@ -170,6 +170,49 @@ func TestPosteriorEstimationMacroConverges(t *testing.T) {
 	}
 }
 
+// TestComparisonModelWithoutParams pins the config a likelihood whose mean comes
+// entirely from upstream naturally produces: a comparison model with no params of
+// its own. The macro constructor Sets "cumulative"/"burn_in_steps" into that map,
+// so before ParameterisedModel.Init allocated it this panicked on assignment to a
+// nil map — an internal failure with nothing pointing at the config that caused
+// it. `params: {}` was the workaround; it should not be needed.
+func TestComparisonModelWithoutParams(t *testing.T) {
+	const noParamsYAML = `data:
+  steps: 60
+  timestep: 1.0
+  partitions:
+  - name: test_data
+    iteration: {type: data_generation, likelihood: {type: poisson}}
+    params: {mean: [3.0]}
+    init_state_values: [3.0]
+    state_history_depth: 20
+    seed: 123
+macros:
+- type: likelihood_comparison
+  name: test_likelihood
+  model:
+    likelihood: {type: poisson}    # takes its mean from upstream, so declares no params
+    params_from_upstream:
+      mean: {upstream: test_data}
+  data: {partition_name: test_data}
+  window:
+    data: [{partition_name: test_data}]
+    depth: 20
+  window_data_history_depth: {test_data: 20}
+`
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(noParamsYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	storage, err := runMacros(LoadApiRunConfigFromYaml(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if values := storage.GetValues("test_likelihood"); len(values) == 0 {
+		t.Fatal("no test_likelihood output recorded")
+	}
+}
+
 // TestLikelihoodMeanFunctionFitMacroEquivalence proves the fit macro is a
 // faithful wrapper of NewLikelihoodMeanFunctionFitPartition (same output as the
 // hand-written Applied), independent of whether the chosen hyperparameters

--- a/pkg/macros/doc.go
+++ b/pkg/macros/doc.go
@@ -50,5 +50,9 @@
 // against the history depths the storage will actually carry —
 // ValidateWindowDataHistoryDepth is the public form of that check, and callers
 // wiring windows through analysis.AddPartitionsToStateTimeStorage should call it
-// with the same map to fail fast instead of underflowing at step time.
+// with the same map to fail fast instead of underflowing at step time. The
+// history depth of a window data partition should *equal* the window depth: a
+// larger one cannot underflow, so it warns rather than panics, but it is the
+// worse failure — the window replays the buffer's zero-filled tail and the
+// likelihood comes out constant and uninformative.
 package macros

--- a/pkg/macros/inference_validate.go
+++ b/pkg/macros/inference_validate.go
@@ -2,9 +2,33 @@ package macros
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/umbralcalc/stochadex/pkg/analysis"
 )
+
+// warnIfWindowDataHistoryTooDeep flags a window data partition whose replay
+// StateHistoryDepth exceeds Window.Depth. Too deep is as broken as too shallow,
+// but silently: general.FromHistoryIteration walks the replay buffer from row
+// StateHistoryDepth-2 down to StateHistoryDepth-Depth-1, so a depth of exactly
+// Window.Depth consumes the buffer, while anything larger anchors the window in
+// rows that are still zero-filled (the buffer starts as zeros and gains one real
+// row per outer step). The likelihood is then computed against zeros for most or
+// all of the run — it comes out near-constant and carries no information about
+// the parameters, so anything downstream of it (a posterior, an ES reward)
+// silently freezes at its prior rather than failing.
+func warnIfWindowDataHistoryTooDeep(depth int, partitionName string, d int) {
+	if d <= depth {
+		return
+	}
+	log.Printf(
+		"macros: WARNING window data partition %q has StateHistoryDepth %d > Window.Depth %d; "+
+			"the window will replay zero-filled rows for the first %d steps and lag the data "+
+			"by %d steps thereafter, so the likelihood will be near-constant and carry no "+
+			"information — set the history depth equal to Window.Depth (%d)",
+		partitionName, d, depth, d-2, d-depth, depth,
+	)
+}
 
 func assertWindowDataSourcesDeepEnough(
 	depth int,
@@ -28,6 +52,7 @@ func assertWindowDataSourcesDeepEnough(
 				ref.PartitionName, d, depth,
 			))
 		}
+		warnIfWindowDataHistoryTooDeep(depth, ref.PartitionName, d)
 	}
 }
 
@@ -60,9 +85,11 @@ func validateAppliedPosteriorWidths(applied AppliedPosteriorEstimation) {
 }
 
 // ValidateWindowDataHistoryDepth checks that each window data source partition
-// will have at least depth rows of history when wired through
+// will have exactly depth rows of history when wired through
 // analysis.AddPartitionsToStateTimeStorage (missing names default to depth 1).
 // Call with the same windowSizeByPartition map passed to analysis.AddPartitionsToStateTimeStorage.
+// Too few rows panics; too many logs a warning (see warnIfWindowDataHistoryTooDeep
+// — an oversized depth voids the likelihood instead of underflowing).
 func ValidateWindowDataHistoryDepth(
 	windowDepth int,
 	windowSizeByPartition map[string]int,
@@ -82,5 +109,6 @@ func ValidateWindowDataHistoryDepth(
 				ref.PartitionName, w, windowDepth, windowDepth,
 			))
 		}
+		warnIfWindowDataHistoryTooDeep(windowDepth, ref.PartitionName, w)
 	}
 }

--- a/pkg/macros/inference_validate_test.go
+++ b/pkg/macros/inference_validate_test.go
@@ -1,6 +1,8 @@
 package macros
 
 import (
+	"bytes"
+	"log"
 	"strings"
 	"testing"
 
@@ -39,6 +41,31 @@ func wantPanic(t *testing.T, want string, fn func()) {
 	fn()
 }
 
+// wantLog runs fn with the standard logger captured and asserts what it wrote
+// contains want; an empty want asserts it wrote nothing.
+func wantLog(t *testing.T, want string, fn func()) {
+	t.Helper()
+	var buf bytes.Buffer
+	flags, writer := log.Flags(), log.Writer()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	defer func() {
+		log.SetOutput(writer)
+		log.SetFlags(flags)
+	}()
+	fn()
+	got := buf.String()
+	if want == "" {
+		if got != "" {
+			t.Errorf("expected no log output, got %q", got)
+		}
+		return
+	}
+	if !strings.Contains(got, want) {
+		t.Errorf("log = %q, want it to contain %q", got, want)
+	}
+}
+
 // wantNoPanic runs fn and fails if it panics.
 func wantNoPanic(t *testing.T, fn func()) {
 	t.Helper()
@@ -75,10 +102,21 @@ func TestAssertWindowDataSourcesDeepEnough(t *testing.T) {
 			assertWindowDataSourcesDeepEnough(5, refs, map[string]int{"obs": 3})
 		})
 	})
-	t.Run("depth equal to the window is accepted", func(t *testing.T) {
+	t.Run("depth equal to the window is accepted silently", func(t *testing.T) {
 		// Boundary: depth == window is exactly enough, not one short.
-		wantNoPanic(t, func() {
-			assertWindowDataSourcesDeepEnough(5, refs, map[string]int{"obs": 5})
+		wantLog(t, "", func() {
+			wantNoPanic(t, func() {
+				assertWindowDataSourcesDeepEnough(5, refs, map[string]int{"obs": 5})
+			})
+		})
+	})
+	t.Run("a partition deeper than the window is warned about", func(t *testing.T) {
+		// Too deep cannot underflow, so it runs — and silently replays zeros.
+		// The warning is the only signal the user gets, so it must fire.
+		wantLog(t, "StateHistoryDepth 50 > Window.Depth 5", func() {
+			wantNoPanic(t, func() {
+				assertWindowDataSourcesDeepEnough(5, refs, map[string]int{"obs": 50})
+			})
 		})
 	})
 }
@@ -108,9 +146,18 @@ func TestValidateWindowDataHistoryDepth(t *testing.T) {
 			ValidateWindowDataHistoryDepth(4, map[string]int{"obs": 2}, refs)
 		})
 	})
-	t.Run("depth equal to the window is accepted", func(t *testing.T) {
-		wantNoPanic(t, func() {
-			ValidateWindowDataHistoryDepth(4, map[string]int{"obs": 4}, refs)
+	t.Run("depth equal to the window is accepted silently", func(t *testing.T) {
+		wantLog(t, "", func() {
+			wantNoPanic(t, func() {
+				ValidateWindowDataHistoryDepth(4, map[string]int{"obs": 4}, refs)
+			})
+		})
+	})
+	t.Run("a partition deeper than the window is warned about", func(t *testing.T) {
+		wantLog(t, "carry no information", func() {
+			wantNoPanic(t, func() {
+				ValidateWindowDataHistoryDepth(4, map[string]int{"obs": 2000}, refs)
+			})
 		})
 	})
 }

--- a/pkg/macros/likelihood.go
+++ b/pkg/macros/likelihood.go
@@ -6,7 +6,8 @@ package macros
 // to Window.Depth so inner timesteps align with available history (see
 // EmbeddedBurnInSteps to decouple). Use ValidateWindowDataHistoryDepth
 // with analysis.AddPartitionsToStateTimeStorage window sizes to fail fast if
-// history is too shallow for FromHistoryIteration.
+// history is too shallow for FromHistoryIteration — and note that too deep is
+// just as wrong (it replays zeros), which is why it warns.
 
 import (
 	"fmt"
@@ -50,8 +51,13 @@ type ParameterisedModel struct {
 	ParamsFromUpstream map[string]simulator.NamedUpstreamConfig
 }
 
-// Init ensures internal parameter wiring maps are initialised.
+// Init ensures the params and internal parameter wiring maps are initialised.
 func (p *ParameterisedModel) Init() {
+	// A model declared with no params at all (e.g. one taking its mean from
+	// upstream) leaves Params.Map nil, and the constructors below Set into it.
+	if p.Params.Map == nil {
+		p.Params = simulator.NewParams(make(map[string][]float64))
+	}
 	if p.ParamsAsPartitions == nil {
 		p.ParamsAsPartitions = make(map[string][]string)
 	}
@@ -74,7 +80,9 @@ type AppliedLikelihoodComparison struct {
 	EmbeddedBurnInSteps *int
 	// WindowDataHistoryDepth, if non-nil, must map every Window.Data
 	// PartitionName to that partition’s StateHistoryDepth in the outer
-	// simulation; each value must be >= Window.Depth.
+	// simulation; each value should equal Window.Depth. Smaller panics;
+	// larger warns and silently voids the likelihood (see
+	// warnIfWindowDataHistoryTooDeep).
 	WindowDataHistoryDepth map[string]int
 }
 
@@ -224,8 +232,11 @@ type ParameterisedModelWithGradient struct {
 	ParamsFromUpstream map[string]simulator.NamedUpstreamConfig
 }
 
-// Init ensures internal parameter wiring maps are initialised.
+// Init ensures the params and internal parameter wiring maps are initialised.
 func (p *ParameterisedModelWithGradient) Init() {
+	if p.Params.Map == nil {
+		p.Params = simulator.NewParams(make(map[string][]float64))
+	}
 	if p.ParamsAsPartitions == nil {
 		p.ParamsAsPartitions = make(map[string][]string)
 	}

--- a/pkg/macros/likelihood_test.go
+++ b/pkg/macros/likelihood_test.go
@@ -69,6 +69,125 @@ func TestLikelihood(t *testing.T) {
 	)
 }
 
+// likelihoodTestStorage generates a fixed Normal dataset to compare against.
+func likelihoodTestStorage(t *testing.T, steps int) *simulator.StateTimeStorage {
+	t.Helper()
+	return analysis.NewStateTimeStorageFromPartitions(
+		[]*simulator.PartitionConfig{
+			{
+				Name: "test_data",
+				Iteration: &inference.DataGenerationIteration{
+					Likelihood: &inference.NormalLikelihoodDistribution{},
+				},
+				Params: simulator.NewParams(map[string][]float64{
+					"mean":              {1.8, 5.0},
+					"covariance_matrix": {2.5, 0.0, 0.0, 9.0},
+				}),
+				InitStateValues:   []float64{1.3, 8.3},
+				StateHistoryDepth: 1,
+				Seed:              123,
+			},
+		},
+		&simulator.NumberOfStepsTerminationCondition{MaxNumberOfSteps: steps},
+		&simulator.ConstantTimestepFunction{Stepsize: 1.0},
+		0.0,
+	)
+}
+
+func TestWindowDataHistoryDepth(t *testing.T) {
+	// general.FromHistoryIteration walks the replay buffer from row
+	// StateHistoryDepth-2 down to StateHistoryDepth-Depth-1, so the history depth
+	// has to *equal* the window depth. Larger cannot underflow — it quietly
+	// anchors the window in rows that are still zero-filled, and the likelihood
+	// stops depending on the data at all. This pins that failure so the warning
+	// in warnIfWindowDataHistoryTooDeep keeps describing something real.
+	const steps, windowDepth = 100, 10
+	trueMean := []float64{1.8, 5.0}
+
+	// meanLoglike scores a candidate model mean against the data over the whole
+	// run. A window that is working prefers the data-generating mean; the whole
+	// point of the likelihood is that this comparison discriminates.
+	meanLoglike := func(t *testing.T, historyDepth int, mean []float64) float64 {
+		t.Helper()
+		storage := likelihoodTestStorage(t, steps)
+		likePartition := NewLikelihoodComparisonPartition(
+			AppliedLikelihoodComparison{
+				Name: "test_likelihood",
+				Model: ParameterisedModel{
+					Likelihood: &inference.NormalLikelihoodDistribution{},
+					Params: simulator.NewParams(map[string][]float64{
+						"mean":              mean,
+						"covariance_matrix": {2.5, 0.0, 0.0, 9.0},
+					}),
+				},
+				Data: analysis.DataRef{PartitionName: "test_data"},
+				Window: WindowedPartitions{
+					Data:  []analysis.DataRef{{PartitionName: "test_data"}},
+					Depth: windowDepth,
+				},
+				WindowDataHistoryDepth: map[string]int{"test_data": historyDepth},
+			},
+			storage,
+		)
+		storage = analysis.AddPartitionsToStateTimeStorage(
+			storage,
+			[]*simulator.PartitionConfig{likePartition},
+			map[string]int{"test_data": historyDepth},
+		)
+		// The embedded run emits the whole inner state vector; the comparison
+		// partition is appended last, so the loglike is the final element.
+		values := storage.GetValues("test_likelihood")
+		sum := 0.0
+		for _, row := range values[windowDepth+1:] { // skip the burn-in rows
+			sum += row[len(row)-1]
+		}
+		return sum / float64(len(values)-windowDepth-1)
+	}
+
+	t.Run("a history depth equal to the window discriminates", func(t *testing.T) {
+		atTruth := meanLoglike(t, windowDepth, trueMean)
+		atZero := meanLoglike(t, windowDepth, []float64{0.0, 0.0})
+		if atTruth <= atZero {
+			t.Errorf("loglike at the true mean = %v, at zero = %v — want the true mean "+
+				"to score higher", atTruth, atZero)
+		}
+	})
+	t.Run("an oversized history depth scores zeros, not the data", func(t *testing.T) {
+		// The reported failure. Set to the run length, the window replays the
+		// zero-filled tail of the replay buffer, so the likelihood prefers a mean
+		// of zero over the data-generating one: the discrimination is not merely
+		// weakened, it is inverted. Inference driven by this converges on the
+		// zeros — which is why a posterior freezes near its prior with no warning.
+		atTruth := meanLoglike(t, steps, trueMean)
+		atZero := meanLoglike(t, steps, []float64{0.0, 0.0})
+		if atZero <= atTruth {
+			t.Errorf("loglike at the true mean = %v, at zero = %v — this test pins the "+
+				"failure warnIfWindowDataHistoryTooDeep warns about; if the window now "+
+				"reads real data at this depth, fix the warning too", atTruth, atZero)
+		}
+	})
+	t.Run("a model with no params does not panic", func(t *testing.T) {
+		// ParameterisedModel.Init must allocate Params: the constructor Sets
+		// "cumulative"/"burn_in_steps" into it, and a model taking its mean from
+		// upstream declares no params of its own.
+		storage := likelihoodTestStorage(t, steps)
+		wantNoPanic(t, func() {
+			NewLikelihoodComparisonPartition(
+				AppliedLikelihoodComparison{
+					Name:  "test_likelihood",
+					Model: ParameterisedModel{Likelihood: &inference.NormalLikelihoodDistribution{}},
+					Data:  analysis.DataRef{PartitionName: "test_data"},
+					Window: WindowedPartitions{
+						Data:  []analysis.DataRef{{PartitionName: "test_data"}},
+						Depth: windowDepth,
+					},
+				},
+				storage,
+			)
+		})
+	})
+}
+
 func TestWarmStartConvergence(t *testing.T) {
 	t.Run(
 		"test that warm-start accumulates optimizer state across outer steps",


### PR DESCRIPTION
Two engine failures found downstream, both silent until they had already cost a debugging cycle.

## `window_data_history_depth` set too large silently voids the likelihood

The rule is stricter than the validation implied: it must **equal** `Window.Depth`, not merely be `>=` it. `general.FromHistoryIteration` walks the replay buffer from row `StateHistoryDepth-2` down to `StateHistoryDepth-Depth-1`, so an equal depth consumes the buffer exactly and anything larger anchors the window in rows that are still zero-filled — the buffer starts zeroed and gains one real row per outer step.

Set to the run length, the window therefore replays zeros for essentially the whole run. The effect is worse than a weakened signal, it is an inverted one — on the test scenario:

| model mean | history depth 10 (correct) | history depth 100 (oversized) |
|---|---|---|
| true `[1.8, 5.0]` | **−44.8** | −53.4 |
| zero `[0, 0]` | −62.9 | **−36.0** |

The oversized window prefers a mean of zero over the data-generating one, because it is scoring the buffer's zeros rather than the data. That is why a posterior driven by it *freezes at its prior* rather than drifting — the downstream symptom was a posterior pinned at its initial value that no amount of tuning could move.

`assertWindowDataSourcesDeepEnough` only rejected the too-shallow side, which cannot silently void anything. `warnIfWindowDataHistoryTooDeep` now covers the dangerous side, from both that check (the path the YAML macros take, since `pkg/api` passes the map straight through to `AddPartitionsToStateTimeStorage`) and the public `ValidateWindowDataHistoryDepth`.

It **warns rather than panics**, as requested. Worth noting every in-repo config already uses equality, so making it fatal would break nothing here and remains an easy follow-up — a config that trips this produces nothing usable anyway.

## `comparison.model` with no params panicked on a nil map

`ParameterisedModel.Init` allocated the two wiring maps but not `Params`, so a model declaring no params of its own — the natural shape when the likelihood takes its mean from upstream — panicked with a bare `assignment to entry in nil map` when the constructor `Set`s `"cumulative"`/`"burn_in_steps"` into it. Reachable from any such config, and the panic named nothing pointing back at the config that caused it. `Init` now allocates `Params` too, on both `ParameterisedModel` and `ParameterisedModelWithGradient`. The `params: {}` workaround is no longer needed.

## Tests

Both pin behaviour rather than messages:

- `TestWindowDataHistoryDepth` asserts **both** directions of the discrimination, so a change to the replay indexing fails and says the warning needs updating rather than quietly outliving the thing it describes.
- `TestComparisonModelWithoutParams` reproduces the nil-map panic through YAML (verified: panics with the guard disabled, passes with it).
- Warning-fires subtests on both validators, plus silence assertions on the equal-depth boundary.

## Docs

The `WindowDataHistoryDepth` doc comment stated the `>=` rule and is corrected, along with `pkg/macros/doc.go`. The depth rule is also added to the posterior recipe's tuning-levers block (`cfg/` twin and skill copy kept byte-identical) and the `SKILL.md` bullet, where it now sits beside the sampler-coupling note as the second thing that decides converge-vs-merely-run.

`go build`, `go vet`, `gofmt` clean; all `pkg/...` tests pass. Only `test/TestPostgresWritingAndQuerying` fails locally, from no running DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)