### PR TITLE
Add scan to the expressions DSL; allow a zero-width slice; check where's branch widths

### DIFF
--- a/.claude/skills/stochadex-model/SKILL.md
+++ b/.claude/skills/stochadex-model/SKILL.md
@@ -90,7 +90,19 @@ and an **upstream alias** (see wiring below).
 
 **Functions:** `sqrt pow exp log abs min max clamp(x,lo,hi) where(cond,a,b) floor sin cos erf erfc`,
 `slice(v,i,n)`, `concat(a,b)`, `width(v)`, `lag(name,n)` (a value n steps back), plus `+ - * /`
-and comparisons `< > <= >= ==`. Everything is elementwise over vectors with length-1 broadcasting.
+and comparisons `< > <= >= ==`. Everything is elementwise over vectors with length-1 broadcasting,
+including `where` — under a vector condition each branch must be the condition's width or a scalar,
+and a scalar condition is lazy, so only the taken branch is evaluated (and only it draws).
+
+**Not elementwise:** `each(n, i, expr)` builds a width-n value whose element `i` is `expr` with
+the lane index bound — an index shift such as `each(5, i, where(i == 0, births, pop[i-1] * s))`,
+and a per-lane `where` that is lazy, so a switched-off lane draws nothing. `scan(n, i, acc, init,
+expr)` is the same loop with an accumulator threaded through it: lane `i` sees the previous lane's
+value (`init` at lane 0) and the call is the *last* lane's value, so it is a fold, not a map. Use
+it when a lane must see what earlier lanes did — allocation, running maxima, prefix sums:
+`slice(scan(6, i, acc, 0, concat(acc, acc[i] + q[i])), 0, 6)` is an exclusive prefix sum, and
+`each(6, i, sum(slice(q, 0, i)))` is the same thing more simply (a zero-width `slice` is empty,
+and `sum` of it is 0) at O(n²).
 
 **Random draws:** `normal(mean,sd)`, `poisson(rate)`, `uniform(lo,hi)`, `gamma(shape,scale)`,
 `binomial(n,p)`. **Rule (the #1 mistake):** if a draw's parameters are all scalars its width is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,51 @@ an exact version rather than assume stability across minors.
 
 ## [Unreleased]
 
+### Added
+
+- **`scan(n, i, acc, init, expr)`: a bounded fold across lanes.** `each` was the evaluator's only
+  non-elementwise construct, and its lanes are independent and must each produce a scalar, so
+  nothing a lane computes reaches the next one. `scan` runs `n` lanes in order with `acc` bound to
+  the previous lane's value — `init` at lane 0 — and the value of the call is the last lane's.
+
+  Unlike an `each` lane, a `scan` lane may be any width, and that is what closes the case that
+  asked for it: assigning *k* simultaneous arrivals to the first *k* free slots, where each
+  arrival must see the slots the previous ones just took. What accumulates there is *which slots
+  are taken*, not a running total, so it has no prefix-sum reformulation and no `each` spelling at
+  all — a downstream order-book model could state prices, a moving touch and book-walking as data
+  but not order identity, and so could not answer its queue-position output. Running maxima and
+  true prefix operations are the same shape and become O(n): `slice(scan(6, i, acc, 0, concat(acc,
+  acc[i] + q[i])), 0, 6)`.
+
+  It stays as bounded as `each`. The lane count is fixed before the loop, `acc` is threaded rather
+  than assigned to, and there is no recursion, so an expression still always terminates — the
+  property `each` was designed around is preserved rather than traded away. A zero lane count is
+  allowed and gives `init`, which is what a fold over nothing is, and lets the count come from
+  data.
+
+### Fixed
+
+- **`slice(v, from, 0)` gives an empty value instead of panicking.** A zero width was rejected
+  with "slice's width must be at least 1", which killed the natural prefix sum `each(n, i,
+  sum(slice(q, 0, i)))` on lane 0 — where nothing is the correct block to ask for, and `sum` of
+  nothing is 0. The spelling that worked needed both a `where` guard for the answer and a
+  `max(i, 1)` inside it, because the untaken branch is still parsed and bounds-checked. Prefix
+  sums are the main reason to reach for `each`, so the one case the construct exists to serve was
+  the one that needed a workaround. A negative width is still rejected.
+
+- **`where` now checks its branch widths against a vector condition.** Every other combining
+  operation goes through `broadcastLen`, which rejects a width that is neither equal nor 1;
+  `where` selected elementwise directly and so was the one place the rule did not hold. It failed
+  two ways depending on which side was short. A branch **wider** than the condition was silently
+  truncated to its first `len(cond)` elements, with the rest dropped and no diagnostic at all —
+  the dangerous one, since it produces a plausible number. A **narrower** branch ran off the end
+  as a bare Go index panic naming neither the function nor the widths.
+
+  Both are now rejected with a message naming the branch and both widths. A scalar branch under a
+  vector condition still broadcasts, which is how nearly every guard is written and is unaffected.
+  This is a behaviour change: a config that was relying on the silent truncation will now fail
+  rather than return a quietly wrong answer. Nothing in the model catalogue was.
+
 ## [0.13.1] — 2026-07-28
 
 ### Fixed

--- a/models/CONVENTIONS.md
+++ b/models/CONVENTIONS.md
@@ -369,8 +369,10 @@ Two shapes, with very different costs:
   each means either an operator that enlarges what the DSL *is*, or a core `Iteration`. Record
   them and let a second instance argue for the design rather than reaching for it on the first.
 
-The catalogue has surfaced five capability gaps, and **all five are closed** — the table is the
-worked precedent for what the triage produces, not an open-issues list:
+Seven capability gaps have been surfaced, and **all seven are closed** — the table is the
+worked precedent for what the triage produces, not an open-issues list. The last two came
+from a downstream application rather than from `models/`, which is the same evidence by the
+same test: a twin that could not be written, and a named output it blocked.
 
 | Gap | Found by | What closed it |
 |---|---|---|
@@ -379,14 +381,22 @@ worked precedent for what the triage produces, not an open-issues list:
 | Lag-*N* history read — only the current row is exposed | `trywizard` (ageing yellow cards out ten rows back) | `lag(name, n)` |
 | Slicing — no way to address a block within a flat vector | `trywizard` (9 coefficients at a stride-9 offset) | `slice` + `concat` |
 | Draw ordering and lane-wise laziness — an expression takes all its Gammas before any Poisson, and a vector-guarded `where` draws in every lane | `measles-risk-forecaster` (per-area interleaved draws, inactive areas skipped) | `each` |
+| No fold across `each` lanes — lanes are independent and scalar, so a lane cannot see what earlier lanes did | a downstream order-book model (assigning *k* simultaneous arrivals to the first *k* free slots, which blocked its queue-position output) | `scan(n, i, acc, init, expr)` |
+| `slice` rejected a zero width, so the natural prefix sum died on lane 0 | the same model (walking a book across price levels) | a zero width now gives an empty value |
 
-Two things that table is worth reading twice for. **The four structural gaps rhymed**: every
-one was about *structured access* or *per-lane control of draws*, which is exactly the axis a
+Three things that table is worth reading twice for. **The structural gaps rhymed**: every one
+was about *structured access* or *per-lane control of draws*, which is exactly the axis a
 strictly elementwise evaluator gives up — so they were one design question, not four chores,
 and `each` closed two of them at once. And **the draw-ordering row was predicted by the DSL's
 own doc comment** ("a vector-guarded draw consumes randomness in every lane") long before a
 model hit it. A limitation you have documented is still a limitation: a model hitting it is
 evidence that it is time to fix it, not a duplicate of the note.
+
+The third is that **`each` itself turned out to have the shape it was promoted to fix**. It
+answered the index-shift gap by giving lanes an index, and then had exactly the elementwise
+evaluator's problem one level down: its lanes cannot see each other, so the next structural
+gap arrived in the same form. `scan` is the same design question a second time, which is the
+argument for taking the second instance seriously rather than treating a closed axis as done.
 
 Writing a twin also finds bugs in the engine that no model would: `business-survival`'s
 exposed a NaN index silently reading element 0 on arm64 while panicking on amd64, because Go

--- a/pkg/general/expression.go
+++ b/pkg/general/expression.go
@@ -52,7 +52,7 @@ type ExpressionBinding struct {
 //   - any binding declared earlier.
 //
 // Functions: where, clamp, min, max, abs, floor, exp, log, sqrt, pow, sin, cos, erf, erfc,
-// fill, width, slice, concat, sum, dot, lag, each, iid and shared, plus the draws normal,
+// fill, width, slice, concat, sum, dot, lag, each, scan, iid and shared, plus the draws normal,
 // uniform, exponential, poisson, gamma, beta and binomial. Draws take expressions as their
 // parameters, so compound sampling composes naturally: a negative-binomial branching step is
 // just poisson(gamma(shape, rate)).
@@ -69,13 +69,18 @@ type ExpressionBinding struct {
 //   - slice(v, start, width) takes a block out of a vector, and concat(a, b, ...) joins
 //     values, for state and params that pack several quantities end to end. width(v) is how
 //     many elements v has, for a spec that adapts to a param's length rather than fixing it.
+//     A width of zero is allowed and gives an empty value, because that is what the running
+//     end of a prefix operation is: each(n, i, sum(slice(q, 0, i))) has to ask for nothing at
+//     lane 0, and sum of nothing is 0.
 //   - lag(name, n) reads a partition's committed state n rows back, where a bare field name
 //     or an Upstreams alias only ever gives row 0. The partition must keep that many rows
 //     (its state_history_depth), and lag(x, 0) is x.
 //   - each(n, i, expr) builds a width-n value whose element i is expr evaluated with the lane
 //     index i bound. See below.
+//   - scan(n, i, acc, init, expr) is each with an accumulator threaded through the lanes, for
+//     the things a lane needs to see what earlier lanes did. See below.
 //
-// each is the one construct that is not elementwise, and it is what makes an index shift,
+// each is the first construct that is not elementwise, and it is what makes an index shift,
 // a per-lane guard and a per-lane draw order sayable:
 //
 //   - Element i may read element i-1 of something, so a cohort can age: each(60, age,
@@ -92,12 +97,37 @@ type ExpressionBinding struct {
 // recursion, and an expression still always terminates. Draws inside it are explicit in the
 // sense below, exactly as they are inside iid.
 //
+// What each cannot say is anything where a lane must see what earlier lanes did: its lanes are
+// independent, and each must produce a scalar, so nothing is carried between them. That is what
+// scan(n, i, acc, init, expr) adds. It runs n lanes in order with acc bound to the previous
+// lane's value — init for lane 0 — and the value of the whole call is the last lane's, so it is
+// a fold rather than a map. Unlike an each lane, a scan lane may be any width, and that width is
+// the point: the blocking case is allocation, where what has to be carried is which slots are
+// now taken rather than a running total. Assigning k arrivals to the first k free slots is
+//
+//	scan(k, a, taken, occupied, each(6, j, where(j == first_free, 1, taken[j])))
+//
+// where first_free stands in for the sub-expression finding it (there are no local names inside
+// a lane, so it is written out where it is used), and each arrival sees the slots the previous
+// ones just took. Running quantities are the
+// same shape, either threaded as a scalar (a running maximum is scan(n, i, m, v[0], max(m,
+// v[i]))) or grown into the value being built, which is prefix sums in O(n) rather than the
+// O(n^2) of an each of sums:
+//
+//	slice(scan(6, i, acc, 0, concat(acc, acc[i] + q[i])), 0, 6)
+//
+// scan stays bounded exactly as each does: the lane count is fixed before the loop, acc is
+// threaded rather than assigned to, and there is no recursion, so an expression still always
+// terminates. A zero lane count is allowed and gives init, which is the right answer for a fold
+// over nothing and lets the count come from data.
+//
 // Conditionals are expressions, not statements: where(cond, a, b). When cond is a scalar the
 // untaken branch is not evaluated, so a guard such as where(n > 0, binomial(n, p), 0) is safe
 // and draws no randomness on the guarded path. When cond is a vector both branches must be
 // evaluated to select elementwise, as in NumPy, which means a vector-guarded draw consumes
-// randomness in every lane. Prefer scalar guards where that matters — and see each below,
-// which makes a per-element guard scalar and so gets laziness back.
+// randomness in every lane, and each branch must then be either the condition's width or a
+// scalar. Prefer scalar guards where that matters — and see each below, which makes a
+// per-element guard scalar and so gets laziness back.
 //
 // # How wide a draw is
 //
@@ -302,6 +332,22 @@ func (c *exprCtx) explicit() *exprCtx {
 	return &exprCtx{env: c.env, sampler: c.sampler, lag: c.lag, drawsAreExplicit: true}
 }
 
+// bind reserves a name for a comprehension to write its lane index or accumulator into, and
+// returns the undo. The environment is shared with the enclosing scope rather than nested, so
+// a binding that outlived its loop would leak into the next expression — and, because the same
+// iteration is reused every step, into the next step. Call it before the loop and defer the
+// result, so the name is restored (or removed, if it was never there) on the panicking path too.
+func (c *exprCtx) bind(name string) func() {
+	shadowed, wasBound := c.env[name]
+	return func() {
+		if wasBound {
+			c.env[name] = shadowed
+		} else {
+			delete(c.env, name)
+		}
+	}
+}
+
 func exprBool(b bool) float64 {
 	if b {
 		return 1
@@ -481,7 +527,25 @@ func (c *exprCtx) evalCall(n *ast.CallExpr) exprValue {
 			}
 			return arg(2)
 		}
+		// A vector condition selects elementwise, so each branch has to line up with it: the
+		// same width, or a scalar that broadcasts. where is the one place a mismatch was not
+		// caught, because it selects directly rather than going through broadcastLen, and it
+		// failed two ways depending on which side was short — a branch wider than the condition
+		// silently used its first len(cond) elements and dropped the rest, and a narrower one
+		// ran off the end as a bare Go index panic naming neither the function nor the widths.
+		// Both are answers to a question nobody asked; there is no reading of a width-5 branch
+		// under a width-3 condition that is what the author meant.
 		a, b := arg(1), arg(2)
+		for _, branch := range []struct {
+			which string
+			value exprValue
+		}{{"then", a}, {"else", b}} {
+			if len(branch.value) != len(cond) && len(branch.value) != 1 {
+				panic(fmt.Sprintf(
+					"expression: where's %s branch has width %d, which is neither the "+
+						"condition's %d nor 1", branch.which, len(branch.value), len(cond)))
+			}
+		}
 		out := make(exprValue, len(cond))
 		for i := range cond {
 			if cond[i] != 0 {
@@ -544,7 +608,8 @@ func (c *exprCtx) evalCall(n *ast.CallExpr) exprValue {
 				"index to, as in each(40, i, ...)")
 		}
 		inner := c.explicit()
-		shadowed, wasBound := inner.env[index.Name]
+		// The env is shared with the enclosing scope, so the binding must not outlive the loop.
+		defer inner.bind(index.Name)()
 		out := make(exprValue, count)
 		for i := 0; i < count; i++ {
 			inner.env[index.Name] = exprValue{float64(i)}
@@ -556,13 +621,60 @@ func (c *exprCtx) evalCall(n *ast.CallExpr) exprValue {
 			}
 			out[i] = v[0]
 		}
-		// The env is shared with the enclosing scope, so the binding must not outlive the loop.
-		if wasBound {
-			inner.env[index.Name] = shadowed
-		} else {
-			delete(inner.env, index.Name)
-		}
 		return out
+	case "scan":
+		// each with an accumulator threaded through the lanes: lane i evaluates the expression
+		// with the lane index bound and acc bound to the previous lane's value (init at lane 0),
+		// and the value of the call is the last lane's. So it is a fold, not a map.
+		//
+		// This is the one thing each cannot do. Its lanes are independent and each must produce
+		// a scalar, so nothing a lane computes reaches the next one. A scan lane may be any
+		// width, and that is what closes the case that asked for this: allocating k simultaneous
+		// arrivals to the first k free slots, where what has to be carried between lanes is
+		// which slots are now taken rather than a running total. Running maxima and true prefix
+		// operations are the same shape, and become O(n) rather than the O(n^2) of an each of
+		// sums over ever-longer slices.
+		//
+		// It stays as bounded as each: the count is fixed before the loop, acc is threaded
+		// rather than assigned to, and there is still no recursion, so an expression still
+		// always terminates.
+		need(5)
+		countValue := arg(0)
+		if len(countValue) != 1 {
+			panic("expression: scan's count must be a scalar")
+		}
+		count := toIndex(countValue[0], "scan's count")
+		if count < 0 {
+			// Zero is allowed, unlike each's: a fold over no lanes is init, which is the right
+			// answer rather than an edge case, and it lets the count come from data.
+			panic("expression: scan's count must not be negative")
+		}
+		index, ok := n.Args[1].(*ast.Ident)
+		if !ok {
+			panic("expression: scan's second argument must be a name to bind the lane index " +
+				"to, as in scan(40, i, acc, 0, ...)")
+		}
+		accumulator, ok := n.Args[2].(*ast.Ident)
+		if !ok {
+			panic("expression: scan's third argument must be a name to bind the accumulator " +
+				"to, as in scan(40, i, acc, 0, ...)")
+		}
+		if accumulator.Name == index.Name {
+			panic("expression: scan's lane index and accumulator cannot share the name " +
+				index.Name)
+		}
+		// The initial value is evaluated once, in the enclosing scope, before either name is
+		// bound — so an init that mentions them means the outer ones, as it reads.
+		value := arg(3)
+		inner := c.explicit()
+		defer inner.bind(index.Name)()
+		defer inner.bind(accumulator.Name)()
+		for i := 0; i < count; i++ {
+			inner.env[index.Name] = exprValue{float64(i)}
+			inner.env[accumulator.Name] = value
+			value = inner.eval(n.Args[4])
+		}
+		return value
 	case "lag":
 		// A read of a partition's committed state further back than the current row, which is
 		// all a bare name or an upstreams alias ever gives.
@@ -643,6 +755,13 @@ func (c *exprCtx) evalCall(n *ast.CallExpr) exprValue {
 	case "slice":
 		// A block of a vector, for state and params that pack several quantities end to end:
 		// the nine coefficients of a channel inside one flat thirty-six-wide param, say.
+		//
+		// A zero width gives an empty value rather than an error. That is not permissiveness:
+		// the natural prefix sum, each(n, i, sum(slice(q, 0, i))), asks for nothing at lane 0,
+		// and nothing is the correct block to ask for there. Rejecting it forced a guarded
+		// spelling that needed both a where and a max(i, 1) — the where for the answer, the max
+		// because the untaken branch is still bounds-checked — for the one case the construct
+		// exists to serve. sum of an empty value is 0, so the reduction lands where it should.
 		need(3)
 		v, fromValue, widthValue := arg(0), arg(1), arg(2)
 		if len(fromValue) != 1 || len(widthValue) != 1 {
@@ -650,8 +769,8 @@ func (c *exprCtx) evalCall(n *ast.CallExpr) exprValue {
 		}
 		from := toIndex(fromValue[0], "slice's start")
 		width := toIndex(widthValue[0], "slice's width")
-		if width < 1 {
-			panic("expression: slice's width must be at least 1")
+		if width < 0 {
+			panic("expression: slice's width must not be negative")
 		}
 		if from < 0 || from+width > len(v) {
 			panic(fmt.Sprintf(

--- a/pkg/general/expression_constructs_settings.yaml
+++ b/pkg/general/expression_constructs_settings.yaml
@@ -10,9 +10,10 @@ iterations:
 - name: reader
   params:
     coefficients: [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
-  init_state_values: [0.0, 0.0]
+    sweep: [15.0]
+  init_state_values: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
   seed: 4
-  state_width: 2
+  state_width: 10
   state_history_depth: 2
 init_time_value: 0.0
 timesteps_history_depth: 1

--- a/pkg/general/expression_eval_test.go
+++ b/pkg/general/expression_eval_test.go
@@ -195,6 +195,24 @@ func TestExpressionBroadcasting(t *testing.T) {
 			Outputs: []string{"v + pair"},
 		}, []float64{1, 2, 3}, map[string][]float64{"pair": {1, 2}})
 	})
+
+	t.Run("where selects with the same rule as an operator", func(t *testing.T) {
+		// where selects directly rather than going through broadcastLen, so it was the one
+		// place the rule above did not hold: a branch wider than the condition was silently
+		// truncated to its first len(cond) elements, and a narrower one ran off the end with a
+		// bare Go index panic. Both are now rejected — see the malformed-expression table — and
+		// this is the half that must still work, a scalar branch broadcasting under a vector
+		// condition, which is how nearly every guard is written.
+		got := evalOnce(t, &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v", Width: 3}},
+			Outputs: []string{"where(v > 1, v * 10, 0)"},
+		}, []float64{1, 2, 3}, map[string][]float64{})
+		for i, want := range []float64{0, 20, 30} {
+			if got[i] != want {
+				t.Fatalf("got %v, want [0 20 30]", got)
+			}
+		}
+	})
 }
 
 func TestExpressionBindings(t *testing.T) {
@@ -344,15 +362,31 @@ func TestExpressionRejectsMalformedExpressions(t *testing.T) {
 		{"wrong arity", "sqrt(1, 2)", "takes 1 arguments"},
 		{"concat needs two", "concat(1)", "at least 2"},
 		{"index must be scalar", "pair[pair]", "index must be a scalar"},
+		// A vector condition selects elementwise, so a branch that is neither its width nor a
+		// scalar is a mismatch in either direction — the wide one used to be silently truncated.
+		{"where then branch too wide", "sum(where(pair > 0, concat(pair, 3), 0))",
+			"then branch has width 3, which is neither the condition's 2"},
+		{"where then branch too narrow", "sum(where(concat(pair, 3) > 0, pair, 0))",
+			"then branch has width 2, which is neither the condition's 3"},
+		{"where else branch mismatched", "sum(where(pair > 0, 0, concat(pair, 3)))",
+			"else branch has width 3, which is neither the condition's 2"},
+		{"where branch empty", "sum(where(pair > 0, slice(pair, 0, 0), 0))",
+			"then branch has width 0"},
 		{"index out of range", "pair[9]", "out of range"},
 		{"iid count must be scalar", "sum(iid(pair, 1))", "count must be a scalar"},
 		{"iid count below one", "sum(iid(0, 1))", "at least 1"},
 		{"iid lane must be scalar", "sum(iid(2, fill(3, 1)))", "scalar-valued expression"},
 		{"each count must be scalar", "sum(each(pair, i, 1))", "count must be a scalar"},
+		{"scan count must be scalar", "scan(pair, i, acc, 0, acc)", "count must be a scalar"},
+		{"scan count negative", "scan(0 - 1, i, acc, 0, acc)", "must not be negative"},
+		{"scan index is not a name", "scan(2, 7, acc, 0, acc)", "bind the lane index"},
+		{"scan accumulator is not a name", "scan(2, i, 7, 0, 1)", "bind the accumulator"},
+		{"scan names collide", "scan(2, i, i, 0, i)", "cannot share the name i"},
+		{"scan wrong arity", "scan(2, i, acc, 0)", "takes 5 arguments"},
 		{"fill width must be scalar", "sum(fill(pair, 1))", "width must be a scalar"},
 		{"fill width below one", "sum(fill(0, 1))", "at least 1"},
 		{"slice bounds must be scalar", "sum(slice(pair, pair, 1))", "must be scalars"},
-		{"slice width below one", "sum(slice(pair, 0, 0))", "at least 1"},
+		{"slice width negative", "sum(slice(pair, 0, 0 - 1))", "must not be negative"},
 		{"lag needs a name", "lag(1 + 1, 0)", "must be an upstream alias"},
 		{"lag row must be scalar", "lag(self, pair)", "row must be a scalar"},
 	} {

--- a/pkg/general/expression_test.go
+++ b/pkg/general/expression_test.go
@@ -86,8 +86,9 @@ func TestExpressionIteration(t *testing.T) {
 }
 
 // cohortExpr ages a four-bucket cohort with an absorbing top and a guarded draw at the
-// intake; readerExpr reads it through slice, a lag past the current row, and width. Together
-// they put every construct that is not elementwise through the run harnesses.
+// intake; readerExpr reads it through slice, a lag past the current row, width, and the same
+// prefix sum written both ways. Together they put every construct that is not elementwise
+// through the run harnesses.
 func cohortExpr() *ExpressionIteration {
 	return &ExpressionIteration{
 		Fields: []ExpressionField{{Name: "bucket", Width: 4}},
@@ -101,15 +102,26 @@ func cohortExpr() *ExpressionIteration {
 
 func readerExpr() *ExpressionIteration {
 	return &ExpressionIteration{
-		Fields:    []ExpressionField{{Name: "total"}, {Name: "aged"}},
+		Fields: []ExpressionField{
+			{Name: "total"}, {Name: "aged"},
+			{Name: "swept", Width: 4}, {Name: "filled", Width: 4},
+		},
 		Upstreams: map[string]string{"coh": "cohort"},
-		// Three of the six coefficients, with the top bucket deliberately unweighted.
 		Bindings: []ExpressionBinding{
+			// Three of the six coefficients, with the top bucket deliberately unweighted.
 			{Name: "weights", Expr: "concat(slice(coefficients, 0, 3), 0)"},
+			// The same exclusive prefix sum written both ways: as an each over ever-longer
+			// slices, which asks for a zero-width slice at lane 0, and as a scan growing its
+			// accumulator, which is the O(n) spelling. They must agree every step.
+			{Name: "cumulative", Expr: "each(4, i, sum(slice(coh, 0, i)))"},
+			{Name: "running",
+				Expr: "slice(scan(4, i, acc, 0, concat(acc, acc[i] + coh[i])), 0, 4)"},
 		},
 		Outputs: []string{
 			"dot(weights, coh)",
 			"sum(lag(coh, 2)) + width(coefficients)",
+			"clamp(sweep - cumulative, 0, coh)",
+			"clamp(sweep - running, 0, coh)",
 		},
 	}
 }
@@ -117,10 +129,10 @@ func readerExpr() *ExpressionIteration {
 func TestExpressionConstructsRunWithHarnesses(t *testing.T) {
 	// The harnesses are what catch what a unit test cannot: NaNs, a wrong state width, a
 	// mutated params map, and statefulness residue, the last by running the whole simulation
-	// twice and comparing. That last one is the reason this exists — each binds its lane index
-	// into an environment it shares with the enclosing scope, so a restore that leaked would
-	// show up here and nowhere else.
-	t.Run("each, lag, slice, concat and width survive the harnesses", func(t *testing.T) {
+	// twice and comparing. That last one is the reason this exists — each and scan bind their
+	// lane index and accumulator into an environment they share with the enclosing scope, so a
+	// restore that leaked would show up here and nowhere else.
+	t.Run("each, scan, lag, slice, concat and width survive the harnesses", func(t *testing.T) {
 		settings := simulator.LoadSettingsFromYaml("./expression_constructs_settings.yaml")
 		iterations := []simulator.Iteration{cohortExpr(), readerExpr()}
 		for i, iteration := range iterations {
@@ -391,6 +403,44 @@ func TestExpressionStructuredAccess(t *testing.T) {
 		}
 	})
 
+	t.Run("a zero-width slice is empty, which is what a prefix sum needs", func(t *testing.T) {
+		// The natural prefix sum asks for nothing at lane 0, and nothing is the right block to
+		// ask for there. It used to panic, so the spelling that worked needed a where for the
+		// answer and a max(i, 1) as well, because the untaken branch is still bounds-checked.
+		e := &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v", Width: 6}},
+			Outputs: []string{"each(6, i, sum(slice(q, 0, i)))"},
+		}
+		got := evalOnce(t, e, make([]float64, 6), map[string][]float64{
+			"q": {3, 2, 1, 4, 5, 6},
+		})
+		for i, want := range []float64{0, 3, 5, 6, 10, 15} {
+			if got[i] != want {
+				t.Fatalf("got %v, want [0 3 5 6 10 15]", got)
+			}
+		}
+	})
+
+	t.Run("a book sweep walks price levels", func(t *testing.T) {
+		// The downstream case the zero-width slice was blocking: a marketable order consuming
+		// across levels is a prefix sum and a clamp.
+		e := &ExpressionIteration{
+			Fields: []ExpressionField{{Name: "taken", Width: 6}},
+			Bindings: []ExpressionBinding{
+				{Name: "cumulative", Expr: "each(6, i, sum(slice(q, 0, i)))"},
+			},
+			Outputs: []string{"clamp(sweep - cumulative, 0, q)"},
+		}
+		got := evalOnce(t, e, make([]float64, 6), map[string][]float64{
+			"q": {3, 2, 1, 4, 5, 6}, "sweep": {7},
+		})
+		for i, want := range []float64{3, 2, 1, 1, 0, 0} {
+			if got[i] != want {
+				t.Fatalf("got %v, want [3 2 1 1 0 0]", got)
+			}
+		}
+	})
+
 	t.Run("slice and concat reject an out-of-range block", func(t *testing.T) {
 		defer func() {
 			if r := recover(); r == nil {
@@ -512,6 +562,169 @@ func TestExpressionEach(t *testing.T) {
 	})
 }
 
+func TestExpressionScan(t *testing.T) {
+	// each's lanes are independent and each must produce a scalar, so nothing a lane computes
+	// reaches the next one. scan threads an accumulator of any width through them, and the
+	// width is the point: the case that asked for this carries which slots are taken, not a
+	// running total.
+
+	t.Run("a lane sees what earlier lanes took", func(t *testing.T) {
+		// The blocking case: k simultaneous arrivals claim the first k free slots, so each
+		// arrival must see the slots the ones before it just took. It is not a prefix sum —
+		// what accumulates is the occupancy vector — and it has no each spelling at all.
+		//
+		// The first free slot is the length of the leading run of occupied ones, which is how
+		// many prefixes of the accumulator are entirely full.
+		firstFree := "sum(each(6, p, where(sum(slice(acc, 0, p + 1)) == p + 1, 1, 0)))"
+		e := &ExpressionIteration{
+			Fields: []ExpressionField{{Name: "occupancy", Width: 6}},
+			Outputs: []string{
+				"scan(3, a, acc, occupied, each(6, j, where(j == " + firstFree +
+					", 1, acc[j])))",
+			},
+		}
+		got := evalOnce(t, e, make([]float64, 6), map[string][]float64{
+			"occupied": {0, 1, 0, 0, 1, 0},
+		})
+		// Slots 0, 2 and 3 are the first three free ones, and all three are now taken.
+		for i, want := range []float64{1, 1, 1, 1, 1, 0} {
+			if got[i] != want {
+				t.Fatalf("got %v, want [1 1 1 1 1 0]", got)
+			}
+		}
+	})
+
+	t.Run("order identity survives the allocation", func(t *testing.T) {
+		// The output this was actually wanted for: not just which slots filled, but which
+		// arrival got which — queue position per order. Two accumulators are one accumulator
+		// packed end to end, six slots followed by three arrival records seeded at -1.
+		firstFree := "sum(each(6, p, where(sum(slice(acc, 0, p + 1)) == p + 1, 1, 0)))"
+		e := &ExpressionIteration{
+			Fields: []ExpressionField{{Name: "occupancy", Width: 6}, {Name: "slot", Width: 3}},
+			Bindings: []ExpressionBinding{
+				{Name: "allocated", Expr: "scan(3, a, acc, concat(occupied, fill(3, -1)), " +
+					"concat(each(6, j, where(j == " + firstFree + ", 1, acc[j])), " +
+					"each(3, k, where(k == a, " + firstFree + ", acc[6 + k]))))"},
+			},
+			Outputs: []string{"slice(allocated, 0, 6)", "slice(allocated, 6, 3)"},
+		}
+		got := evalOnce(t, e, make([]float64, 9), map[string][]float64{
+			"occupied": {0, 1, 0, 0, 1, 0},
+		})
+		for i, want := range []float64{1, 1, 1, 1, 1, 0, 0, 2, 3} {
+			if got[i] != want {
+				t.Fatalf("got %v, want [1 1 1 1 1 0 | 0 2 3]", got)
+			}
+		}
+	})
+
+	t.Run("a growing accumulator gives prefix sums in one pass", func(t *testing.T) {
+		// The same answer as each(6, i, sum(slice(q, 0, i))), but each lane extends the value
+		// rather than re-summing from the start. The accumulator is seeded with the exclusive
+		// prefix's leading zero, so the last lane's extra entry is sliced off.
+		e := &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v", Width: 6}},
+			Outputs: []string{"slice(scan(6, i, acc, 0, concat(acc, acc[i] + q[i])), 0, 6)"},
+		}
+		got := evalOnce(t, e, make([]float64, 6), map[string][]float64{
+			"q": {3, 2, 1, 4, 5, 6},
+		})
+		for i, want := range []float64{0, 3, 5, 6, 10, 15} {
+			if got[i] != want {
+				t.Fatalf("got %v, want [0 3 5 6 10 15]", got)
+			}
+		}
+	})
+
+	t.Run("a running maximum, threaded and as a sequence", func(t *testing.T) {
+		final := evalOnce(t, &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "m"}},
+			Outputs: []string{"scan(5, i, m, v[0], max(m, v[i]))"},
+		}, []float64{0}, map[string][]float64{"v": {2, 7, 3, 9, 4}})
+		if final[0] != 9 {
+			t.Fatalf("got %v, want 9", final[0])
+		}
+		sequence := evalOnce(t, &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "m", Width: 5}},
+			Outputs: []string{"slice(scan(5, i, acc, v[0], concat(acc, max(acc[i], v[i]))), 1, 5)"},
+		}, make([]float64, 5), map[string][]float64{"v": {2, 7, 3, 9, 4}})
+		for i, want := range []float64{2, 7, 7, 9, 9} {
+			if sequence[i] != want {
+				t.Fatalf("got %v, want [2 7 7 9 9]", sequence)
+			}
+		}
+	})
+
+	t.Run("no lanes gives the initial value", func(t *testing.T) {
+		// A fold over nothing is its seed, which is the right answer rather than an edge case,
+		// and it is what lets the lane count come from data.
+		got := evalOnce(t, &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v"}},
+			Outputs: []string{"scan(0, i, acc, 42, acc + 1)"},
+		}, []float64{0}, map[string][]float64{})
+		if got[0] != 42 {
+			t.Fatalf("got %v, want 42", got[0])
+		}
+	})
+
+	t.Run("scan binds both names without leaking either", func(t *testing.T) {
+		// Both bindings go into the environment shared with the enclosing scope, so both must
+		// be put back. The seed is evaluated before either is bound, so it means the outer ones.
+		e := &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v"}},
+			Outputs: []string{"scan(3, i, acc, 0, acc + i) + i * 10 + acc * 100"},
+		}
+		got := evalOnce(t, e, []float64{0}, map[string][]float64{"i": {1}, "acc": {2}})
+		// The fold is 0, then 1, then 3; the params are intact afterwards.
+		if got[0] != 3+10+200 {
+			t.Fatalf("got %v, want 213", got[0])
+		}
+	})
+
+	t.Run("draws inside a lane are per lane, in lane order", func(t *testing.T) {
+		// scan is explicit about draw width for the same reason each is: a lane is one
+		// evaluation, so a scalar-parameter draw in it means one sample per lane.
+		got := evalOnce(t, &ExpressionIteration{
+			Fields:  []ExpressionField{{Name: "v"}},
+			Outputs: []string{"scan(3, i, acc, 0, acc + normal(0, 1))"},
+		}, []float64{0}, map[string][]float64{})
+		sampler := rng.New(1)
+		want := 0.0
+		for i := 0; i < 3; i++ {
+			want += sampler.Normal(0, 1)
+		}
+		if got[0] != want {
+			t.Fatalf("got %v, want %v — draws are not one per lane in order", got[0], want)
+		}
+	})
+}
+
+func TestExpressionPrefixSpellingsAgree(t *testing.T) {
+	// The two ways of saying a prefix sum are the two gaps this pair of constructs closed, and
+	// a model may be written either way, so they have to be the same function. Random data,
+	// because a hand-picked vector is where an off-by-one hides.
+	sampler := rng.New(11)
+	q := make([]float64, 8)
+	for i := range q {
+		q[i] = sampler.Uniform(-5, 5)
+	}
+	viaEach := evalOnce(t, &ExpressionIteration{
+		Fields:  []ExpressionField{{Name: "v", Width: 8}},
+		Outputs: []string{"each(8, i, sum(slice(q, 0, i)))"},
+	}, make([]float64, 8), map[string][]float64{"q": q})
+	viaScan := evalOnce(t, &ExpressionIteration{
+		Fields:  []ExpressionField{{Name: "v", Width: 8}},
+		Outputs: []string{"slice(scan(8, i, acc, 0, concat(acc, acc[i] + q[i])), 0, 8)"},
+	}, make([]float64, 8), map[string][]float64{"q": q})
+	// Floating-point addition is not associative, but both spellings add in the same order, so
+	// they agree exactly rather than to a tolerance.
+	for i := range viaEach {
+		if viaEach[i] != viaScan[i] {
+			t.Fatalf("element %d: each gives %v, scan gives %v", i, viaEach[i], viaScan[i])
+		}
+	}
+}
+
 func TestExpressionNonFiniteIndex(t *testing.T) {
 	// Found while writing business-survival's twin, whose first width probe was NaN-poisoned.
 	// int(NaN) neither panics nor is portable: on arm64 it is 0, so a NaN index passes a
@@ -525,6 +738,7 @@ func TestExpressionNonFiniteIndex(t *testing.T) {
 		{"iid count", "sum(iid(bad, 1))"},
 		{"each count", "sum(each(bad, i, 1))"},
 		{"each lane index", "sum(each(2, i, v[i * bad]))"},
+		{"scan count", "scan(bad, i, acc, 0, acc)"},
 		{"fill width", "sum(fill(bad, 1))"},
 		{"slice start", "sum(slice(v, bad, 1))"},
 		{"slice width", "sum(slice(v, 0, bad))"},


### PR DESCRIPTION
Closes the two actionable capability gaps a downstream repo recorded against v0.13.1, plus a bug found while closing them. Both gaps were re-verified in that repo before being brought upstream, and both are the strong evidence `models/CONVENTIONS.md` asks for: a twin that could not be written, and a named output it blocked.

## 1. `scan(n, i, acc, init, expr)` — a bounded fold across lanes

`each` was the evaluator's only non-elementwise construct, and its lanes are independent and must each produce a scalar, so nothing a lane computes reaches the next one. `scan` runs `n` lanes in order with `acc` bound to the previous lane's value — `init` at lane 0 — and the value of the call is the **last** lane's, so it is a fold rather than a map.

**A `scan` lane may be any width, and that is the decision the whole thing turns on.** The blocking case is allocation: assigning *k* simultaneous arrivals to the first *k* free slots. What accumulates there is *which slots are taken*, not a running total, so it has no prefix-sum reformulation and no `each` spelling at all. The downstream order-book model could state prices, a moving touch and book-walking as data, but not order identity, and so could not answer its queue-position stability output.

Returning the final accumulator rather than the per-lane sequence is what makes that width usable directly. The sequence is recovered by growing the accumulator with `concat`, which also gives prefix sums in O(n) rather than the O(n²) of an `each` of sums:

```
slice(scan(6, i, acc, 0, concat(acc, acc[i] + q[i])), 0, 6)
```

Termination is preserved, which is the property `each` was designed around and the constraint any fix had to respect: the lane count is fixed before the loop, `acc` is threaded rather than assigned to, and there is no recursion. A zero lane count gives `init` — the right answer for a fold over nothing, and it lets the count come from data. `each` still requires at least one lane, unchanged.

## 2. `slice(v, from, 0)` gives an empty value

The natural prefix sum `each(n, i, sum(slice(q, 0, i)))` asks for nothing at lane 0, where nothing is the correct block to ask for and `sum` of it is 0. Rejecting it forced a guarded spelling needing both a `where` and a `max(i, 1)` inside it — the `where` for the answer, the `max` because the untaken branch is still parsed and bounds-checked — for the one case the construct exists to serve. A negative width is still rejected.

## 3. `where` now checks its branch widths (behaviour change)

Found while closing the above: an empty branch is newly reachable, and `where` had no width check at all. Every other combining operation goes through `broadcastLen`, which rejects a width that is neither equal nor 1; `where` selected elementwise directly, so it was the one place the rule did not hold. It failed two ways:

- A branch **wider** than the condition was silently truncated to its first `len(cond)` elements, rest dropped, no diagnostic. The dangerous one — it produces a plausible number.
- A **narrower** branch ran off the end as a bare Go index panic naming neither the function nor the widths.

Both now panic naming the branch and both widths. A scalar branch under a vector condition still broadcasts, which is how nearly every guard is written, and the scalar-condition path is untouched, so the lazy guard idiom and every `where` inside an `each` lane are unaffected.

**This is a behaviour change.** A config relying on the silent truncation will now fail rather than return a quietly wrong answer. Nothing in `models/` or `cfg/` was — the full suite passes unchanged — but that is not proof for downstream repos, and this is the release that would surface it.

## Tests

The allocation case and order identity (two accumulators packed end to end, giving arrival→slot `[0 2 3]`); the running maximum both threaded and as a sequence; zero lanes; non-leaking bindings; per-lane draw order; and the book sweep reproducing the downstream report's `[3 2 1 1 0 0]` exactly.

The harness config now carries **both prefix-sum spellings side by side**, with a test asserting they agree exactly — same addition order, so no tolerance needed. A model may be written either way, so they have to be the same function.

`scan`'s two-name binding turned the existing save/restore into `exprCtx.bind`, now deferred, which also makes `each` restore its lane index on the panicking path rather than leaking it into the next expression and — since the iteration is reused every step — the next step.

## One note in `models/CONVENTIONS.md` worth reading

`each` itself turned out to have the shape it was promoted to fix. It answered the index-shift gap by giving lanes an index, and then had exactly the elementwise evaluator's problem one level down: its lanes cannot see each other, so the next structural gap arrived in the same form. `scan` is the same design question a second time, which is the argument for taking a second instance seriously rather than treating a closed axis as done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
