### PR TITLE
Release v0.14.0: stamp changelog

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The stochadex simulation engine, packaged as an installable Claude Code plugin.",
-    "version": "0.13.1"
+    "version": "0.14.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stochadex",
   "description": "Author, run, and analyse a stochastic simulation as a single YAML config for the stochadex engine — no Go, no compilation, no toolchain. Bundles the stochadex-model skill with four validated, converging worked recipes.",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "author": {
     "name": "umbralcalc",
     "email": "umbralcalc@gmail.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,20 @@ an exact version rather than assume stability across minors.
 
 ## [Unreleased]
 
+## [0.14.0] — 2026-08-03
+
+A release about the expressions DSL, and about one axis of it in particular. Two capability
+gaps were recorded downstream against v0.13.1 and re-verified against the code before being
+brought upstream; closing them turned up a third problem in `where` that no model had hit yet.
+The minor bump is for that third one — `scan` and the zero-width `slice` are both additive, but
+the `where` check can fail a config that used to run.
+
+Worth noting what the shape of the main entry says. `each` was itself promoted to close the
+index-shift gap, by giving lanes an index — and then had the strictly-elementwise evaluator's
+problem one level down, because its lanes cannot see each other. `scan` is the same design
+question a second time, which is the argument for taking a second instance seriously rather
+than treating a closed axis as done.
+
 ### Added
 
 - **`scan(n, i, acc, init, expr)`: a bounded fold across lanes.** `each` was the evaluator's only
@@ -1254,7 +1268,8 @@ treat the intermediates as internal, never shipped API.
   stochastic-process formalism (diffusions, Poisson noise, windowed history for noise
   dependencies) before any Go engine existed. The pivot to Go begins Feb 2023.
 
-[Unreleased]: https://github.com/umbralcalc/stochadex/compare/v0.13.1...HEAD
+[Unreleased]: https://github.com/umbralcalc/stochadex/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/umbralcalc/stochadex/compare/v0.13.1...v0.14.0
 [0.13.1]: https://github.com/umbralcalc/stochadex/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/umbralcalc/stochadex/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/umbralcalc/stochadex/compare/v0.11.0...v0.12.0


### PR DESCRIPTION
Stamps the `[Unreleased]` section written by #74 as **v0.14.0**, and bumps the plugin manifests. No code changes.

## Why a minor, not a patch

The smallest of the three entries is the one that decides it. `scan` and the zero-width `slice` are both additive — no config that ran before can fail because of them. The `where` branch-width check **can**: a config relying on the silent truncation of a branch wider than its condition now panics instead of returning a plausible wrong number.

Nothing in `models/` or `cfg/` was relying on it, and the full suite passes unchanged, but that is not evidence about downstream repos. Under the `v0.x` policy in the changelog header, a breaking change goes in a minor bump.

## What's in it

- **Added** — `scan(n, i, acc, init, expr)`, a bounded fold across lanes. Closes the one gap that had forced a modelling decision downstream: order identity, which needs a lane to see what earlier lanes did and has no `each` spelling at all.
- **Fixed** — `slice(v, from, 0)` gives an empty value rather than panicking, which is what the natural prefix sum needs at lane 0.
- **Fixed** — `where` now checks its branch widths against a vector condition, the one place the "equal width or scalar" rule did not hold.

The header note on the release records what the shape of the main entry says rather than only what it does: `each` was itself promoted to close the index-shift gap by giving lanes an index, and then had the strictly-elementwise evaluator's problem one level down. `scan` is the same design question a second time.

## Files

| file | change |
|---|---|
| `CHANGELOG.md` | `[Unreleased]` → `[0.14.0] — 2026-08-03`, header note, compare links |
| `.claude-plugin/plugin.json` | `0.13.1` → `0.14.0` |
| `.claude-plugin/marketplace.json` | `0.13.1` → `0.14.0` |

Tag `v0.14.0` to be pushed on merge, which is what fires `release.yml` (binaries, accelerated builds, OCI image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
